### PR TITLE
Impl try-runtime for Manta runtimes

### DIFF
--- a/.github/workflows/check_calamari_pc.yml
+++ b/.github/workflows/check_calamari_pc.yml
@@ -1,0 +1,53 @@
+---
+
+name: Check Calamari-PC
+
+# Controls when the action will run.
+# yamllint disable-line rule:truthy
+on:
+  # Triggers the workflow on push or pull request events
+  # but only for the calamari (default) branch.
+  pull_request:
+    branches: [manta-pc]
+  push:
+    branches: [manta-pc]
+
+# A workflow run is made up of one or more jobs
+# that can run sequentially or in parallel
+jobs:
+  check:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks
+    # that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run yamllint
+        uses: actionshub/yamllint@main
+
+      - name: Set-Up
+        run: sudo apt install -y
+             cmake pkg-config libssl-dev
+             git build-essential clang
+             libclang-dev curl
+
+      - name: Install Rustup
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source ~/.cargo/env
+          rustup update stable
+          rustup update nightly
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          rustup component add clippy
+          rustup component add rustfmt
+
+      - name: Check Calamari Clippy
+        run: |
+          SKIP_WASM_BUILD= cargo clippy --features calamari
+
+      - name: Check Calamari Build
+        run: |
+          cargo check --features calamari
+          cargo check --all-features

--- a/.github/workflows/check_manta_pc.yml
+++ b/.github/workflows/check_manta_pc.yml
@@ -54,7 +54,4 @@ jobs:
       - name: Check Manta-PC Build
         run: |
           cargo check --features manta-pc
-
-                - name: Check Manta-PC Build
-        run: |
-          cargo check --features manta-pc
+          cargo check --all-features

--- a/.github/workflows/check_manta_pc.yml
+++ b/.github/workflows/check_manta_pc.yml
@@ -1,6 +1,6 @@
 ---
 
-name: Check Set-Up & Build
+name: Check Manta-PC
 
 # Controls when the action will run.
 # yamllint disable-line rule:truthy
@@ -51,15 +51,10 @@ jobs:
         run: |
           SKIP_WASM_BUILD= cargo clippy --features manta-pc
 
-      - name: Check Calamari Clippy
-        run: |
-          SKIP_WASM_BUILD= cargo clippy --features calamari
-
       - name: Check Manta-PC Build
         run: |
           cargo check --features manta-pc
 
-      - name: Check Calamari Build
+                - name: Check Manta-PC Build
         run: |
-          cargo check --features calamari
-          cargo check --all-features
+          cargo check --features manta-pc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal 0.3.2",
  "log",
  "manta-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "try-runtime-cli",
 ]
 
 [[package]]
@@ -4393,6 +4394,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal 0.3.2",
  "manta-primitives",
  "max-encoded-len",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,6 +39,7 @@ jsonrpc-core = "15.1.0"
 # Substrate frames
 frame-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
 frame-benchmarking-cli = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
