### PR TITLE
[manta] [ready to merge] #30 fix linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.0"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#8174efbfbb437d25b5d3291bbed83d6b63aed80a"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#c81983367941d0297fe307ba453b81ac395b1db2"
 dependencies = [
  "aes 0.7.0",
  "ark-bls12-381",
@@ -8391,7 +8391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/runtimes/manta/runtime/src/lib.rs
+++ b/runtimes/manta/runtime/src/lib.rs
@@ -1,3 +1,6 @@
+// suppressing linter on impl From
+// linter will trigger a complain on `frame-support-3.0.0` which we cannot fix
+#![allow(clippy::from_over_into)]
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -242,7 +245,7 @@ parameter_types! {
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4; // from Reef
 	pub const MaxIterations: u32 = 10;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
-	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5 as u32, 10_000);
+	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
 	// offchain tx signing
 	pub const StakingUnsignedPriority: TransactionPriority = TransactionPriority::max_value() / 2;
 }
@@ -350,7 +353,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const NativeTokenExistentialDeposit: u128 = 1 * MA;
+	pub const NativeTokenExistentialDeposit: u128 = MA;
 	pub const MaxLocks: u32 = 50;
 }
 

--- a/runtimes/manta/runtime/src/lib.rs
+++ b/runtimes/manta/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 // suppressing linter on impl From
 // linter will trigger a complain on `frame-support-3.0.0` which we cannot fix
 #![allow(clippy::from_over_into)]
+#![allow(clippy::identity_op)]
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -353,7 +354,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const NativeTokenExistentialDeposit: u128 = MA;
+	pub const NativeTokenExistentialDeposit: u128 = 1 * MA;
 	pub const MaxLocks: u32 = 50;
 }
 

--- a/runtimes/manta/src/chain_spec.rs
+++ b/runtimes/manta/src/chain_spec.rs
@@ -37,7 +37,7 @@ const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
 
 fn session_keys(grandpa: GrandpaId, babe: BabeId) -> manta_runtime::opaque::SessionKeys {
-	manta_runtime::opaque::SessionKeys { grandpa, babe }
+	manta_runtime::opaque::SessionKeys { babe, grandpa }
 }
 
 #[allow(dead_code)]
@@ -356,9 +356,7 @@ pub fn manta_testnet_config_genesis(
 			..Default::default()
 		}),
 		pallet_collective_Instance1: Some(CouncilConfig::default()),
-		pallet_sudo: Some(SudoConfig {
-			key: root_key.clone(),
-		}), // we do sudo right now, this will be removed after full decentralization
+		pallet_sudo: Some(SudoConfig { key: root_key }), // we do sudo right now, this will be removed after full decentralization
 		pallet_babe: Some(BabeConfig {
 			authorities: vec![],
 		}),
@@ -466,7 +464,7 @@ pub fn manta_local_dev_genesis() -> GenesisConfig {
 
 	let initial_balances = vec![
 		(root_key.clone(), 1000 * MA),
-		(stash_account, 1000_000_000 * MA),
+		(stash_account, 1_000_000_000 * MA),
 		(controller_account, 20_000_000 * MA),
 	];
 

--- a/runtimes/manta/src/lib.rs
+++ b/runtimes/manta/src/lib.rs
@@ -1,3 +1,7 @@
+// suppressing linter on complex Result
+// leaving a FIXME; and will be fixed in future
+#![allow(clippy::type_complexity)]
+
 pub mod chain_spec;
 pub mod rpc;
 pub mod service;

--- a/runtimes/manta/src/main.rs
+++ b/runtimes/manta/src/main.rs
@@ -1,5 +1,8 @@
 //! Substrate Node Template CLI library.
 #![warn(missing_docs)]
+// suppressing linter on complex Result
+// leaving a FIXME; and will be fixed in future
+#![allow(clippy::type_complexity)]
 
 mod chain_spec;
 #[macro_use]

--- a/runtimes/manta/src/service.rs
+++ b/runtimes/manta/src/service.rs
@@ -4,7 +4,6 @@
 
 use manta_runtime::{opaque::Block, RuntimeApi};
 use sc_client_api::{ExecutorProvider, RemoteBackend};
-use sc_consensus_babe;
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sc_network::NetworkService;
@@ -29,6 +28,8 @@ type FullGrandpaBlockImport =
 	sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>;
 type LightClient = sc_service::TLightClient<Block, RuntimeApi, Executor>;
 
+
+// FIXME: the output types are to complex (clippy)
 pub fn new_partial(
 	config: &Configuration,
 ) -> Result<
@@ -232,7 +233,7 @@ pub fn new_full_base(
 	let (_rpc_handlers, telemetry_connection_notifier) =
 		sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 			config,
-			backend: backend.clone(),
+			backend,
 			client: client.clone(),
 			keystore: keystore_container.sync_keystore(),
 			network: network.clone(),
@@ -339,6 +340,8 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 	new_full_base(config, |_, _| ()).map(|NewFullBase { task_manager, .. }| task_manager)
 }
 
+
+// FIXME: the output types are to complex (clippy)
 pub fn new_light_base(
 	mut config: Configuration,
 ) -> Result<
@@ -392,8 +395,8 @@ pub fn new_light_base(
 		babe_block_import,
 		Some(Box::new(justification_import)),
 		client.clone(),
-		select_chain.clone(),
-		inherent_data_providers.clone(),
+		select_chain,
+		inherent_data_providers,
 		&task_manager.spawn_handle(),
 		config.prometheus_registry(),
 		sp_consensus::NeverCanAuthor,


### PR DESCRIPTION
you should be able to run
```
cargo +nightly clippy
```
without any warnings or errors.

The complains are not fixed, but suppressed.
See comments in the code.