### PR TITLE
Integrate runtime upgrade test into CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                               ✰  Thanks for creating a PR! ✰
+v    Before hitting that submit button please review the checkboxes.
+v    If a checkbox is n/a - please still include it but + a little note why
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+## Description
+
+<!-- Add a description of the changes that this PR introduces and the files that
+are the most critical to review.
+-->
+
+closes: #XXXX
+
+---
+
+Before we can merge this PR, please make sure that all the following items have been
+checked off. If any of the checklist items are not applicable, please leave them but
+write a little note why.
+
+- [ ] Targeted PR against correct branch (master)
+- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
+- [ ] Wrote unit tests
+- [ ] Updated relevant documentation in the code
+- [ ] Re-reviewed `Files changed` in the Github PR explorer

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -446,7 +446,7 @@ jobs:
       matrix:
         chain-spec:
           -
-            id: calamari-testnet
+            id: calamari-testnet-ci
             expected:
               block-count:
                 para: 6

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -6,11 +6,11 @@ name: publish draft releases
 
 # yamllint disable-line rule:truthy
 on:
+  pull_request:
+      - manta-pc
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-    pull_request:
-      - manta-pc
 
 jobs:
 

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -7,10 +7,10 @@ name: publish draft releases
 # yamllint disable-line rule:truthy
 on:
   push:
-    branch:
-      - manta-pc
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+    pull_request:
+      - manta-pc
 
 jobs:
 

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -9,8 +9,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-    # branch:
-    #   - manta-pc
+    branch:
+      - ghzlatarev/rtu-calamari-test-net
 
 jobs:
 
@@ -564,7 +564,6 @@ jobs:
                     "flags": [
                       "--rpc-cors=all",
                       "--rpc-port=9971",
-                      "--rpc-methods=unsafe",
                       "--",
                       "--execution=wasm"
                     ]
@@ -575,7 +574,6 @@ jobs:
                     "flags": [
                       "--rpc-cors=all",
                       "--rpc-port=9972",
-                      "--rpc-methods=unsafe",
                       "--",
                       "--execution=wasm"
                     ]
@@ -587,7 +585,6 @@ jobs:
                     "flags": [
                       "--rpc-cors=all",
                       "--rpc-port=9973",
-                      "--rpc-methods=unsafe",
                       "--",
                       "--execution=wasm"
                     ]
@@ -598,7 +595,6 @@ jobs:
                     "flags": [
                       "--rpc-cors=all",
                       "--rpc-port=9974",
-                      "--rpc-methods=unsafe",
                       "--",
                       "--execution=wasm"
                     ]
@@ -609,7 +605,6 @@ jobs:
                     "flags": [
                       "--rpc-cors=all",
                       "--rpc-port=9975",
-                      "--rpc-methods=unsafe",
                       "--",
                       "--execution=wasm"
                     ]

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1313,10 +1313,10 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: us-east-1
-          aws-subnet-id: subnet-08c26caf0a52b7c19
-          aws-security-group-id: sg-0315bffea9042ac9b
+          # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: eu-west-1
+          # aws-subnet-id: subnet-08c26caf0a52b7c19
+          # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
           aws-instance-root-volume-size: 32
           aws-instance-lifecycle: spot
@@ -1358,10 +1358,10 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: us-east-1
-          aws-subnet-id: subnet-08c26caf0a52b7c19
-          aws-security-group-id: sg-0315bffea9042ac9b
+          # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: eu-west-1
+          # aws-subnet-id: subnet-08c26caf0a52b7c19
+          # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
           aws-instance-root-volume-size: 32
           aws-instance-lifecycle: spot
@@ -1401,10 +1401,10 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: us-east-1
-          aws-subnet-id: subnet-08c26caf0a52b7c19
-          aws-security-group-id: sg-0315bffea9042ac9b
+          # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: eu-west-1
+          # aws-subnet-id: subnet-08c26caf0a52b7c19
+          # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
           aws-instance-root-volume-size: 64
           aws-instance-lifecycle: spot
@@ -1444,10 +1444,10 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: us-east-1
-          aws-subnet-id: subnet-08c26caf0a52b7c19
-          aws-security-group-id: sg-0315bffea9042ac9b
+          # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: eu-west-1
+          # aws-subnet-id: subnet-08c26caf0a52b7c19
+          # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
           aws-instance-root-volume-size: 64
           aws-instance-lifecycle: spot

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1490,12 +1490,12 @@ jobs:
         name: get runtime version
         id: get-runtime-version-current
         run: |
-          runtime-ver-current="$(ruby -e '
+          runtime_ver_current="$(ruby -e '
             require "./scripts/github/lib.rb";
             puts get_runtime("calamari")
           ')"
-          echo "::set-output name=runtime-ver-current::$runtime-ver-current"
-          echo $runtime-ver-current
+          echo "::set-output name=runtime-ver-current::$runtime_ver_current"
+          echo $runtime_ver_current
           echo ....................
       - name: Show new runtime version
         run: echo "The selected value is ${{ steps.get-runtime-version-current.outputs.runtime-ver-current }}"
@@ -1507,12 +1507,12 @@ jobs:
           cd temp_for_run
           git clone -b manta-pc https://github.com/Manta-Network/Manta.git
           cd Manta
-          runtime-ver-base="$(ruby -e '
+          runtime_ver_base="$(ruby -e '
             require "./scripts/github/lib.rb";
             puts get_runtime("calamari")
           ')"
