### PR TITLE
Update pallet-manta-pay dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.1"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#823bb79841f430b83c0b1ce7d0d7e7c1c1cf9176"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=consistent-naming#8e631c52cd405227d445a9f15c6c533395098061"
 dependencies = [
  "ark-std",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.1"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=consistent-naming#8e631c52cd405227d445a9f15c6c533395098061"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#455f128af719fb8c73d74d80856cf296e251b52c"
 dependencies = [
  "ark-std",
  "data-encoding",

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -60,7 +60,7 @@ pallet-utility = { default-features = false, version = '3.0.0' }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
-pallet-manta-pay = { branch = "calamari", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
+pallet-manta-pay = { branch = "consistent-naming", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
 manta-primitives = { path="../primitives", default-features = false }
 
 [dev-dependencies]

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -60,7 +60,7 @@ pallet-utility = { default-features = false, version = '3.0.0' }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
-pallet-manta-pay = { branch = "consistent-naming", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
+pallet-manta-pay = { branch = "calamari", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
 manta-primitives = { path="../primitives", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Once [this PR](https://github.com/Manta-Network/pallet-manta-pay/pull/87) is merged, I will update the hash here to update Manta with the correct pallet-manta-pay version for working with the `manta-subxt` client. 