### PR TITLE
[Manta-PC] Update Spec Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ### Bug fixes
 
+## v3.0.7
+
+### Breaking changes
+
+### Features
+
+### Improvements
+- [\#225](https://github.com/Manta-Network/Manta/pull/225) split MA and KMA definitions.
+- Bump spec version to 3
+
+### Bug fixes
+
 ## v3.0.6
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "calamari-pc"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "async-trait",
  "calamari-runtime",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "manta-pc-runtime"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "manta-primitives"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'calamari-pc'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.0.6'
+version = '3.0.7'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 2,
+	spec_version: 3,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/manta-pc/Cargo.toml
+++ b/runtime/manta-pc/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'manta-pc-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.0.6'
+version = '3.0.7'
 
 [dependencies]
 smallvec = "1.6.1"

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ['Manta Network']
 name = "manta-primitives"
-version = "3.0.6"
+version = "3.0.7"
 edition = "2018"
 homepage = 'https://manta.network'
 license = 'GPL-3.0'


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
