### PR TITLE
[Manta-PC] runtime upgrade hotfix

### DIFF
--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -10,7 +10,7 @@ version = '3.0.0'
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.1.0", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.14", default-features = false }
-hex-literal = { version = '0.3.1', optional = true }
+hex-literal = { version = '0.3.1' }
 serde = { version = '1.0.119', features = ['derive'], optional = true }
 smallvec = "1.6.1"
 
@@ -89,7 +89,6 @@ try-runtime = [
 
 runtime-benchmarks = [
 	'cumulus-pallet-session-benchmarking/runtime-benchmarks',
-	'hex-literal',
 	'sp-runtime/runtime-benchmarks',
 	'xcm-builder/runtime-benchmarks',
 	'frame-benchmarking',

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -142,7 +142,8 @@ impl Contains<Call> for BaseFilter {
 			| Call::ParachainSystem(_)
 			| Call::Authorship(_)
 			| Call::Sudo(_)
-			| Call::Multisig(_) => true,
+			| Call::Multisig(_) 
+			| Call::Balances(_)=> true,
 			// pallet-timestamp and parachainSystem could not be filtered because they are used in commuication between releychain and parachain.
 			// pallet-authorship use for orml
 			// Sudo also cannot be filtered because it is used in runtime upgrade.
@@ -529,13 +530,12 @@ construct_runtime!(
 pub struct CalamariUpgradeHotFix;
 impl OnRuntimeUpgrade for CalamariUpgradeHotFix {
 	fn on_runtime_upgrade() -> Weight {
-		// This is for testing, need to change to calamari mainnet account for deploy
-		let sudo = hex!["bc153ffd4c96de7496df009c6f4ecde6f95bf67b60e0c1025a7552d0b6926e04"].into();
-		let alice = hex!["d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"].into();
+		let sudo = hex!["9b862dcfb8bc6b7d419e3ce659b3c1704b7dea3ec3ee2745de72e8948330af2d"].into();
+		let sudo_controller_1 = hex!["d607f740bb32a506c53fe81ddeabeab7333943ee4ef4c7adf0a6970a0c728833"].into();
 		<Balances as Currency<_>>::transfer(
 			&sudo,
-			&alice,
-			200_000_000_000_000_000u128,
+			&sudo_controller_1,
+			10_000_000_000_000_000u128,
 			ExistenceRequirement::AllowDeath,
 		).unwrap();
 		1

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -535,7 +535,7 @@ impl OnRuntimeUpgrade for CalamariUpgradeHotFix {
 		<Balances as Currency<_>>::transfer(
 			&sudo,
 			&alice,
-			2_000_000_000_000u128,
+			200_000_000_000_000_000u128,
 			ExistenceRequirement::AllowDeath,
 		).unwrap();
 		1

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -23,7 +23,7 @@ use sp_version::RuntimeVersion;
 
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{Contains, Everything},
+	traits::{Contains, Currency, Everything, ExistenceRequirement, OnRuntimeUpgrade},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight,
@@ -39,6 +39,7 @@ use manta_primitives::{
 	Index, Signature,
 };
 use sp_runtime::Perbill;
+use hex_literal::hex;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
@@ -525,6 +526,22 @@ construct_runtime!(
 	}
 );
 
+pub struct CalamariUpgradeHotFix;
+impl OnRuntimeUpgrade for CalamariUpgradeHotFix {
+	fn on_runtime_upgrade() -> Weight {
+		// This is for testing, need to change to calamari mainnet account for deploy
+		let sudo = hex!["bc153ffd4c96de7496df009c6f4ecde6f95bf67b60e0c1025a7552d0b6926e04"].into();
+		let alice = hex!["d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"].into();
+		<Balances as Currency<_>>::transfer(
+			&sudo,
+			&alice,
+			2_000_000_000_000u128,
+			ExistenceRequirement::AllowDeath,
+		).unwrap();
+		1
+	 }
+}
+
 /// The address format for describing accounts.
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block type as expected by this runtime.
@@ -554,6 +571,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
+	CalamariUpgradeHotFix
 >;
 
 impl_runtime_apis! {

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 2,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
