### PR TITLE
[Manta] Disable the truthy warning in yml file

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@
 name: Check Set-Up & Build
 
 # Controls when the action will run.
+# yamllint disable-line rule:truthy
 on:
   # Triggers the workflow on push or pull request events
   # but only for the manta (default) branch.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,7 @@
 
 name: publish-release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches: [manta]


### PR DESCRIPTION
closes #13 

* Disable [truthy] truthy value should be one of [false, true] warning in yml files