### PR TITLE
[Manta] Adapt to new pallat-manta-pay interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,7 +3675,8 @@ dependencies = [
 
 [[package]]
 name = "manta-api"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-api?branch=manta#6bb78f88f9783ab1474ba033020ada0433799759"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -3705,6 +3706,7 @@ dependencies = [
 [[package]]
 name = "manta-asset"
 version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -3719,7 +3721,8 @@ dependencies = [
 
 [[package]]
 name = "manta-crypto"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#125d5eec169a23ac8d631dc29b29bc4f5385169f"
 dependencies = [
  "aes-gcm 0.9.2",
  "ark-bls12-381",
@@ -3739,7 +3742,8 @@ dependencies = [
 
 [[package]]
 name = "manta-data"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -3754,7 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "manta-error"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-error?branch=manta#00810285947f59b1e051fa7d2d0e1d10bbaf9bd8"
 dependencies = [
  "ark-crypto-primitives",
  "ark-relations",
@@ -3766,7 +3771,8 @@ dependencies = [
 
 [[package]]
 name = "manta-ledger"
-version = "0.1.0"
+version = "0.1.1"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#4378d9c461f8002c0d2b1dce5823f11ee9ae9c84"
 dependencies = [
  "manta-crypto",
  "manta-error",
@@ -4427,6 +4433,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.1"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#b81239ebaa676718cd0f865bb595d3fcb26d090c"
 dependencies = [
  "ark-std",
  "data-encoding",
@@ -8501,7 +8508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "manta-runtime"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,6 @@ dependencies = [
 [[package]]
 name = "manta-api"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-api?branch=manta#1db0a888fe31e5ff3dd922e04465f676715e4013"
 dependencies = [
  "ark-bls12-381",
  "ark-crypto-primitives",
@@ -3706,7 +3705,6 @@ dependencies = [
 [[package]]
 name = "manta-asset"
 version = "0.1.1"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -3722,7 +3720,6 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#20ed34f0f36556e4e83d7e6640d481eef9006f75"
 dependencies = [
  "aes-gcm 0.9.2",
  "ark-bls12-381",
@@ -3743,7 +3740,6 @@ dependencies = [
 [[package]]
 name = "manta-data"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -3753,24 +3749,24 @@ dependencies = [
  "manta-asset",
  "manta-crypto",
  "manta-error",
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "manta-error"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-error?branch=manta#201b4e70577fa282474ceee2008e4e24ba790e21"
 dependencies = [
  "ark-crypto-primitives",
  "ark-relations",
  "ark-serialize",
  "ark-std",
  "displaydoc",
+ "parity-scale-codec",
 ]
 
 [[package]]
 name = "manta-ledger"
 version = "0.1.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#0e20d7e46a8179c53930b60c2ac90d7495ce9ba0"
 dependencies = [
  "manta-crypto",
  "manta-error",
@@ -4431,7 +4427,6 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "3.0.1"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay?branch=calamari#455f128af719fb8c73d74d80856cf296e251b52c"
 dependencies = [
  "ark-std",
  "data-encoding",

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Manta Network']
 edition = '2018'
 license = 'GPL V3'
 name = 'manta-runtime'
-version = '3.0.0'
+version = '3.0.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -60,7 +60,7 @@ pallet-utility = { default-features = false, version = '3.0.0' }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
-pallet-manta-pay = { path = "../../../../pallet-manta-pay", default-features = false }
+pallet-manta-pay = { branch = "calamari", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
 manta-primitives = { path="../primitives", default-features = false }
 
 [dev-dependencies]

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -60,7 +60,7 @@ pallet-utility = { default-features = false, version = '3.0.0' }
 # Attention! Our integration test scripts modify these dependencies with "sed" command.
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
-pallet-manta-pay = { branch = "calamari", git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
+pallet-manta-pay = { path = "../../../../pallet-manta-pay", default-features = false }
 manta-primitives = { path="../primitives", default-features = false }
 
 [dev-dependencies]

--- a/runtimes/manta/runtime/src/lib.rs
+++ b/runtimes/manta/runtime/src/lib.rs
@@ -95,7 +95,6 @@ pub mod opaque {
 	}
 }
 
-// TODO: change the runtime name
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -107,8 +106,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 2,
-	impl_version: 1,
+	spec_version: 3,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/types.json
+++ b/types.json
@@ -1,8 +1,8 @@
 {
     "CurrencyId": {
-        "_enum": [
-            "MA"
-        ]
+      "_enum": [
+        "MA"
+      ]
     },
     "CurrencyIdOf": "CurrencyId",
     "Amount": "i128",
@@ -10,7 +10,42 @@
     "AccountInfo": "AccountInfoWithDualRefCount",
     "AssetId": "u32",
     "AssetBalance": "u128",
-    "PrivateTransferPayload": "[u8;648]",
-    "ReclaimPayload": "[u8;536]"
-}
-
+    "MantaRandomValue": "[u8;32]",
+    "MantaEciesCiphertext": {
+      "EncryptedMsg": "[u8; 36]",
+      "EphermalPk": "[u8; 32]"
+    },
+    "MintData": {
+      "AssetId": "AssetId",
+      "Amount": "AssetBalance",
+      "Cm": "MantaRandomValue",
+      "K": "MantaRandomValue",
+      "S": "MantaRandomValue",
+      "EncryptedNote": "MantaEciesCiphertext"
+    },
+    "SenderData": {
+      "K": "MantaRandomValue",
+      "VoidNumber": "MantaRandomValue",
+      "Root": "MantaRandomValue"
+    },
+    "ReceiverData": {
+      "K": "MantaRandomValue",
+      "Cm": "MantaRandomValue",
+      "EncryptedNote": "MantaEciesCiphertext"
+    },
+    "PrivateTransferData": {
+      "Sender1": "SenderData",
+      "Sender2": "SenderData",
+      "Receiver1": "ReceiverData",
+      "Receiver2": "ReceiverData",
+      "Proof": "[u8;192]"
+    },
+    "ReclaimData": {
+      "AssetId": "AssetId",
+      "ReclaimAmount": "AssetBalance",
+      "Sender1": "SenderData",
+      "Sender2": "SenderData",
+      "Receiver": "ReceiverData",
+      "Proof": "[u8; 192]"
+    }
+  }


### PR DESCRIPTION
This PR upgrade pallet-manta-pay, which uses a new interface for `mint`/`private_transfer`/`reclaim`:

- [x]  bump pallet-manta-pay version
- [x] update `types.json`