### PR TITLE
Uncomment pallets in generate-weights-files.yml

### DIFF
--- a/.github/workflows/generate_weights_files.yml
+++ b/.github/workflows/generate_weights_files.yml
@@ -129,45 +129,45 @@ jobs:
       matrix:
         benchmark:
           -
-          #   extrinsic:
-          #     id: '*'
-          #     name: pallet_democracy
-          #   pallet:
-          #     id: pallet_democracy
-          #     name: pallet_democracy
-          #   iterations: 20
-          # -
-          #   extrinsic:
-          #     id: '*'
-          #     name: pallet_collective
-          #   pallet:
-          #     id: pallet_collective
-          #     name: pallet_collective
-          #   iterations: 20
-          # -
-          #   extrinsic:
-          #     id: '*'
-          #     name: pallet_membership
-          #   pallet:
-          #     id: pallet_membership
-          #     name: pallet_membership
-          #   iterations: 20
-          # -
-          #   extrinsic:
-          #     id: '*'
-          #     name: pallet_treasury
-          #   pallet:
-          #     id: pallet_treasury
-          #     name: pallet_treasury
-          #   iterations: 20
-          # -
-          #   extrinsic:
-          #     id: '*'
-          #     name: pallet_scheduler
-          #   pallet:
-          #     id: pallet_scheduler
-          #     name: pallet_scheduler
-          #   iterations: 20
+            extrinsic:
+              id: '*'
+              name: pallet_democracy
+            pallet:
+              id: pallet_democracy
+              name: pallet_democracy
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_collective
+            pallet:
+              id: pallet_collective
+              name: pallet_collective
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_membership
+            pallet:
+              id: pallet_membership
+              name: pallet_membership
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_treasury
+            pallet:
+              id: pallet_treasury
+              name: pallet_treasury
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_scheduler
+            pallet:
+              id: pallet_scheduler
+              name: pallet_scheduler
+            iterations: 20
     steps:
       -
         uses: actions/download-artifact@v2


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

* Uncomment pallets to be benchmarked in `generate_weights_files.yml`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
