### PR TITLE
[Manta-PC] benchmark persistence workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -211,6 +211,7 @@ jobs:
                 observed: ISODate(),
                 pallet: "${{ matrix.benchmark.pallet.name }}",
                 extrinsic: "${{ matrix.benchmark.extrinsic.name }}",
+                machine: "c5a.8xlarge",
                 actual: {
                   time: '${actual_time}',
                   unit: "'${actual_unit}'"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,287 @@
+---
+
+# yamllint disable rule:line-length
+
+name: benchmark
+
+on:
+  push:
+    branch:
+      - manta
+
+jobs:
+
+  build-benchmark:
+    needs: start-worker
+    runs-on: ${{ needs.start-worker.outputs.runner-label }}
+    steps:
+      -
+        name: install sccache
+
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      -
+        name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      -
+        name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      -
+        name: start sccache server
+        run: sccache --start-server
+      -
+        name: init
+        env:
+          CARGO_TERM_COLOR: always
+        run: |
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup toolchain install stable
+          rustup toolchain install nightly
+          rustup default stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
+          rustup update
+      -
+        name: build
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 2G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+          CARGO_TERM_COLOR: always
+        run: |
+          source ${HOME}/.cargo/env
+          cargo install --verbose --git https://github.com/${GITHUB_REPOSITORY} --rev ${GITHUB_SHA:0:7} --features runtime-benchmarks --locked --force --root ~/.cargo
+      -
+        name: stop sccache server
+        run: sccache --stop-server || true
+      -
+        name: upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: manta
+          path: /home/runner/.cargo/bin/manta
+
+  run-benchmark:
+    name: benchmark (${{ matrix.benchmark.pallet.name }} ${{ matrix.benchmark.extrinsic.name }} < ${{ matrix.benchmark.expected.time }} ${{ matrix.benchmark.expected.unit }})
+    needs:
+      - start-worker
+      - build-benchmark
+    runs-on: ${{ needs.start-worker.outputs.runner-label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        benchmark:
+          -
+            extrinsic:
+              id: init_asset
+              name: init-asset
+            pallet:
+              id: pallet_manta_pay
+              name: pallet-manta-pay
+            iterations: 1000
+            expected:
+              time: 6000
+              unit: µs
+          -
+            extrinsic:
+              id: transfer_asset
+              name: transfer-asset
+            pallet:
+              id: pallet_manta_pay
+              name: pallet-manta-pay
+            iterations: 1000
+            expected:
+              time: 60
+              unit: µs
+          -
+            extrinsic:
+              id: mint_private_asset
+              name: mint-private-asset
+            pallet:
+              id: pallet_manta_pay
+              name: pallet-manta-pay
+            iterations: 1000
+            expected:
+              time: 48000
+              unit: µs
+          -
+            extrinsic:
+              id: private_transfer
+              name: private-transfer
+            pallet:
+              id: pallet_manta_pay
+              name: pallet-manta-pay
+            iterations: 1000
+            expected:
+              time: 220000
+              unit: µs
+          -
+            extrinsic:
+              id: reclaim
+              name: reclaim
+            pallet:
+              id: pallet_manta_pay
+              name: pallet-manta-pay
+            iterations: 1000
+            expected:
+              time: 180000
+              unit: µs
+    steps:
+      -
+        name: install mongodb-mongosh
+        run: |
+          if command -v mongosh &> /dev/null; then
+            echo "mongosh detected"
+          else
+            # https://docs.mongodb.com/mongodb-shell/install
+            sudo apt-get install gnupg
+            wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+            sudo apt-get update
+            sudo apt-get install -y mongodb-mongosh
+          fi
+      -
+        uses: actions/download-artifact@v2
+        with:
+          name: manta
+      -
+        run: |
+          mv manta $HOME/.local/bin/
+          chmod +x $HOME/.local/bin/manta
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      -
+        name: observe benchmark
+        run: |
+          manta benchmark \
+            --pallet ${{ matrix.benchmark.pallet.id }} \
+            --extrinsic ${{ matrix.benchmark.extrinsic.id }} \
+            --execution=Wasm \
+            --wasm-execution Compiled \
+            --repeat ${{ matrix.benchmark.iterations }} \
+            2> ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}-stderr.log \
+            > ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}-stdout.log
+          cat ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}-stdout.log | head -8 | tail -2 | xargs -n1 | tail -2 | tr '\n' ' ' | sed 's/ *$//g' | jq \
+            --raw-input \
+            --slurp \
+            '. |= split(" ") | { time: .[0] | tonumber, unit: .[1] }' \
+            > ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}.json
+      -
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}.json
+          path: ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}.json
+      -
+        name: evaluate and persist benchmark
+        run: |
+          expected_time=${{ matrix.benchmark.expected.time }}
+          expected_unit=${{ matrix.benchmark.expected.unit }}
+          actual_time=$(jq '.time' ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}.json)
+          actual_unit=$(jq -r '.unit' ${{ github.workspace }}/benchmark-${{ matrix.benchmark.pallet.name }}-${{ matrix.benchmark.extrinsic.name }}.json)
+          mongosh "mongodb+srv://benchmark-cluster.ucudy.mongodb.net/${{ github.repository_owner }}" \
+            --authenticationMechanism MONGODB-AWS \
+            --authenticationDatabase '$external' \
+            --eval 'db.${{ github.event.repository.name }}.insertOne(
+              {
+                repo: "${{ github.repository }}",
+                sha: "${{ github.sha }}",
+                observed: ISODate(),
+                pallet: "${{ matrix.benchmark.pallet.name }}",
+                extrinsic: "${{ matrix.benchmark.extrinsic.name }}",
+                actual: {
+                  time: '${actual_time}',
+                  unit: "'${actual_unit}'"
+                },
+                expected: {
+                  time: '${expected_time}',
+                  unit: "'${expected_unit}'"
+                }
+              }
+            )'
+          if [ "${actual_unit}" != "${expected_unit}" ]; then echo "actual unit of time (${actual_time} ${actual_unit}) differs from expected unit of time (${expected_time} ${expected_unit})"; exit 1; fi
+          if (( $(echo "$actual_time <= $expected_time" | bc -l) )); then echo "actual time (${actual_time} ${actual_unit}) is within expected time (${expected_time} ${expected_unit})"; else echo "actual time (${actual_time} ${actual_unit}) exceeds expected time (${expected_time} ${expected_unit})"; exit 1; fi
+
+  #brag-or-whine:
+  #  needs: run-benchmark
+  #  runs-on: ubuntu-latest
+  #  if: ${{ always() }}
+  #  steps:
+  #    -
+  #      uses: actions/download-artifact@v2
+  #    -
+  #      env:
+  #        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+  #        DISCORD_USERNAME: raybot
+  #        DISCORD_AVATAR: https://gist.githubusercontent.com/grenade/66a46007b37778d81ee064394263b16c/raw/raybot.png
+  #      uses: Ilshidur/action-discord@0.3.2
+  #      with:
+  #        args: 'link to latest benchmark graph goes here'
+
+  start-worker:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: us-east-1
+          aws-subnet-id: subnet-08c26caf0a52b7c19
+          aws-security-group-id: sg-0315bffea9042ac9b
+          aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
+          aws-instance-root-volume-size: 32
+          aws-instance-lifecycle: spot
+          aws-iam-role-name: github-action-worker
+          aws-image-search-pattern: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+          aws-image-search-owners: '["099720109477"]' # canonical
+
+  stop-worker:
+    needs:
+      - start-worker
+      - run-benchmark
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-worker.outputs.aws-region }}
+          runner-label: ${{ needs.start-worker.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-worker.outputs.aws-instance-id }}
+
+# yamllint enable rule:line-length


### PR DESCRIPTION
this workflow:
- uses self-hosted aws runners to produce a benchmark build and observe/record benchmark timings for that build
- adds benchmark persistence to a historical benchmarks table which will allow us to graph benchmark timings over time and across commits.