+try-runtime-cli = { version = '0.9.0', git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
 # Substrate pallets rpc
 pallet-transaction-payment-rpc = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
@@ -99,7 +100,14 @@ manta-primitives = { path = '../runtime/primitives' }
 substrate-build-script-utils = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
 
 [features]
-default = []
+default = ["cli"]
+cli = [
+	"try-runtime-cli",
+]
+try-runtime = [ 
+	#"manta-pc-runtime/try-runtime",
+]
+
 runtime-benchmarks = [
 	'polkadot-service/runtime-benchmarks',
 	'manta-pc-runtime/runtime-benchmarks',

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -100,15 +100,10 @@ manta-primitives = { path = '../runtime/primitives' }
 substrate-build-script-utils = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
 
 [features]
-default = ["cli"]
-cli = [
-	"try-runtime-cli",
-]
+default = []
 try-runtime = [ 
-	"manta-pc-runtime/try-runtime",
-	"calamari-runtime/try-runtime",
+	'try-runtime-cli',
 ]
-
 runtime-benchmarks = [
 	'polkadot-service/runtime-benchmarks',
 	'manta-pc-runtime/runtime-benchmarks',

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,7 +39,7 @@ jsonrpc-core = "15.1.0"
 # Substrate frames
 frame-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
 frame-benchmarking-cli = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
-try-runtime-cli = { version = '0.9.0', git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
 # Substrate pallets rpc
 pallet-transaction-payment-rpc = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -105,7 +105,8 @@ cli = [
 	"try-runtime-cli",
 ]
 try-runtime = [ 
-	#"manta-pc-runtime/try-runtime",
+	"manta-pc-runtime/try-runtime",
+	"calamari-runtime/try-runtime",
 ]
 
 runtime-benchmarks = [

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,7 +39,7 @@ jsonrpc-core = "15.1.0"
 # Substrate frames
 frame-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
 frame-benchmarking-cli = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
+try-runtime-cli = { version = '0.9.0', git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
 # Substrate pallets rpc
 pallet-transaction-payment-rpc = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.8" }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -37,6 +37,14 @@ pub enum Subcommand {
 	/// The custom benchmark subcommmand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+
+	/// Try some command against runtime state.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
+	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
+	#[cfg(not(feature = "try-runtime"))]
+	TryRuntime,
 }
 
 /// Command for exporting the genesis state of the parachain

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -324,6 +324,40 @@ pub fn run() -> Result<()> {
 					.into())
 			}
 		}
+		Some(Subcommand::TryRuntime(cmd)) => {
+			if cfg!(feature = "try-runtime") {
+				let runner = cli.create_runner(cmd)?;
+				runner.async_run(|config| {
+					// we don't need any of the components of new_partial, just a runtime, or a task
+					// manager to do `async_run`.
+					let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+					let task_manager =
+						sc_service::TaskManager::new(config.task_executor.clone(), registry)
+							.map_err(|e| {
+								sc_cli::Error::Service(sc_service::Error::Prometheus(e))
+							})?;
+
+					cfg_if::cfg_if! {
+						if #[cfg(feature = "manta-pc")] {
+							Ok((
+								cmd.run::<Block, MantaPCRuntimeExecutor>(config),
+								task_manager,
+							))
+						} else {
+							#[cfg(feature = "calamari")]
+							Ok((
+								cmd.run::<Block, CalamariRuntimeExecutor>(config),
+								task_manager,
+							))
+						}
+					}
+				})
+			} else {
+				Err("try-runtime wasn't enabled when building the node. \
+				You can enable it with `--features try-runtime`."
+					.into())
+			}
+		}
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -324,40 +324,37 @@ pub fn run() -> Result<()> {
 					.into())
 			}
 		}
+		#[cfg(feature = "try-runtime")]
 		Some(Subcommand::TryRuntime(cmd)) => {
-			if cfg!(feature = "try-runtime") {
-				let runner = cli.create_runner(cmd)?;
-				runner.async_run(|config| {
-					// we don't need any of the components of new_partial, just a runtime, or a task
-					// manager to do `async_run`.
-					let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-					let task_manager =
-						sc_service::TaskManager::new(config.task_executor.clone(), registry)
-							.map_err(|e| {
-								sc_cli::Error::Service(sc_service::Error::Prometheus(e))
-							})?;
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				// we don't need any of the components of new_partial, just a runtime, or a task
+				// manager to do `async_run`.
+				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+				let task_manager =
+					sc_service::TaskManager::new(config.task_executor.clone(), registry)
+						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
 
-					cfg_if::cfg_if! {
-						if #[cfg(feature = "manta-pc")] {
-							Ok((
-								cmd.run::<Block, MantaPCRuntimeExecutor>(config),
-								task_manager,
-							))
-						} else {
-							#[cfg(feature = "calamari")]
-							Ok((
-								cmd.run::<Block, CalamariRuntimeExecutor>(config),
-								task_manager,
-							))
-						}
+				cfg_if::cfg_if! {
+					if #[cfg(feature = "manta-pc")] {
+						Ok((
+							cmd.run::<Block, MantaPCRuntimeExecutor>(config),
+							task_manager,
+						))
+					} else {
+						#[cfg(feature = "calamari")]
+						Ok((
+							cmd.run::<Block, CalamariRuntimeExecutor>(config),
+							task_manager,
+						))
 					}
-				})
-			} else {
-				Err("try-runtime wasn't enabled when building the node. \
-				You can enable it with `--features try-runtime`."
-					.into())
-			}
+				}
+			})
 		}