-          echo "::set-output name=runtime-ver-base::$runtime-ver-base"
-          echo $runtime-ver-base
+          echo "::set-output name=runtime-ver-base::$runtime_ver_base"
+          echo $runtime_ver_base
           echo ....................
       - name: Show base runtime version
         run: echo "The selected value is ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}"

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -340,11 +340,410 @@ jobs:
       #   run: |
       #     jq --slurp '. | add' ${{ github.workspace }}/extrinsic-benchmark-pallet-manta-pay-*.json > ${{ github.workspace }}/extrinsic-benchmark-pallet-manta-pay.json
 
+  build-node-old:
+    needs:
+      - start-node-builder-old
+      - check-for-runtime-upgrade
+    runs-on: ${{ needs.start-node-builder-old.outputs.runner-label }}
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        uses: actions/checkout@v2
+        with:
+          ref: '4204135e90ce02fa28af0913c8f050b76bd3ea23'
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: install sccache
+
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: start sccache server
+        run: sccache --start-server
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: init
+        run: |
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup toolchain install stable
+          rustup toolchain install nightly
+          rustup default stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
+          rustup update
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: build
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 2G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+        run: |
+          source ${HOME}/.cargo/env
+          cargo build --verbose --release --features calamari
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: stop sccache server
+        run: sccache --stop-server || true
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: strip
+        run: |
+          strip target/release/calamari-pc
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: calamari-pc-old
+          path: target/release/calamari-pc
+
+  runtime-upgrade-test:
+    needs:
+      - build-node-old
+      - build-calamari-runtime
+      - start-runtime-upgrade-tester
+      - check-for-runtime-upgrade
+    runs-on: ${{ needs.start-runtime-upgrade-tester.outputs.runner-label }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        chain-spec:
+          -
+            id: calamari-testnet
+            expected:
+              block-count:
+                para: 6
+              peer-count:
+                para: 2
+    steps:
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        run: |
+          mkdir -p $HOME/.local/share/calamari-pc
+          mkdir -p $HOME/.local/bin
+          echo "${HOME}/.nvm/versions/node/v16.3.0/bin" >> $GITHUB_PATH
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: fetch calamari-pc-old
+        uses: actions/download-artifact@v2
+        with:
+          name: calamari-pc-old
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: mv and chmod calamari-pc-old
+        run: |
+          pwd
+          ls -a
+          mv ${{ github.workspace }}/calamari-pc $HOME/.local/bin/
+          chmod +x $HOME/.local/bin/calamari-pc
+          ls -ahl ${{ github.workspace }}/
+          ls -ahl $HOME/.local/bin/
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: fetch and chmod polkadot
+        run: |
+          curl -L -o $HOME/.local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.9/polkadot
+          chmod +x $HOME/.local/bin/polkadot
+          ls -ahl $HOME/.local/bin/
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        id: create-chainspec
+        run: |
+          calamari-pc export-state --chain ${{ matrix.chain-spec.id }} > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json || true
+          calamari-pc build-spec --chain ${{ matrix.chain-spec.id }} --disable-default-bootnode --raw > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-spec.json
+          jq \
+            --sort-keys \
+            --arg name "calamari testnet ${GITHUB_SHA:0:7}" \
+            --arg id ${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7} \
+            --arg relay_chain rococo-local-${GITHUB_SHA:0:7} \
+            --arg parachain_id 2084 \
+            '. |
+              .name = $name |
+              .id = $id |
+              .relay_chain = $relay_chain |
+              .para_id = ($parachain_id | tonumber) |
+              .telemetryEndpoints = [["/dns/api.telemetry.manta.systems/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]]
+            ' $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-spec.json > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json
+          ls -ahl $HOME/.local/share/calamari-pc/
+          echo "::set-output name=short-sha::${GITHUB_SHA:0:7}"
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: create launch config
+        run: |
+          echo '{
+            "relaychain": {
+              "chain": "rococo-local",
+              "mutation": {},
+              "nodes": [
+                {
+                  "name": "alice",
+                  "wsPort": 9911,
+                  "port": 31331,
+                  "flags": [
+                    "--rpc-cors=all",
+                    "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
+                  ]
+                },
+                {
+                  "name": "bob",
+                  "wsPort": 9912,
+                  "port": 31332,
+                  "flags": [
+                    "--rpc-cors=all",
+                    "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
+                  ]
+                },
+                {
+                  "name": "charlie",
+                  "wsPort": 9913,
+                  "port": 31333,
+                  "flags": [
+                    "--rpc-cors=all",
+                    "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
+                  ]
+                }
+              ],
+              "genesis": {
+                "runtime": {
+                  "runtime_genesis_config": {
+                    "parachainsConfiguration": {
+                      "config": {
+                        "validation_upgrade_frequency": 1,
+                        "validation_upgrade_delay": 1
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "parachains": [
+              {
+                "id": "2084",
+                "nodes": [
+                  {
+                    "wsPort": 9921,
+                    "port": 32331,
+                    "flags": [
+                      "--rpc-cors=all",
+                      "--rpc-port=9971",
+                      "--rpc-methods=unsafe",
+                      "--",
+                      "--execution=wasm"
+                    ]
+                  },
+                  {
+                    "wsPort": 9922,
+                    "port": 32332,
+                    "flags": [
+                      "--rpc-cors=all",
+                      "--rpc-port=9972",
+                      "--rpc-methods=unsafe",
+                      "--",
+                      "--execution=wasm"
+                    ]
+                  },
+                  {
+                    "name": "charlie",
+                    "wsPort": 9923,
+                    "port": 32333,
+                    "flags": [
+                      "--rpc-cors=all",
+                      "--rpc-port=9973",
+                      "--rpc-methods=unsafe",
+                      "--",
+                      "--execution=wasm"
+                    ]
+                  },
+                  {
+                    "wsPort": 9924,
+                    "port": 32334,
+                    "flags": [
+                      "--rpc-cors=all",
+                      "--rpc-port=9974",
+                      "--rpc-methods=unsafe",
+                      "--",
+                      "--execution=wasm"
+                    ]
+                  },
+                  {
+                    "wsPort": 9925,
+                    "port": 32335,
+                    "flags": [
+                      "--rpc-cors=all",
+                      "--rpc-port=9975",
+                      "--rpc-methods=unsafe",
+                      "--",
+                      "--execution=wasm"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "hrmpChannels": [],
+            "types": {},
+            "finalization": false
+          }' | \
+          jq \
+            --arg relaychain_bin $HOME/.local/bin/polkadot \
+            --arg relaychain_id rococo-local-${GITHUB_SHA:0:7} \
+            --arg relaychain_name "rococo local ${GITHUB_SHA:0:7}" \
+            --arg parachains_bin $HOME/.local/bin/calamari-pc \
+            --arg parachains_spec $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json \
+            '.
+              | .relaychain.bin = $relaychain_bin
+              | .relaychain.mutation.id = $relaychain_id
+              | .relaychain.mutation.name = $relaychain_name
+              | .parachains[].bin = $parachains_bin
+              | .parachains[].chain = $parachains_spec
+            ' > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
+          jq . $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
+          ls -ahl $HOME/.local/share/calamari-pc/
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        uses: actions/checkout@v2
+        with:
+          repository: Manta-Network/manta-pc-launch
+          path: manta-pc-launch
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        uses: actions/checkout@v2
+        with:
+          repository: Manta-Network/Dev-Tools
+          path: dev-tools-calamari
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: launch testnet
+        run: |
+          cd ${{ github.workspace }}/manta-pc-launch
+          yarn install
+          yarn build
+          pm2 start dist/cli.js \
+            --name manta-pc-launch \
+            --output ${{ github.workspace }}/manta-pc-launch-for-${{ matrix.chain-spec.id }}-stdout.log \
+            --error ${{ github.workspace }}/manta-pc-launch-for-${{ matrix.chain-spec.id }}-stderr.log \
+            --no-autorestart \
+            -- $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: init measure-block-time calamari
+        run: |
+          cd ${{ github.workspace }}/dev-tools-calamari/measure-block-time
+          yarn install
+          sed -i -- 's/9988/9921/g' index.js
+          pm2 start index.js \
+            --name measure-block-time-${{ matrix.chain-spec.id }} \
+            --output ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log \
+            --error ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stderr.log \
+            --no-autorestart
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: fetch new calamari_runtime.compact.compressed.wasm
+        uses: actions/download-artifact@v2
+        with:
+          name: calamari-runtime
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: run test suites
+        run: |
+          # todo: implement moonbeam-like js test suite triggers here
+          sleep 120
+
+          echo "midnight supply never you faith veteran danger purity tired illness dune token" > ${{ github.workspace }}/dev-tools-calamari/runtime-upgrade-test/root_mnemonics
+          curl -vH 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"author_insertKey", "params":["aura", "inhale connect winner reduce cheese bachelor crucial never metal seat time wage", "0xee73f78b7dd29f30902c1a3bd1e4a6fcc2f26be088343d3ee011e2660fd02a66"],"id":1 }' localhost:9971
+          curl -vH 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"author_insertKey", "params":["aura", "timber else work trophy build winner mechanic chunk budget orchard glide extra", "0x7cd4af9ad51d443740f71ecd5850385e98985224628c5ea08209bb2015523f3c"],"id":1 }' localhost:9972
+          curl -vH 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"author_insertKey", "params":["aura", "civil cigar remain hybrid glove symptom review what pole lock concert lamp", "0xb40aa6bd104d0260b60350c2fb30d4882437466d66135130b667799ea6c9f52b"],"id":1 }' localhost:9973
+          curl -vH 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"author_insertKey", "params":["aura", "output evidence anger invest country opinion girl mouse direct double carbon usage", "0x4a3aa51469e802be6504422cd9dd03be638ac3f6dc3a7c0c85a6ace3e72f0048"],"id":1 }' localhost:9974
+          curl -vH 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"author_insertKey", "params":["aura", "series disorder today argue interest pond flight guess asthma guilt road gadget", "0xa68feb4fe2ea3f8ff288af4254aad2284e1cd0da67cb9ea61c13632bad57eb40"],"id":1 }' localhost:9975
+          cp calamari_runtime.compact.compressed.wasm ${{ github.workspace }}/dev-tools-calamari/runtime-upgrade-test/calamari.wasm
+          cd ${{ github.workspace }}/dev-tools-calamari/runtime-upgrade-test
+          yarn install
+          yarn
+          sleep 60
+          pm2 start index.js \
+            --name test-runtime-upgrade-${{ matrix.chain-spec.id }} \
+            --output ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stdout.log \
+            --error ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stderr.log \
+            --no-autorestart
+          cd ${{ github.workspace }}
+          sleep 30
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: stop testnet
+        run: |
+          cd ${{ github.workspace }}/manta-pc-launch
+          pm2 stop measure-block-time-${{ matrix.chain-spec.id }}
+          pm2 stop manta-pc-launch
+          pm2 stop test-runtime-upgrade-${{ matrix.chain-spec.id }}
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: runtime-upgrade-test-for-${{ matrix.chain-spec.id }}-stdout.log
+          path: ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stdout.log
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: runtime-upgrade-test-for-${{ matrix.chain-spec.id }}-stderr.log
+          path: ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stderr.log
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: parse runtime upgrade log
+        run: |
+          grep 'Included at block hash' ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words} | tee ${{ github.workspace }}/runtime-upgrade-output.csv; done
+          if [ ! -f ${{ github.workspace }}/runtime-upgrade-output.csv ]; then echo "Runtime upgrade failed"; exit 1; fi
+      -
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        name: parse calamari block times
+        run: |
+          grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[4]},${words[8]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
+          if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
+          jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
+
   integration-test:
     needs:
       - build-node
       - build-calamari-runtime
       - start-integration-tester
+      - check-for-runtime-upgrade
     runs-on: ${{ needs.start-integration-tester.outputs.runner-label }}
     timeout-minutes: 90
     strategy:
@@ -557,13 +956,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Manta-Network/Dev-Tools
-          ref: 8ee3341a268b892e05fdcfc0d113db557fc86234
           path: dev-tools-rococo
       -
         uses: actions/checkout@v2
         with:
           repository: Manta-Network/Dev-Tools
-          ref: 8ee3341a268b892e05fdcfc0d113db557fc86234
           path: dev-tools-calamari
       -
         name: launch testnet
@@ -599,7 +996,6 @@ jobs:
             --output ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log \
             --error ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stderr.log \
             --no-autorestart
-
       -
         name: run test suites
         run: |
@@ -778,6 +1174,7 @@ jobs:
       - build-calamari-runtime
       - run-benchmark
       - integration-test
+      - runtime-upgrade-test
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
@@ -951,6 +1348,49 @@ jobs:
           runner-label: ${{ needs.start-node-builder.outputs.runner-label }}
           aws-instance-id: ${{ needs.start-node-builder.outputs.aws-instance-id }}
 
+  start-node-builder-old:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: us-east-1
+          aws-subnet-id: subnet-08c26caf0a52b7c19
+          aws-security-group-id: sg-0315bffea9042ac9b
+          aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
+          aws-instance-root-volume-size: 32
+          aws-instance-lifecycle: spot
+          aws-image-search-pattern: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+          aws-image-search-owners: '["099720109477"]' # canonical
+
+  stop-node-builder-old:
+    needs:
+      - start-node-builder-old
+      - build-node-old
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-node-builder-old.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder-old.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder-old.outputs.aws-instance-id }}
+
   start-integration-tester:
     runs-on: ubuntu-latest
     outputs:
@@ -993,5 +1433,94 @@ jobs:
           aws-region: ${{ needs.start-integration-tester.outputs.aws-region }}
           runner-label: ${{ needs.start-integration-tester.outputs.runner-label }}
           aws-instance-id: ${{ needs.start-integration-tester.outputs.aws-instance-id }}
+
+  start-runtime-upgrade-tester:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+          aws-region: us-east-1
+          aws-subnet-id: subnet-08c26caf0a52b7c19
+          aws-security-group-id: sg-0315bffea9042ac9b
+          aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
+          aws-instance-root-volume-size: 64
+          aws-instance-lifecycle: spot
+          aws-image-search-pattern: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+          aws-image-search-owners: '["099720109477"]' # canonical
+
+  stop-runtime-upgrade-tester:
+    needs:
+      - runtime-upgrade-test
+      - check-for-runtime-upgrade
+      - start-runtime-upgrade-tester
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-runtime-upgrade-tester.outputs.aws-region }}
+          runner-label: ${{ needs.start-runtime-upgrade-tester.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-runtime-upgrade-tester.outputs.aws-instance-id }}
+
+  check-for-runtime-upgrade:
+    runs-on: ubuntu-latest
+    outputs:
+      should_check_runtime_upgrade: ${{ steps.comparison-result.outputs.should_check_runtime_upgrade }}
+      runtime-version: ${{ steps.get-runtime-version.outputs.runtime_ver }}
+      runtime-version-old: ${{ steps.get-runtime-version-old.outputs.runtime_ver_old }}
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: ruby setup
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      -
+        name: get runtime version
+        id: get-runtime-version
+        run: |
+          runtime_ver="$(ruby -e '
+            require "./scripts/github/lib.rb";
+            puts get_runtime("calamari")
+          ')"
+          echo "::set-output name=runtime_ver::$runtime_ver"
+          echo $runtime_ver
+          echo ....................
+      - name: Show new runtime version
+        run: echo "The selected value is ${{ steps.get-runtime-version.outputs.runtime_ver }}"
+      -
+        name: get old runtime version
+        id: get-runtime-version-old
+        run: |
+          mkdir temp_for_run
+          cd temp_for_run
+          git clone -b manta-pc https://github.com/Manta-Network/Manta.git
+          cd Manta
+          runtime_ver="$(ruby -e '
+            require "./scripts/github/lib.rb";
+            puts get_runtime("calamari")
+          ')"
+          echo "::set-output name=runtime_ver_old::$runtime_ver"
+          echo $runtime_ver
+          echo ....................
+      - name: Show old runtime version
+        run: echo "The selected value is ${{ steps.get-runtime-version-old.outputs.runtime_ver_old }}"
 
 # yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1314,7 +1314,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: eu-west-1
+          aws-region: us-west-1
           # aws-subnet-id: subnet-08c26caf0a52b7c19
           # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
@@ -1359,7 +1359,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: eu-west-1
+          aws-region: us-west-1
           # aws-subnet-id: subnet-08c26caf0a52b7c19
           # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
@@ -1402,7 +1402,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: eu-west-1
+          aws-region: us-west-1
           # aws-subnet-id: subnet-08c26caf0a52b7c19
           # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly
@@ -1445,7 +1445,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # aws-instance-ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
-          aws-region: eu-west-1
+          aws-region: us-west-1
           # aws-subnet-id: subnet-08c26caf0a52b7c19
           # aws-security-group-id: sg-0315bffea9042ac9b
           aws-instance-type: c5a.8xlarge # 32 vcpu, 64gb ram, $1.392 hourly

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -9,8 +9,8 @@ on:
   push:
     branch:
       - manta-pc
-    #tags:
-    #  - v[0-9]+.[0-9]+.[0-9]+*
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
 
@@ -77,9 +77,9 @@ jobs:
             ${{ steps.srtool-build.outputs.wasm }}
             ${{ steps.srtool-build.outputs.wasm_compressed }}
 
-  build-node:
-    needs: start-node-builder
-    runs-on: ${{ needs.start-node-builder.outputs.runner-label }}
+  build-node-current:
+    needs: start-node-builder-current
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -158,9 +158,9 @@ jobs:
 
   build-benchmark:
     needs:
-      - start-node-builder
-      - build-node
-    runs-on: ${{ needs.start-node-builder.outputs.runner-label }}
+      - start-node-builder-current
+      - build-node-current
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
     steps:
       -
         name: install sccache
@@ -234,9 +234,9 @@ jobs:
   run-benchmark:
     name: benchmark (${{ matrix.benchmark.pallet.name }} ${{ matrix.benchmark.extrinsic.name }})
     needs:
-      - start-node-builder
+      - start-node-builder-current
       - build-benchmark
-    runs-on: ${{ needs.start-node-builder.outputs.runner-label }}
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
     strategy:
       matrix:
         benchmark:
@@ -340,21 +340,21 @@ jobs:
       #   run: |
       #     jq --slurp '. | add' ${{ github.workspace }}/extrinsic-benchmark-pallet-manta-pay-*.json > ${{ github.workspace }}/extrinsic-benchmark-pallet-manta-pay.json
 
-  build-node-old:
+  build-node-base:
     needs:
-      - start-node-builder-old
+      - start-node-builder-base
       - check-for-runtime-upgrade
-    runs-on: ${{ needs.start-node-builder-old.outputs.runner-label }}
+    runs-on: ${{ needs.start-node-builder-base.outputs.runner-label }}
     env:
       CARGO_TERM_COLOR: always
     steps:
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/checkout@v2
         with:
           ref: '4204135e90ce02fa28af0913c8f050b76bd3ea23'
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: install sccache
 
         env:
@@ -369,7 +369,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: cache cargo registry
         uses: actions/cache@v2
         with:
@@ -380,7 +380,7 @@ jobs:
           restore-keys: |
             cargo-
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: cache sccache
         uses: actions/cache@v2
         continue-on-error: false
@@ -390,11 +390,11 @@ jobs:
           restore-keys: |
             sccache-
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: start sccache server
         run: sccache --start-server
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: init
         run: |
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
@@ -406,7 +406,7 @@ jobs:
           cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
           rustup update
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: build
         env:
           RUST_BACKTRACE: full
@@ -417,25 +417,25 @@ jobs:
           source ${HOME}/.cargo/env
           cargo build --verbose --release --features calamari
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: stop sccache server
         run: sccache --stop-server || true
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: strip
         run: |
           strip target/release/calamari-pc
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: upload
         uses: actions/upload-artifact@v2
         with:
-          name: calamari-pc-old
+          name: calamari-pc-base
           path: target/release/calamari-pc
 
   runtime-upgrade-test:
     needs:
-      - build-node-old
+      - build-node-base
       - build-calamari-runtime
       - start-runtime-upgrade-tester
       - check-for-runtime-upgrade
@@ -454,21 +454,21 @@ jobs:
                 para: 2
     steps:
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         run: |
           mkdir -p $HOME/.local/share/calamari-pc
           mkdir -p $HOME/.local/bin
           echo "${HOME}/.nvm/versions/node/v16.3.0/bin" >> $GITHUB_PATH
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
-        name: fetch calamari-pc-old
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
+        name: fetch calamari-pc-base
         uses: actions/download-artifact@v2
         with:
-          name: calamari-pc-old
+          name: calamari-pc-base
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
-        name: mv and chmod calamari-pc-old
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
+        name: mv and chmod calamari-pc-base
         run: |
           pwd
           ls -a
@@ -477,14 +477,14 @@ jobs:
           ls -ahl ${{ github.workspace }}/
           ls -ahl $HOME/.local/bin/
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: fetch and chmod polkadot
         run: |
           curl -L -o $HOME/.local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.9/polkadot
           chmod +x $HOME/.local/bin/polkadot
           ls -ahl $HOME/.local/bin/
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         id: create-chainspec
         run: |
           calamari-pc export-state --chain ${{ matrix.chain-spec.id }} > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json || true
@@ -505,7 +505,7 @@ jobs:
           ls -ahl $HOME/.local/share/calamari-pc/
           echo "::set-output name=short-sha::${GITHUB_SHA:0:7}"
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: create launch config
         run: |
           echo '{
@@ -632,19 +632,19 @@ jobs:
           jq . $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
           ls -ahl $HOME/.local/share/calamari-pc/
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/checkout@v2
         with:
           repository: Manta-Network/manta-pc-launch
           path: manta-pc-launch
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/checkout@v2
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-calamari
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: launch testnet
         run: |
           cd ${{ github.workspace }}/manta-pc-launch
@@ -657,7 +657,7 @@ jobs:
             --no-autorestart \
             -- $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: init measure-block-time calamari
         run: |
           cd ${{ github.workspace }}/dev-tools-calamari/measure-block-time
@@ -669,13 +669,13 @@ jobs:
             --error ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stderr.log \
             --no-autorestart
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: fetch new calamari_runtime.compact.compressed.wasm
         uses: actions/download-artifact@v2
         with:
           name: calamari-runtime
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: run test suites
         run: |
           # todo: implement moonbeam-like js test suite triggers here
@@ -700,7 +700,7 @@ jobs:
           cd ${{ github.workspace }}
           sleep 30
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: stop testnet
         run: |
           cd ${{ github.workspace }}/manta-pc-launch
@@ -708,25 +708,25 @@ jobs:
           pm2 stop manta-pc-launch
           pm2 stop test-runtime-upgrade-${{ matrix.chain-spec.id }}
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/upload-artifact@v2
         with:
           name: runtime-upgrade-test-for-${{ matrix.chain-spec.id }}-stdout.log
           path: ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stdout.log
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/upload-artifact@v2
         with:
           name: runtime-upgrade-test-for-${{ matrix.chain-spec.id }}-stderr.log
           path: ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stderr.log
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: parse runtime upgrade log
         run: |
           grep 'Included at block hash' ${{ github.workspace }}/test-runtime-upgrade-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words} | tee ${{ github.workspace }}/runtime-upgrade-output.csv; done
           if [ ! -f ${{ github.workspace }}/runtime-upgrade-output.csv ]; then echo "Runtime upgrade failed"; exit 1; fi
       -
-        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version != needs.check-for-runtime-upgrade.outputs.runtime-version-old }}
+        if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: parse calamari block times
         run: |
           grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[4]},${words[8]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
@@ -735,7 +735,7 @@ jobs:
 
   integration-test:
     needs:
-      - build-node
+      - build-node-current
       - build-calamari-runtime
       - start-integration-tester
       - check-for-runtime-upgrade
@@ -1264,7 +1264,7 @@ jobs:
   publish-node:
     runs-on: ubuntu-latest
     needs:
-      - build-node
+      - build-node-current
       - create-draft-release
     outputs:
       download_url: ${{ steps.upload-calamari-pc.outputs.browser_download_url }}
@@ -1298,7 +1298,7 @@ jobs:
         with:
           args: 'draft runtime release ${{ github.ref }} created at ${{ needs.create-draft-release.outputs.release_url }}'
 
-  start-node-builder:
+  start-node-builder-current:
     runs-on: ubuntu-latest
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
@@ -1323,10 +1323,10 @@ jobs:
           aws-image-search-pattern: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
           aws-image-search-owners: '["099720109477"]' # canonical
 
-  stop-node-builder:
+  stop-node-builder-current:
     needs:
-      - start-node-builder
-      - build-node
+      - start-node-builder-current
+      - build-node-current
       - build-benchmark
       - run-benchmark
     runs-on: ubuntu-latest
@@ -1339,11 +1339,11 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ needs.start-node-builder.outputs.aws-region }}
-          runner-label: ${{ needs.start-node-builder.outputs.runner-label }}
-          aws-instance-id: ${{ needs.start-node-builder.outputs.aws-instance-id }}
+          aws-region: ${{ needs.start-node-builder-current.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder-current.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder-current.outputs.aws-instance-id }}
 
