### PR TITLE
[Calamari]Add CI job for dockerizing calamari client

### DIFF
--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -873,4 +873,41 @@ jobs:
       - name: Show base runtime version
         run: echo "The selected value is ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}"
 
+  # Build docker image
+  docker-image-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Get tag name
+      - run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.MANTABOT_DOCKER_USERNAME }}
+          password: ${{ secrets.MANTABOT_DOCKER_TOKEN }}
+
+      - name: Set Tag env
+        if: ${{ github.event.release.tag_name }}
+        run: |
+          echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: docker/calamari.Dockerfile
+          tags: |
+            mantanetwork/calamari:latest
+            mantanetwork/calamari:${{ env.RELEASE_VERSION }}
+          build-args: TAG_NAME=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
 # yamllint enable rule:line-length

--- a/docker/calamari.Dockerfile
+++ b/docker/calamari.Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04 as builder
+LABEL description="run calamari binary distribution in docker"
+ARG TAG_NAME
+ARG BINARY="https://github.com/Manta-Network/Manta/releases/download/${TAG_NAME}/calamari-pc"
+ARG CALAMARI_GENESIS="https://raw.githubusercontent.com/Manta-Network/Manta/${TAG_NAME}/genesis/calamari-genesis.json"
+ARG KUSAMA_GENESIS="https://raw.githubusercontent.com/paritytech/polkadot/v0.9.9-1/node/service/res/kusama.json"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /calamari-bin
+
+ADD "$BINARY" /calamari-bin/calamari-pc 
+ADD "$CALAMARI_GENESIS" /calamari-bin/calamari-genesis.json
+ADD "$KUSAMA_GENESIS" /calamari-bin/kusama.json
+
+RUN apt-get update && \
+	apt install -y openssl libssl-dev
+
+# shrink size
+RUN rm -rf /usr/share/*
+
+# make executable and check	
+RUN cp ./calamari-pc /usr/local/bin/calamari-pc && \
+    chmod +x /usr/local/bin/calamari-pc && \
+    ldd /usr/local/bin/calamari-pc && \
+    /usr/local/bin/calamari-pc --version
+
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/calamari"]
+
+ENTRYPOINT ["/usr/local/bin/calamari-pc"]
+CMD ["/usr/local/bin/calamari-pc"]
+
+ENV DEBIAN_FRONTEND teletype


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #https://github.com/Manta-Network/pelagos/issues/15

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code. [wiki](https://github.com/Manta-Network/Manta/wiki/Manually-Build-and-Deploy-Calamari-Docker-Image)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.

## How to build and deploy
### Build
Just take it as example. It should be built automatically once a new release is published.
```shell
cd docker
docker build --build-arg TAG_NAME="v3.0.1-6147698" -t mantanetwork/calamari:latest .
```

## Run
- Full node
```shell
docker run \
-it \
-p 30333:30333 \
-p 9944:9944 \
-p 9933:9933 \
-v ~/calamari-full-node:/full \
--name calamari-full-node \
mantanetwork/calamari:latest \
--chain calamari-genesis.json \
--parachain-id 2084 \
--base-path /full/calamari-full/data \
--keystore-path /full/calamari-full/keystore \
--name "Calamari Full Node" \
--rpc-cors all \
-- \
--chain kusama.json
```

- Archive node
```shell
docker run \
-it \
-p 30333:30333 \
-p 9944:9944 \
-p 9933:9933 \
-v ~/calamari-archive-node:/archive \
--name calamari-archive-node \
mantanetwork/calamari:latest \
--chain calamari-genesis.json \
--parachain-id 2084 \
--base-path /archive/calamari-archive/data \
--keystore-path /archive/calamari-archive/keystore \
--name "Calamari Archive Node" \
--rpc-cors all \
--pruning archive \
-- \
--chain kusama.json
```

- Collator node
```shell
docker run \
-it \
-p 30333:30333 \
-p 9944:9944 \
-p 9933:9933 \
-v ~/calamari-collator-node:/collator \
--name calamari-full-node \
mantanetwork/calamari:latest \
--chain calamari-genesis.json \
--parachain-id 2084 \
--base-path /collator/calamari-collator/data \
--keystore-path /collator/calamari-collator/keystore \
--name "Calamari Collator Node" \
--rpc-cors all \
--validator \
-- \
--chain kusama.json
```
