### PR TITLE
[Manta-PC] Make benchmarking workflow manually trigerrable from Github GUI

### DIFF
--- a/.github/workflows/check_calamari_pc.yml
+++ b/.github/workflows/check_calamari_pc.yml
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD cargo check --features calamari
-          SKIP_WASM_BUILD cargo check --all-features
+          cargo check --features calamari
+          cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/check_calamari_pc.yml
+++ b/.github/workflows/check_calamari_pc.yml
@@ -101,8 +101,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD= cargo clippy --features calamari
-          SKIP_WASM_BUILD= cargo fmt
+          SKIP_WASM_BUILD=1 cargo clippy --features calamari
+          SKIP_WASM_BUILD=1 cargo fmt
       -
         name: Check Calamari Build
         env:
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo check --features calamari
-          cargo check --all-features
+          SKIP_WASM_BUILD=1 cargo check --features calamari
+          SKIP_WASM_BUILD=1 cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/check_calamari_pc.yml
+++ b/.github/workflows/check_calamari_pc.yml
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD=1 cargo check --features calamari
-          SKIP_WASM_BUILD=1 cargo check --all-features
+          SKIP_WASM_BUILD cargo check --features calamari
+          SKIP_WASM_BUILD cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/check_manta_pc.yml
+++ b/.github/workflows/check_manta_pc.yml
@@ -101,8 +101,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD= cargo clippy --features manta-pc
-          SKIP_WASM_BUILD= cargo fmt
+          SKIP_WASM_BUILD=1 cargo clippy --features manta-pc
+          SKIP_WASM_BUILD=1 cargo fmt
       -
         name: Check Manta-PC Build
         env:
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo check --features manta-pc
-          cargo check --all-features
+          SKIP_WASM_BUILD=1 cargo check --features manta-pc
+          SKIP_WASM_BUILD=1 cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/check_manta_pc.yml
+++ b/.github/workflows/check_manta_pc.yml
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD cargo check --features manta-pc
-          SKIP_WASM_BUILD cargo check --all-features
+          cargo check --features manta-pc
+          cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/check_manta_pc.yml
+++ b/.github/workflows/check_manta_pc.yml
@@ -112,8 +112,8 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          SKIP_WASM_BUILD=1 cargo check --features manta-pc
-          SKIP_WASM_BUILD=1 cargo check --all-features
+          SKIP_WASM_BUILD cargo check --features manta-pc
+          SKIP_WASM_BUILD cargo check --all-features
       -
         name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/generate_weights_files.yml
+++ b/.github/workflows/generate_weights_files.yml
@@ -6,10 +6,7 @@ name: Benchmark Pallets & Generate Weights Files
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    types: [opened]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 env:
   AWS_INSTANCE_SSH_PUBLIC_KEY: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
@@ -27,18 +24,7 @@ jobs:
     needs:
       - start-node-builder-current
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
-    if: ${{ github.event.comment.body == 'generate-weights-files'}}
     steps:
-      - uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '👋 Thanks for benchmarking! Please wait until the results are posted in a subsequent comment...'
-            })
       -
         uses: actions/checkout@v2
       -
@@ -108,16 +94,6 @@ jobs:
         with:
           name: calamari-pc
           path: target/release/calamari-pc
-      - uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Please download the newly generated weights files from ----> https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}'
-            })
 
   run-benchmark:
     name: benchmark (${{ matrix.benchmark.pallet.name }} ${{ matrix.benchmark.extrinsic.name }})
@@ -151,14 +127,6 @@ jobs:
             pallet:
               id: pallet_membership
               name: pallet_membership
-            iterations: 20
-          -
-            extrinsic:
-              id: '*'
-              name: pallet_treasury
-            pallet:
-              id: pallet_treasury
-              name: pallet_treasury
             iterations: 20
           -
             extrinsic:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

* Switch from PR comment triggers to triggering the benchmarking workflow manually from Github GUI.
* The problem with previous solution was that any comment could trigger so we had to have few conditionals to filter out different scenarios. Nevertheless this would still flood our Actions tab with grey jobs
* Comment triggers will be implemented with Parity\s bench-bot

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
