### PR TITLE
[Calamari-pc] Add base filter for calamari-pc

### DIFF
--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -136,26 +136,21 @@ parameter_types! {
 pub struct BaseFilter;
 impl Filter<Call> for BaseFilter {
 	fn filter(c: &Call) -> bool {
-		!matches!(
-			c,
-			// Monetary
-			Call::Assets(pallet_assets::Call::create(..)) | Call::Balances(_) |
-			// Filter these calls to prevent users from creating assets or making transfers.
-			// Core
-			Call::System(_) |
-			// Filter these calls to prevent users from runtime upgrade without sudo privilege.
-			// pallet-timestamp(_) and parachainSystem(_) could not be filtered because they are used in commuication between releychain and parachain.
-			// Utility
-			Call::Utility(_) | Call::Multisig(_) |
-			// Filter these calls to prevent users from utility operation.
-			Call::Authorship(_) |
+		match c {
+			Call::Timestamp(_) => true,
+			Call::ParachainSystem(_) => true,
+			// pallet-timestamp and parachainSystem could not be filtered because they are used in commuication between releychain and parachain.
+			Call::Authorship(_) => true,
+			// pallet-authorship use for orml
+			Call::Sudo(_) => true,
 			// Sudo also cannot be filtered because it is used in runtime upgrade.
-			// Collator
-			Call::Session(_) | Call::CollatorSelection(_) |
-			// Filter these calls to prevent users from setting keys and selecting collator for parachain (couldn't use now).
-			//XCM
-			Call::DmpQueue(_) | Call::PolkadotXcm(_) // Filter XCM pallet.
-		)
+			_ => false,
+			// Filter System to prevent users from runtime upgrade without sudo privilege.
+			// Filter Assets and Balances to prevent users from creating assets or making transfers.
+			// Filter Utility and Multisig to prevent users from setting keys and selecting collator for parachain (couldn't use now).
+			// Filter Session and CollatorSelection to prevent users from utility operation.
+			// Filter XCM pallet.
+		}
 	}
 }
 

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -142,7 +142,7 @@ impl Filter<Call> for BaseFilter {
 			Call::Assets(pallet_assets::Call::create(..)) | Call::Balances(_) |
 			// Filter these calls to prevent users from creating assets or making transfers.
 			// Core
-			Call::System(_) | 
+			Call::System(_) |
 			// Filter these calls to prevent users from runtime upgrade without sudo privilege.
 			// pallet-timestamp(_) and parachainSystem(_) could not be filtered because they are used in commuication between releychain and parachain.
 			// Utility
@@ -154,8 +154,7 @@ impl Filter<Call> for BaseFilter {
 			Call::Session(_) | Call::CollatorSelection(_) |
 			// Filter these calls to prevent users from setting keys and selecting collator for parachain (couldn't use now).
 			//XCM
-			Call::DmpQueue(_) | Call::PolkadotXcm(_) 
-			// Filter XCM pallet
+			Call::DmpQueue(_) | Call::PolkadotXcm(_) // Filter XCM pallet.
 		)
 	}
 }

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -137,12 +137,11 @@ pub struct BaseFilter;
 impl Filter<Call> for BaseFilter {
 	fn filter(c: &Call) -> bool {
 		match c {
-			Call::Timestamp(_) => true,
-			Call::ParachainSystem(_) => true,
+			Call::Timestamp(_) | Call::ParachainSystem(_) | Call::Authorship(_) | Call::Sudo(_) => {
+				true
+			}
 			// pallet-timestamp and parachainSystem could not be filtered because they are used in commuication between releychain and parachain.
-			Call::Authorship(_) => true,
 			// pallet-authorship use for orml
-			Call::Sudo(_) => true,
 			// Sudo also cannot be filtered because it is used in runtime upgrade.
 			_ => false,
 			// Filter System to prevent users from runtime upgrade without sudo privilege.

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -140,20 +140,29 @@ impl Filter<Call> for BaseFilter {
 			c,
 			// Monetary
 			Call::Assets(pallet_assets::Call::create(..)) | Call::Balances(_) |
+			// Filter these calls to prevent users from creating assets or making transfers.
 			// Core
-			Call::System(_) | Call::Timestamp(_) | Call::ParachainSystem(_) |
+			Call::System(_) | 
+			// Filter these calls to prevent users from runtime upgrade without sudo privilege.
+			// pallet-timestamp(_) and parachainSystem(_) could not be filtered because they are used in commuication between releychain and parachain.
 			// Utility
 			Call::Utility(_) | Call::Multisig(_) |
-			Call::Sudo(_) | Call::Authorship(_) |
+			// Filter these calls to prevent users from utility operation.
+			Call::Authorship(_) |
+			// Sudo also cannot be filtered because it is used in runtime upgrade.
 			// Collator
-			Call::Session(_) | Call::CollatorSelection(_)
+			Call::Session(_) | Call::CollatorSelection(_) |
+			// Filter these calls to prevent users from setting keys and selecting collator for parachain (couldn't use now).
+			//XCM
+			Call::DmpQueue(_) | Call::PolkadotXcm(_) 
+			// Filter XCM pallet
 		)
 	}
 }
 
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = ();
+	type BaseCallFilter = BaseFilter; // Let filter useable.
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type AccountId = AccountId;

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -161,7 +161,7 @@ impl Filter<Call> for BaseFilter {
 
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = BaseFilter; // Let filter useable.
+	type BaseCallFilter = BaseFilter; // Let filter activate.
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type AccountId = AccountId;


### PR DESCRIPTION
Add base filter to prevent users from using unnecessary pallet on shell chain. Three pallets are not filtered: `pallet-sudo`, `pallet-timestamp` and `pallet-parachainsystem`