### PR TITLE
[Calamari]Add more collators for calamari-local chain spec and update polkadot deps

### DIFF
--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -604,7 +604,7 @@ jobs:
         name: run test suites
         run: |
           # todo: implement moonbeam-like js test suite triggers here
-          sleep 180
+          sleep 210
       -
         name: stop testnet
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "bp-message-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-runtime",
  "frame-support",
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "bp-runtime",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "bp-rialto"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "bp-wococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.4",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "derive_more 0.99.16",
  "futures 0.3.16",
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "bp-message-dispatch",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6346,7 +6346,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-network-protocol",
@@ -6360,7 +6360,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-network-protocol",
@@ -6373,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "lru",
@@ -6396,7 +6396,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "lru",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.16",
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "always-assert",
  "futures 0.3.16",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "lru",
@@ -6521,7 +6521,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6535,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-network-protocol",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6573,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "parity-scale-codec",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "derive_more 0.99.16",
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.16",
@@ -6641,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.16",
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-subsystem",
@@ -6674,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-subsystem",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "derive_more 0.99.16",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-participation"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "polkadot-node-primitives",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.16",
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "memory-lru",
@@ -6836,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6887,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "futures 0.3.16",
  "parity-scale-codec",
@@ -6911,7 +6911,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6951,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -6981,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -7003,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-all-subsystems-gen"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "assert_matches",
  "proc-macro2 1.0.28",
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen-proc-macro"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.28",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "derive_more 0.99.16",
  "frame-support",
@@ -7058,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "frame-system",
@@ -7088,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7121,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.4",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitvec 0.20.4",
  "frame-benchmarking",
@@ -7239,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "bitflags",
  "bitvec 0.20.4",
@@ -7278,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "arrayvec 0.5.2",
  "futures 0.3.16",
@@ -7395,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-primitives",
  "bp-messages",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11886,7 +11886,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.4",
@@ -12064,7 +12064,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12075,7 +12075,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12094,7 +12094,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.9-1"
-source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#67d539dd74768096cbe024dce2577560729b2341"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.9#7a9f624777ad2d2adb3a1e6797a31f9d653c9587"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -435,6 +435,18 @@ pub fn calamari_local_config(id: ParaId) -> CalamariChainSpec {
 						get_account_id_from_seed::<sr25519::Public>("Bob"),
 						get_collator_keys_from_seed("Bob"),
 					),
+					(
+						get_account_id_from_seed::<sr25519::Public>("Charlie"),
+						get_collator_keys_from_seed("Charlie"),
+					),
+					(
+						get_account_id_from_seed::<sr25519::Public>("Dave"),
+						get_collator_keys_from_seed("Dave"),
+					),
+					(
+						get_account_id_from_seed::<sr25519::Public>("Eve"),
+						get_collator_keys_from_seed("Eve"),
+					),
 				],
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![


### PR DESCRIPTION
Closes #165 

1. Add more collators for calamari-local chain spec.
2. Update polkadot deps to the latest commit of branch `release-v0.9.9`.
> Tips: We're using the commit `67d539dd74768096cbe024dce2577560729b2341`, but the latest commit is `7a9f624777ad2d2adb3a1e6797a31f9d653c9587`.
And no need to update cumulus and substrate deps, they didn't update both repositories actually.