+		#[cfg(not(feature = "try-runtime"))]
+		Some(Subcommand::TryRuntime) => Err("Try-runtime wasn't enabled when building the node. \
+		You can enable it with `--features try-runtime`."
+			.into()),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -84,8 +84,8 @@ substrate-wasm-builder = { version = '4.0.0', git = 'https://github.com/parityte
 [features]
 default = ['std']
 try-runtime = [
-	"frame-executive/try-runtime",
-	"frame-try-runtime",
+	'frame-executive/try-runtime',
+	'frame-try-runtime',
 ]
 
 runtime-benchmarks = [

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -36,6 +36,7 @@ frame-executive = { version = '3.0.0', git = 'https://github.com/paritytech/subs
 frame-support = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system-rpc-runtime-api = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 
 # Substrate pallets
 pallet-assets = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
@@ -82,6 +83,11 @@ substrate-wasm-builder = { version = '4.0.0', git = 'https://github.com/parityte
 
 [features]
 default = ['std']
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+]
+
 runtime-benchmarks = [
 	'hex-literal',
 	'sp-runtime/runtime-benchmarks',
@@ -118,6 +124,7 @@ std = [
 	'frame-executive/std',
 	'frame-system/std',
 	'frame-system-rpc-runtime-api/std',
+	'frame-try-runtime/std',
 	'pallet-assets/std',
 	'pallet-authorship/std',
 	'pallet-balances/std',

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -23,7 +23,7 @@ use sp_version::RuntimeVersion;
 
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{All, Filter},
+	traits::{All, Filter, OnRuntimeUpgrade},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
@@ -734,6 +734,28 @@ impl_runtime_apis! {
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}
+	}
+}
+
+// Example custom try-runtime hooks
+pub struct Custom;
+impl OnRuntimeUpgrade for Custom {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		// Do something. You have access to temporary storage with:
+		// Self::set_temp_storage(key, value);
+		unimplemented!()
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		unimplemented!()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		// Do something. You can access the temporary storage with:
+		// Self::get_temp_storage(key, value);
+		unimplemented!()
 	}
 }
 

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -689,6 +689,15 @@ impl_runtime_apis! {
 		}
 	}
 
+	#[cfg(feature = "try-runtime")]
+	impl frame_try_runtime::TryRuntime<Block> for Runtime {
+		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
+			//log::info!("try-runtime::on_runtime_upgrade calamari-pc.");
+			let weight = Executive::try_runtime_upgrade()?;
+			Ok((weight, RuntimeBlockWeights::get().max_block))
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn dispatch_benchmark(

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -692,7 +692,6 @@ impl_runtime_apis! {
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
 		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
-			//log::info!("try-runtime::on_runtime_upgrade calamari-pc.");
 			let weight = Executive::try_runtime_upgrade()?;
 			Ok((weight, RuntimeBlockWeights::get().max_block))
 		}

--- a/runtime/manta-pc/Cargo.toml
+++ b/runtime/manta-pc/Cargo.toml
@@ -31,10 +31,12 @@ sp-version = { version = '3.0.0', git = 'https://github.com/paritytech/substrate
 # Substrate frames
 frame-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 frame-system-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, optional = true, branch = "polkadot-v0.9.8" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 frame-executive = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-support = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system-rpc-runtime-api = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
+#try-runtime-cli = { version = '0.9.0', git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
 # Substrate pallets
 pallet-assets = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
@@ -83,6 +85,16 @@ substrate-wasm-builder = { version = '4.0.0', git = 'https://github.com/parityte
 
 [features]
 default = ['std']
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	#"try-runtime-cli",
+]
+
+cli = [
+	#"try-runtime-cli",
+]
+
 runtime-benchmarks = [
 	'hex-literal',
 	'sp-runtime/runtime-benchmarks',
@@ -113,6 +125,7 @@ std = [
 	'sp-version/std',
 	'sp-offchain/std',
 	'sp-session/std',
+	"frame-try-runtime/std",
 	'sp-block-builder/std',
 	'sp-transaction-pool/std',
 	'sp-inherents/std',

--- a/runtime/manta-pc/Cargo.toml
+++ b/runtime/manta-pc/Cargo.toml
@@ -85,8 +85,8 @@ substrate-wasm-builder = { version = '4.0.0', git = 'https://github.com/parityte
 [features]
 default = ['std']
 try-runtime = [
-	"frame-executive/try-runtime",
-	"frame-try-runtime",
+	'frame-executive/try-runtime',
+	'frame-try-runtime',
 ]
 
 runtime-benchmarks = [

--- a/runtime/manta-pc/Cargo.toml
+++ b/runtime/manta-pc/Cargo.toml
@@ -31,12 +31,11 @@ sp-version = { version = '3.0.0', git = 'https://github.com/paritytech/substrate
 # Substrate frames
 frame-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 frame-system-benchmarking = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, optional = true, branch = "polkadot-v0.9.8" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 frame-executive = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-support = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
 frame-system-rpc-runtime-api = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
-#try-runtime-cli = { version = '0.9.0', git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.8" }
 
 # Substrate pallets
 pallet-assets = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
@@ -88,11 +87,6 @@ default = ['std']
 try-runtime = [
 	"frame-executive/try-runtime",
 	"frame-try-runtime",
-	#"try-runtime-cli",
-]
-
-cli = [
-	#"try-runtime-cli",
 ]
 
 runtime-benchmarks = [
@@ -125,7 +119,6 @@ std = [
 	'sp-version/std',
 	'sp-offchain/std',
 	'sp-session/std',
-	"frame-try-runtime/std",
 	'sp-block-builder/std',
 	'sp-transaction-pool/std',
 	'sp-inherents/std',
@@ -133,6 +126,7 @@ std = [
 	'frame-executive/std',
 	'frame-system/std',
 	'frame-system-rpc-runtime-api/std',
+	'frame-try-runtime/std',
 	'pallet-assets/std',
 	'pallet-authorship/std',
 	'pallet-balances/std',

--- a/runtime/manta-pc/src/lib.rs
+++ b/runtime/manta-pc/src/lib.rs
@@ -695,7 +695,6 @@ pub type Executive = frame_executive::Executive<
 	AllPallets,
 >;
 
-//#[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
 		fn slot_duration() -> sp_consensus_aura::SlotDuration {

--- a/runtime/manta-pc/src/lib.rs
+++ b/runtime/manta-pc/src/lib.rs
@@ -24,7 +24,7 @@ use sp_version::RuntimeVersion;
 use codec::{Decode, Encode};
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{All, InstanceFilter, MaxEncodedLen},
+	traits::{All, InstanceFilter, MaxEncodedLen, OnRuntimeUpgrade},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
@@ -848,6 +848,28 @@ impl_runtime_apis! {
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}
+	}
+}
+
+// Example custom try-runtime hooks
+pub struct Custom;
+impl OnRuntimeUpgrade for Custom {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		// Do something. You have access to temporary storage with:
+		// Self::set_temp_storage(key, value);
+		unimplemented!()
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		unimplemented!()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		// Do something. You can access the temporary storage with:
+		// Self::get_temp_storage(key, value);
+		unimplemented!()
 	}
 }
 

--- a/runtime/manta-pc/src/lib.rs
+++ b/runtime/manta-pc/src/lib.rs
@@ -695,6 +695,7 @@ pub type Executive = frame_executive::Executive<
 	AllPallets,
 >;
 
+//#[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
 		fn slot_duration() -> sp_consensus_aura::SlotDuration {
@@ -799,6 +800,15 @@ impl_runtime_apis! {
 	impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
 		fn collect_collation_info() -> cumulus_primitives_core::CollationInfo {
 			ParachainSystem::collect_collation_info()
+		}
+	}
+
+	#[cfg(feature = "try-runtime")]
+	impl frame_try_runtime::TryRuntime<Block> for Runtime {
+		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
+			//log::info!("try-runtime::on_runtime_upgrade manta-pc.");
+			let weight = Executive::try_runtime_upgrade()?;
+			Ok((weight, RuntimeBlockWeights::get().max_block))
 		}
 	}
 

--- a/runtime/manta-pc/src/lib.rs
+++ b/runtime/manta-pc/src/lib.rs
@@ -805,7 +805,6 @@ impl_runtime_apis! {
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
 		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
-			//log::info!("try-runtime::on_runtime_upgrade manta-pc.");
 			let weight = Executive::try_runtime_upgrade()?;
 			Ok((weight, RuntimeBlockWeights::get().max_block))
 		}


### PR DESCRIPTION
closes #122 

* initial ``try-runtime`` integration for ``manta-pc`` and ``calamari-pc``
* scaffold runtime hooks in ``manta-pc`` and ``calamari-pc``
* update CI to check ``--all-features``

* you can build the binaries with ``cargo build --release --features=manta-pc,try-runtime``
* you can explore the command with ``./target/release/manta-pc  try-runtime --help``