-  start-node-builder-old:
+  start-node-builder-base:
     runs-on: ubuntu-latest
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
@@ -1368,10 +1368,10 @@ jobs:
           aws-image-search-pattern: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
           aws-image-search-owners: '["099720109477"]' # canonical
 
-  stop-node-builder-old:
+  stop-node-builder-base:
     needs:
-      - start-node-builder-old
-      - build-node-old
+      - start-node-builder-base
+      - build-node-base
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
@@ -1382,9 +1382,9 @@ jobs:
           github-token: ${{ secrets.GH_SHR_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ needs.start-node-builder-old.outputs.aws-region }}
-          runner-label: ${{ needs.start-node-builder-old.outputs.runner-label }}
-          aws-instance-id: ${{ needs.start-node-builder-old.outputs.aws-instance-id }}
+          aws-region: ${{ needs.start-node-builder-base.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder-base.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder-base.outputs.aws-instance-id }}
 
   start-integration-tester:
     runs-on: ubuntu-latest
@@ -1476,9 +1476,8 @@ jobs:
   check-for-runtime-upgrade:
     runs-on: ubuntu-latest
     outputs:
-      should_check_runtime_upgrade: ${{ steps.comparison-result.outputs.should_check_runtime_upgrade }}
-      runtime-version: ${{ steps.get-runtime-version.outputs.runtime_ver }}
-      runtime-version-old: ${{ steps.get-runtime-version-old.outputs.runtime_ver_old }}
+      runtime-version-current: ${{ steps.get-runtime-version.outputs.runtime-ver-current }}
+      runtime-version-base: ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}
     steps:
       -
         uses: actions/checkout@v2
