### PR TITLE
[Manta] Reconfigure CI file slightly

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
           cargo +nightly clippy --release
       - name: Check Build
         run: |
-          cargo check --release --all-features
+          cargo check --all-features
       - name: Run Tests
         run: |
           cargo test --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,10 +54,7 @@ jobs:
           cargo +nightly clippy --release
       - name: Check Build
         run: |
-          cargo check --release
-      - name: Check Benchmark
-        run: |
-          cargo check --features runtime-benchmarks
+          cargo check --release --all-features
       - name: Run Tests
         run: |
           cargo test --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
           cargo +nightly fmt --all -- --check
       - name: Check Clippy
         run: |
-          cargo +nightly clippy --release
+          cargo +nightly clippy
       - name: Check Build
         run: |
           cargo check --all-features


### PR DESCRIPTION
closes #13 

* Dropped the job completion time to 45 minutes.
* Before we had 2 calls ```cargo build --release``` with different ```features``` flag
* Now we do a single ```cargo build --release --all-features```