### PR TITLE
Fix pallet-assets types clash

### DIFF
--- a/types.json
+++ b/types.json
@@ -9,6 +9,7 @@
     },
     "CurrencyIdOf": "CurrencyId",
     "Amount": "i128",
-    "AmountOf": "Amount"
+    "AmountOf": "Amount",
+    "TAssetsBalance": "u128"
 }
 


### PR DESCRIPTION
closes #106 

* Fix problem with classing pallet-assets types, by updating ``types.json`` to disambiguate
* "TAssetsBalance": "u128"