@@ -1489,33 +1488,33 @@ jobs:
           ruby-version: 2.7
       -
         name: get runtime version
-        id: get-runtime-version
+        id: get-runtime-version-current
         run: |
-          runtime_ver="$(ruby -e '
+          runtime-ver-current="$(ruby -e '
             require "./scripts/github/lib.rb";
             puts get_runtime("calamari")
           ')"
-          echo "::set-output name=runtime_ver::$runtime_ver"
-          echo $runtime_ver
+          echo "::set-output name=runtime-ver-current::$runtime-ver-current"
+          echo $runtime-ver-current
           echo ....................
       - name: Show new runtime version
-        run: echo "The selected value is ${{ steps.get-runtime-version.outputs.runtime_ver }}"
+        run: echo "The selected value is ${{ steps.get-runtime-version-current.outputs.runtime-ver-current }}"
       -
-        name: get old runtime version
-        id: get-runtime-version-old
+        name: get base runtime version
+        id: get-runtime-version-base
         run: |
           mkdir temp_for_run
           cd temp_for_run
           git clone -b manta-pc https://github.com/Manta-Network/Manta.git
           cd Manta
-          runtime_ver="$(ruby -e '
+          runtime-ver-base="$(ruby -e '
             require "./scripts/github/lib.rb";
             puts get_runtime("calamari")
           ')"
