### PR TITLE
[Manta-PC]Refactor MantaTransactorAdaptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,7 @@ dependencies = [
  "log",
  "manta-primitives",
  "manta-xassets",
+ "manta-xcm-support",
  "max-encoded-len",
  "pallet-assets",
  "pallet-aura",
@@ -4493,6 +4494,20 @@ dependencies = [
  "manta-primitives",
  "parity-scale-codec",
  "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
+name = "manta-xcm-support"
+version = "3.0.0"
+dependencies = [
+ "frame-support",
+ "log",
+ "manta-primitives",
+ "parity-scale-codec",
  "sp-runtime",
  "sp-std",
  "xcm",

--- a/runtime/manta-pc/Cargo.toml
+++ b/runtime/manta-pc/Cargo.toml
@@ -76,6 +76,7 @@ pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-featu
 
 # Self dependencies
 manta-primitives = { path = '../primitives', default-features = false }
+manta-xcm-support = { path = '../xcm-support', default-features = false }
 manta-xassets = { path = '../../pallets/manta-xassets', default-features = false }
 
 [package.metadata.docs.rs]
@@ -143,6 +144,7 @@ std = [
 	'pallet-xcm/std',
 	'pallet-transaction-payment/std',
 	'manta-primitives/std',
+	'manta-xcm-support/std',
 	'parachain-info/std',
 	"cumulus-pallet-aura-ext/std",
 	'cumulus-pallet-parachain-system/std',

--- a/runtime/primitives/src/currency_id.rs
+++ b/runtime/primitives/src/currency_id.rs
@@ -14,6 +14,10 @@ pub enum TokenSymbol {
 	KAR = 128,
 	// Shiden
 	SDN = 50,
+
+	// Relaychain Token
+	KSM,
+	DOT,
 }
 
 impl Default for TokenSymbol {
@@ -31,5 +35,31 @@ pub enum CurrencyId {
 impl Default for CurrencyId {
 	fn default() -> Self {
 		Self::Token(TokenSymbol::MA)
+	}
+}
+
+#[allow(dead_code)]
+impl CurrencyId {
+	fn is_native(&self) -> bool {
+		matches!(
+			*self,
+			Self::Token(TokenSymbol::KMA) | Self::Token(TokenSymbol::MA)
+		)
+	}
+
+	fn is_parachain(&self) -> bool {
+		matches!(
+			*self,
+			Self::Token(TokenSymbol::ACA)
+				| Self::Token(TokenSymbol::KAR)
+				| Self::Token(TokenSymbol::SDN)
+		)
+	}
+
+	fn is_relaychain(&self) -> bool {
+		matches!(
+			*self,
+			Self::Token(TokenSymbol::KSM) | Self::Token(TokenSymbol::DOT)
+		)
 	}
 }

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(clippy::unnecessary_cast)]
 #![allow(clippy::upper_case_acronyms)]
+#![forbid(clippy::unwrap_used)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod constants;

--- a/runtime/xcm-support/Cargo.toml
+++ b/runtime/xcm-support/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+authors = ['Manta Network']
+name = "manta-xcm-support"
+version = "3.0.0"
+edition = "2018"
+homepage = 'https://manta.network'
+license = 'GPL-3.0'
+repository = 'https://github.com/Manta-Network/Manta/'
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.1.0", default-features = false }
+log = { version = "0.4.14", default-features = false }
+
+# Substrate primitives
+sp-runtime = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
+sp-std = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
+
+# Substrate frames
+frame-support = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.8" }
+
+# xcm dependencies
+xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.8" }
+xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.8" }
+
+# Self dependencies
+manta-primitives = { path = '../primitives', default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	'codec/std',
+	'frame-support/std',
+	'log/std',
+	'manta-primitives/std',
+	'sp-runtime/std',
+	'sp-std/std',
+	'xcm/std',
+	'xcm-executor/std',
+]

--- a/runtime/xcm-support/src/lib.rs
+++ b/runtime/xcm-support/src/lib.rs
@@ -1,0 +1,269 @@
+#![forbid(clippy::unwrap_used)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::FullCodec;
+use core::{convert::TryFrom, marker::PhantomData};
+use frame_support::traits::{Currency, ExistenceRequirement, Get, WithdrawReasons};
+use manta_primitives::currency_id::{CurrencyId as MantaCurrencyId, TokenSymbol};
+use sp_runtime::traits::{MaybeSerializeDeserialize, StaticLookup};
+use sp_std::{
+	cmp::{Eq, PartialEq},
+	fmt::Debug,
+	vec::Vec,
+};
+use xcm::v0::{Error as XcmError, MultiAsset, MultiLocation, Result as XcmResult};
+use xcm_executor::traits::{Convert, FilterAssetLocation, TransactAsset};
+
+// A Handler for withdrawing/depositting relaychain/parachain tokens.
+pub struct MantaTransactorAdaptor<
+	NativeCurrency,
+	XCurrency,
+	AccountIdConverter,
+	AccountId,
+	CurrencyId,
+	LocationMapCurrencyId,
+>(
+	PhantomData<(
+		NativeCurrency,
+		XCurrency,
+		AccountIdConverter,
+		AccountId,
+		CurrencyId,
+		LocationMapCurrencyId,
+	)>,
+);
+impl<
+		NativeCurrency: Currency<AccountId>,
+		XCurrency: manta_primitives::traits::XCurrency<
+			AccountId,
+			Balance = NativeCurrency::Balance,
+			CurrencyId = MantaCurrencyId,
+		>,
+		AccountIdConverter: Convert<MultiLocation, AccountId>,
+		AccountId: sp_std::fmt::Debug + Clone,
+		CurrencyId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug,
+		LocationMapCurrencyId: StaticLookup<Source = MultiLocation, Target = MantaCurrencyId>,
+	> TransactAsset
+	for MantaTransactorAdaptor<
+		NativeCurrency,
+		XCurrency,
+		AccountIdConverter,
+		AccountId,
+		CurrencyId,
+		LocationMapCurrencyId,
+	>
+{
+	fn can_check_in(_origin: &MultiLocation, _what: &MultiAsset) -> XcmResult {
+		Ok(())
+	}
+
+	fn deposit_asset(asset: &MultiAsset, who: &MultiLocation) -> XcmResult {
+		log::info!(target: "manta-xassets", "deposit_asset: asset = {:?}, who = {:?}", asset, who);
+
+		let who = AccountIdConverter::convert_ref(who).map_err(|_| {
+			XcmError::FailedToTransactAsset("Failed to convert multilocation to account id")
+		})?;
+
+		match asset {
+			MultiAsset::ConcreteFungible { id, amount } => {
+				let currency_id = LocationMapCurrencyId::lookup(id.clone()).map_err(|_| {
+					XcmError::FailedToTransactAsset("Now we didn't support this multiLocation")
+				})?;
+				let amount =
+					NativeCurrency::Balance::try_from(*amount).map_err(|_| XcmError::Overflow)?;
+
+				match currency_id {
+					MantaCurrencyId::Token(TokenSymbol::MA)
+					| MantaCurrencyId::Token(TokenSymbol::KMA) => {
+						NativeCurrency::deposit_creating(&who, amount);
+					}
+					MantaCurrencyId::Token(TokenSymbol::ACA)
+					| MantaCurrencyId::Token(TokenSymbol::KAR)
+					| MantaCurrencyId::Token(TokenSymbol::SDN)
+					| MantaCurrencyId::Token(TokenSymbol::KSM) => {
+						XCurrency::deposit(currency_id, &who, amount)
+							.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+					}
+					_ => {
+						log::info!(target: "manta-xassets", "Failed to deposit Unknow asset.");
+					}
+				}
+
+				Ok(())
+			}
+			_ => Err(XcmError::FailedToTransactAsset(
+				"We don't support this multi-asset now",
+			)),
+		}
+	}
+
+	fn withdraw_asset(
+		asset: &MultiAsset,
+		who: &MultiLocation,
+	) -> Result<xcm_executor::Assets, XcmError> {
+		log::info!(target: "manta-xassets", "withdraw_asset: asset = {:?}, who = {:?}", asset, who);
+
+		let who = AccountIdConverter::convert_ref(who).map_err(|_| {
+			XcmError::FailedToTransactAsset("Failed to convert multilocation to account id")
+		})?;
+
+		match asset {
+			MultiAsset::ConcreteFungible { id, amount } => {
+				let amount =
+					NativeCurrency::Balance::try_from(*amount).map_err(|_| XcmError::Overflow)?;
+				let currency_id = LocationMapCurrencyId::lookup(id.clone()).map_err(|_| {
+					XcmError::FailedToTransactAsset("Now we didn't support this multiLocation")
+				})?;
+
+				match currency_id {
+					MantaCurrencyId::Token(TokenSymbol::MA)
+					| MantaCurrencyId::Token(TokenSymbol::KMA) => {
+						NativeCurrency::withdraw(
+							&who,
+							amount,
+							WithdrawReasons::TRANSFER,
+							ExistenceRequirement::AllowDeath,
+						)
+						.map_err(|e| {
+							log::info!(target: "manta-xassets", "withdraw_asset: error = {:?}", e);
+							XcmError::FailedToTransactAsset(e.into())
+						})?;
+					}
+					MantaCurrencyId::Token(TokenSymbol::ACA)
+					| MantaCurrencyId::Token(TokenSymbol::KAR)
+					| MantaCurrencyId::Token(TokenSymbol::SDN)
+					| MantaCurrencyId::Token(TokenSymbol::KSM) => {
+						XCurrency::withdraw(currency_id, &who, amount)
+							.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+					}
+					_ => {
+						log::info!(target: "manta-xassets", "Failed to deposit Unknow asset.");
+					}
+				}
+
+				Ok(asset.clone().into())
+			}
+			_ => Err(XcmError::NotWithdrawable),
+		}
+	}
+}
+
+/// Which parachain or asset we support
+pub struct TrustedParachains<Chains>(PhantomData<Chains>);
+impl<Chains: Get<Vec<(MultiLocation, u128)>>> FilterAssetLocation for TrustedParachains<Chains> {
+	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
+		log::info!(target: "manta-xassets", "filter_asset_location: origin = {:?}, asset = {:?}", origin, asset);
+
+		Chains::get()
+			.iter()
+			.map(|(location, _)| location)
+			.any(|location| *location == *origin)
+	}
+}
+
+/// Lookup table for finding currency id by multilocation.
+pub struct MultiLocationToCurrencyId<T>(PhantomData<T>);
+impl<MultiLocationMapCurrencyId: Get<Vec<(MultiLocation, MantaCurrencyId)>>> StaticLookup
+	for MultiLocationToCurrencyId<MultiLocationMapCurrencyId>
+{
+	type Source = MultiLocation;
+	type Target = MantaCurrencyId;
+
+	fn lookup(s: Self::Source) -> Result<Self::Target, frame_support::error::LookupError> {
+		let get_all = MultiLocationMapCurrencyId::get();
+		for i in get_all.iter() {
+			if s == i.0 {
+				return Ok(i.1);
+			}
+		}
+
+		Err(frame_support::error::LookupError)
+	}
+
+	fn unlookup(t: Self::Target) -> Self::Source {
+		let get_all = MultiLocationMapCurrencyId::get();
+		for i in get_all.iter() {
+			if t == i.1 {
+				return i.0.clone();
+			}
+		}
+
+		// This means we don't find multilocation by currency id.
+		MultiLocation::Null
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::parameter_types;
+	use xcm::v0::Junction;
+
+	parameter_types! {
+		pub MultiLocationMapCurrencyId: Vec<(MultiLocation, MantaCurrencyId)> = vec![
+			// Acala karura => KAR, native token
+			(MultiLocation::X3(Junction::Parent, Junction::Parachain(2000), Junction::GeneralKey([0, 128].to_vec())), MantaCurrencyId::Token(TokenSymbol::KAR)),
+			// Manta manta-pc => MA, native token, for example, acala can send it back to manta parachain.
+			(MultiLocation::X3(Junction::Parent, Junction::Parachain(2000), Junction::GeneralKey([0, 5].to_vec())), MantaCurrencyId::Token(TokenSymbol::MA)),
+			// Manta calamari => KMA, native token, for example, karura can send it back to manta parachain.
+			(MultiLocation::X3(Junction::Parent, Junction::Parachain(2000), Junction::GeneralKey([0, 133].to_vec())), MantaCurrencyId::Token(TokenSymbol::KMA)),
+		];
+		pub TrustedChains: Vec<(MultiLocation, u128)> = vec![
+			// Acala local and live, 0.01 ACA
+			(MultiLocation::X2(Junction::Parent, Junction::Parachain(2000)), 10_000_000_000),
+			(MultiLocation::X2(Junction::Parent, Junction::Parachain(2084)), 10_000_000_000),
+		];
+	}
+
+	#[test]
+	fn find_currency_id_by_multilocation_should_work() {
+		let karura = MultiLocation::X3(
+			Junction::Parent,
+			Junction::Parachain(2000),
+			Junction::GeneralKey([0, 128].to_vec()),
+		);
+		let currency_id = MultiLocationToCurrencyId::<MultiLocationMapCurrencyId>::lookup(karura);
+		assert!(currency_id.is_ok());
+		assert_eq!(
+			currency_id.unwrap(),
+			MantaCurrencyId::Token(TokenSymbol::KAR)
+		);
+
+		let unknown = MultiLocation::X3(
+			Junction::Parent,
+			Junction::Parachain(1999),
+			Junction::GeneralKey([0, 1].to_vec()),
+		);
+		let currency_id = MultiLocationToCurrencyId::<MultiLocationMapCurrencyId>::lookup(unknown);
+		assert!(currency_id.is_err());
+
+		let kar = MantaCurrencyId::Token(TokenSymbol::KAR);
+		let location = MultiLocationToCurrencyId::<MultiLocationMapCurrencyId>::unlookup(kar);
+		assert_eq!(
+			location,
+			MultiLocation::X3(
+				Junction::Parent,
+				Junction::Parachain(2000),
+				Junction::GeneralKey([0, 128].to_vec())
+			)
+		);
+
+		let shiden = MantaCurrencyId::Token(TokenSymbol::SDN);
+		let location = MultiLocationToCurrencyId::<MultiLocationMapCurrencyId>::unlookup(shiden);
+		assert_eq!(location, MultiLocation::Null);
+	}
+
+	#[test]
+	fn filter_asset_location_should_work() {
+		let karura = MultiLocation::X2(Junction::Parent, Junction::Parachain(2000));
+
+		let found =
+			TrustedParachains::<TrustedChains>::filter_asset_location(&MultiAsset::None, &karura);
+		assert!(found);
+
+		let unknown = MultiLocation::X2(Junction::Parent, Junction::Parachain(1999));
+		let not_found =
+			TrustedParachains::<TrustedChains>::filter_asset_location(&MultiAsset::None, &unknown);
+		assert!(!not_found);
+	}
+}


### PR DESCRIPTION
1. Refactor `MantaTransactorAdaptor`.
2. Add crate 'manta-xcm-support' that implements xcm related traits and data types.
3. Add a clippy to disable the usage of `unwrap` while do clippy check.
4. Define xcm events to `manta-xassets`.