### PR TITLE
[Manta] update pallet-manta-pay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "manta-asset"
+version = "3.0.0"
+source = "git+https://github.com/Manta-Network/manta-asset?branch=master#49ab31edd9453616b3e5ca1e5268278b497f07fe"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ed-on-bls12-381",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "blake2",
+ "frame-support",
+ "manta-crypto",
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "manta-crypto"
+version = "3.0.0"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=master#a23182964290aa30cb7e28b1b8958538b6d3c992"
+dependencies = [
+ "aes 0.7.0",
+ "ark-bls12-381",
+ "ark-crypto-primitives",
+ "ark-ed-on-bls12-381",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-serialize",
+ "ark-std",
+ "blake2",
+ "generic-array 0.14.4",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "manta-primitives"
 version = "3.0.0"
 dependencies = [
@@ -4342,12 +4376,10 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.0"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#d31a981b59ebcb3b491714a850d2c40c63cc513c"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#83041b8dd39d79e947d714bfcaeb99a44247b698"
 dependencies = [
- "aes 0.7.0",
  "ark-bls12-381",
  "ark-crypto-primitives",
- "ark-ec",
  "ark-ed-on-bls12-381",
  "ark-ff",
  "ark-groth16",
@@ -4355,19 +4387,18 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "blake2",
  "data-encoding",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "generic-array 0.14.4",
  "hkdf",
+ "manta-asset",
+ "manta-crypto",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "sha2 0.9.4",
  "sp-runtime",
  "sp-std",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -8393,7 +8424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "3.0.0"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=master#a23182964290aa30cb7e28b1b8958538b6d3c992"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=master#63e52df4ef1c3f9b8c6db87d8d20287036877105"
 dependencies = [
  "aes 0.7.0",
  "ark-bls12-381",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.0"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#83041b8dd39d79e947d714bfcaeb99a44247b698"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#551210d5bb27f29f49971b90769295ec6d8b3590"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -8424,7 +8424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 


### PR DESCRIPTION
Update `pallet-manta-pay` to the newest version.
Currently, runtime-benchmarks fails. I suspect because of newly added dependencies (`manta-asset` and `manta-crypto`).