-          echo "::set-output name=runtime_ver_old::$runtime_ver"
-          echo $runtime_ver
+          echo "::set-output name=runtime-ver-base::$runtime-ver-base"
+          echo $runtime-ver-base
           echo ....................
-      - name: Show old runtime version
-        run: echo "The selected value is ${{ steps.get-runtime-version-old.outputs.runtime_ver_old }}"
+      - name: Show base runtime version
+        run: echo "The selected value is ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}"
 
 # yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -7,7 +7,7 @@ name: publish draft releases
 # yamllint disable-line rule:truthy
 on:
   pull_request:
-      - manta-pc
+    branches: [manta-pc]
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -7,10 +7,10 @@ name: publish draft releases
 # yamllint disable-line rule:truthy
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
     branch:
-      - ghzlatarev/rtu-calamari-test-net
+      - manta-pc
+    #tags:
+    #  - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
 

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -352,7 +352,7 @@ jobs:
         if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         uses: actions/checkout@v2
         with:
-          ref: '4204135e90ce02fa28af0913c8f050b76bd3ea23'
+          ref: 'f08ce6840a0ccfdeb6a34a70a28235a948aad85d'
       -
         if: ${{ needs.check-for-runtime-upgrade.outputs.runtime-version-current != needs.check-for-runtime-upgrade.outputs.runtime-version-base }}
         name: install sccache

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -533,6 +533,69 @@ pub fn calamari_testnet_config(id: ParaId) -> CalamariChainSpec {
 	// (controller_account, aura_id)
 	let initial_authorities: Vec<(AccountId, AuraId)> = vec![
 		(
+			// account id: dmvSXhJWeJEKTZT8CCUieJDaNjNFC4ZFqfUm4Lx1z7J7oFzBf
+			hex!["4294b2a716cea91dd008d694d264feeaf9f0baf9c0b8cbe3e107515947ed440d"].into(),
+			hex!["10814b2b41bf39155ef7b38bb2431056894ba71acc35cf0101c999fd69f9c357"]
+				.unchecked_into(),
+		),
+		(
+			// account id: dmxvZaMQir24EPxvFiCzkhDZaiScPB7ZWpHXUv5x8uct2A3du
+			hex!["b06e5d852078f64ab74af9b31add10e36d0438b847bc925fbacbf1e14963e379"].into(),
+			hex!["f2ac4141fee9f9ba42e830f39f00f316e45d280db1464a9148702ab7c4fcde52"]
+				.unchecked_into(),
+		),
+		(
+			// account id: dmud2BmjLyMtbAX2FaVTUtvmutoCKvR3GbARLc4crzGvVMCwu
+			hex!["1e58d3c3900c7ce6c6d82152becb45bf7bd3453fb2d267e5f72ca51285bca173"].into(),
+			hex!["f6284f9446db8f895c6cf02d0d6de6e67885a1e55c880ccac640ff4bc076df68"]
+				.unchecked_into(),
+		),
+		(
+			// account id: dmx4vuA3PnQmraqJqeJaKRydUjP1AW4wMVTPLQWgZSpDyQUrp
+			hex!["8a93e0f756448030dcb3018d25d75c7bf97a2e2ff15d02fd1f55bf3f2104fb5b"].into(),
+			hex!["741101a186479f4f28aa40fc78f02d7307ed3574e829aed76fdede5876e46a43"]
+				.unchecked_into(),
+		),
+		(
+			// account id: dmtwRyEeNyRW3KApnTxjHahWCjN5b9gDjdvxpizHt6E9zYkXj
+			hex!["0027131c176c0d19a2a5cc475ecc657f936085912b846839319249e700f37e79"].into(),
+			hex!["8ebf03bda1702d719f428bc0a4c7cfca010c44a48ef79752490818c901548d20"]
+				.unchecked_into(),
+		),
+	];
+
+	// root account: dmyBqgFxMPZs1wKz8vFjv7nD4RBu4HeYhZTsGxSDU1wXQV15R
+	let root_key: AccountId =
+		hex!["bc153ffd4c96de7496df009c6f4ecde6f95bf67b60e0c1025a7552d0b6926e04"].into();
+
+	CalamariChainSpec::from_genesis(
+		// Name
+		"Calamari Parachain Testnet",
+		// ID
+		"calamari_testnet",
+		ChainType::Local,
+		move || calamari_testnet_genesis(initial_authorities.clone(), root_key.clone(), id),
+		vec![],
+		Some(
+			sc_telemetry::TelemetryEndpoints::new(vec![(STAGING_TELEMETRY_URL.to_string(), 0)])
+				.expect("Calamari testnet telemetry url is valid; qed"),
+		),
+		Some(CALAMARI_PROTOCOL_ID),
+		Some(properties),
+		Extensions {
+			relay_chain: KUSAMA_RELAYCHAIN_DEV_NET.into(),
+			para_id: id.into(),
+		},
+	)
+}
+
+#[cfg(feature = "calamari")]
+pub fn calamari_testnet_config_ci(id: ParaId) -> CalamariChainSpec {
+	let properties = calamari_properties();
+
+	// (controller_account, aura_id)
+	let initial_authorities: Vec<(AccountId, AuraId)> = vec![
+		(
 			hex!["d664b6e69e3b1bcd89274bf90a2abf409baa9a4cd9072194cdc70ead1ba65f0c"].into(),
 			hex!["ee73f78b7dd29f30902c1a3bd1e4a6fcc2f26be088343d3ee011e2660fd02a66"]
 				.unchecked_into(),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -533,40 +533,34 @@ pub fn calamari_testnet_config(id: ParaId) -> CalamariChainSpec {
 	// (controller_account, aura_id)
 	let initial_authorities: Vec<(AccountId, AuraId)> = vec![
 		(
-			// account id: dmvSXhJWeJEKTZT8CCUieJDaNjNFC4ZFqfUm4Lx1z7J7oFzBf
-			hex!["4294b2a716cea91dd008d694d264feeaf9f0baf9c0b8cbe3e107515947ed440d"].into(),
-			hex!["10814b2b41bf39155ef7b38bb2431056894ba71acc35cf0101c999fd69f9c357"]
+			hex!["d664b6e69e3b1bcd89274bf90a2abf409baa9a4cd9072194cdc70ead1ba65f0c"].into(),
+			hex!["ee73f78b7dd29f30902c1a3bd1e4a6fcc2f26be088343d3ee011e2660fd02a66"]
 				.unchecked_into(),
 		),
 		(
-			// account id: dmxvZaMQir24EPxvFiCzkhDZaiScPB7ZWpHXUv5x8uct2A3du
-			hex!["b06e5d852078f64ab74af9b31add10e36d0438b847bc925fbacbf1e14963e379"].into(),
-			hex!["f2ac4141fee9f9ba42e830f39f00f316e45d280db1464a9148702ab7c4fcde52"]
+			hex!["b4cc4dcffaa95be696f76b8b68ea114f46edc67f343f6aacabe8e5000af38b50"].into(),
+			hex!["7cd4af9ad51d443740f71ecd5850385e98985224628c5ea08209bb2015523f3c"]
 				.unchecked_into(),
 		),
 		(
-			// account id: dmud2BmjLyMtbAX2FaVTUtvmutoCKvR3GbARLc4crzGvVMCwu
-			hex!["1e58d3c3900c7ce6c6d82152becb45bf7bd3453fb2d267e5f72ca51285bca173"].into(),
-			hex!["f6284f9446db8f895c6cf02d0d6de6e67885a1e55c880ccac640ff4bc076df68"]
+			hex!["c68bbab6a85bd17548f61ab26a52c577c12748f08062cffe921316a7283fbc00"].into(),
+			hex!["b40aa6bd104d0260b60350c2fb30d4882437466d66135130b667799ea6c9f52b"]
 				.unchecked_into(),
 		),
 		(
-			// account id: dmx4vuA3PnQmraqJqeJaKRydUjP1AW4wMVTPLQWgZSpDyQUrp
-			hex!["8a93e0f756448030dcb3018d25d75c7bf97a2e2ff15d02fd1f55bf3f2104fb5b"].into(),
-			hex!["741101a186479f4f28aa40fc78f02d7307ed3574e829aed76fdede5876e46a43"]
+			hex!["20e3ddcf0c6c456f2b9d035d3309fe84f43c2c5abc524a7fc903ed3d813c714b"].into(),
+			hex!["4a3aa51469e802be6504422cd9dd03be638ac3f6dc3a7c0c85a6ace3e72f0048"]
 				.unchecked_into(),
 		),
 		(
-			// account id: dmtwRyEeNyRW3KApnTxjHahWCjN5b9gDjdvxpizHt6E9zYkXj
-			hex!["0027131c176c0d19a2a5cc475ecc657f936085912b846839319249e700f37e79"].into(),
-			hex!["8ebf03bda1702d719f428bc0a4c7cfca010c44a48ef79752490818c901548d20"]
+			hex!["a2057091a6d15a9d64c398f148395b69aaae99626cffa53ac5e6beaa5790f946"].into(),
+			hex!["a68feb4fe2ea3f8ff288af4254aad2284e1cd0da67cb9ea61c13632bad57eb40"]
 				.unchecked_into(),
 		),
 	];
 
-	// root account: dmyBqgFxMPZs1wKz8vFjv7nD4RBu4HeYhZTsGxSDU1wXQV15R
 	let root_key: AccountId =
-		hex!["bc153ffd4c96de7496df009c6f4ecde6f95bf67b60e0c1025a7552d0b6926e04"].into();
+		hex!["04ac7fe1675e10c0df9c136f53df912e6ae7d2c21778a293c534226f8a3e6a0c"].into();
 
 	CalamariChainSpec::from_genesis(
 		// Name

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -41,6 +41,8 @@ fn load_spec(
 		#[cfg(feature = "calamari")]
 		"calamari-testnet" => Box::new(chain_spec::calamari_testnet_config(para_id)),
 		#[cfg(feature = "calamari")]
+		"calamari-testnet-ci" => Box::new(chain_spec::calamari_testnet_config_ci(para_id)),
+		#[cfg(feature = "calamari")]
 		"calamari" => Box::new(chain_spec::calamari_config()),
 		path => {
 			let path = std::path::PathBuf::from(path);

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 2,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
closes https://github.com/Manta-Network/pallet-manta-pay/issues/92

* Integrates a runtime upgrade test into the CI
* First the spec version from the current commit is compared to the spec verion in the base branch.
* If they don't match the runtime upgrade job is triggered.
* The code from the base branch is used to launch the tesntet
* The code from the current commit is used to build the wasm to upgrade the runtime
* The log for the runtime upgrade is parsed for success and also block production is checked.
* The log is also uploaded as artifact.