### PR TITLE
Update Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,19 @@ cargo build --release
 
 ## Manta Developement
 Currently, there are two developing branches:
-* `manta-pc`: Manta Network/Calamari Network's parachain runtime
+* `manta`: Manta Network/Calamari Network's parachain runtime
 * `dolphin`: Dolphin testnet runtime (a standlone testnet runs its own consensus)
 
 ## Semantic Versioning
 Manta/Calamari's version number:
-`v<x>.<y>.<z>-<relay-id>.<para-id>`
+`v<x>.<y>.<z>
 
 where:
 
 * `<x>` is the major version, i.e. major product release.
 * `<y>` is the middle verison, i.e. adding major features.
 * `<z>` is the minor version, i.e. performance improvement and bug fixes.
-* `<relay-id>` is the relay chain name, i.e. kusama or polkadot
-* `<para-id>` is the parachain name, i.e. clamari or manta
+
 
 ## Contributing
 * please submit your code through PR.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </a>
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/Manta-Network/Manta/Check%20Calamari-PC/manta-pc)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/Manta-Network/Manta/Check%20Calamari-PC/manta)
 [![Twitter](https://img.shields.io/badge/-Twitter-5c5c5c?logo=Twitter)](https://twitter.com/mantanetwork)
 [![Discord](https://img.shields.io/badge/Discord-gray?logo=discord)](https://discord.gg/n4QFj4n5vg)
 [![Telegram](https://img.shields.io/badge/Telegram-gray?logo=telegram)](https://t.me/mantanetworkofficial)
@@ -39,30 +39,30 @@ where:
 
 ## ci build
 
-[![publish draft releases](https://github.com/Manta-Network/Manta/actions/workflows/publish-draft-releases.yml/badge.svg?branch=manta-pc)](https://github.com/Manta-Network/Manta/actions/workflows/publish-draft-releases.yml)
+[![publish draft releases](https://github.com/Manta-Network/Manta/actions/workflows/publish-draft-releases.yml/badge.svg?branch=manta)](https://github.com/Manta-Network/Manta/actions/workflows/publish-draft-releases.yml)
 
-the [publish draft releases](https://github.com/Manta-Network/Manta/blob/manta-pc/.github/workflows/publish-draft-releases.yml) workflow builds:
+the [publish draft releases](https://github.com/Manta-Network/Manta/blob/manta/.github/workflows/publish-draft-releases.yml) workflow builds:
 
 * **manta** the manta/calamari parachain executable
 * wasm runtimes:
   * **manta** the manta parachain wasm runtime
   * **calamari** the calamari parachain wasm runtime
 
-the workflow is triggered whenever a tag containing a semver is pushed to the github repo. if you have a branch derived from the [manta-pc](https://github.com/Manta-Network/Manta/tree/manta-pc) branch, you may trigger a ci-build and create a draft release (only available to Manta-Network org members) with commands similar to the following:
+the workflow is triggered whenever a tag containing a semver is pushed to the github repo. if you have a branch derived from the [manta](https://github.com/Manta-Network/Manta/tree/manta) branch, you may trigger a ci-build and create a draft release (only available to Manta-Network org members) with commands similar to the following:
 
 ```bash
-# clone the repo and checkout the `manta-pc` branch
-git clone --branch manta-pc git@github.com:Manta-Network/Manta.git
+# clone the repo and checkout the `manta` branch
+git clone --branch manta git@github.com:Manta-Network/Manta.git
 
-# create a new branch called `my-awesome-feature`, derived from branch `manta-pc` which contains the ci build workflow
-git checkout -b my-awesome-feature manta-pc
+# create a new branch called `my-awesome-feature`, derived from branch `manta` which contains the ci build workflow
+git checkout -b my-awesome-feature manta
 
 # ... add my awesome feature ...
 git add .
 git commit -m "added my awesome feature"
 
 # create a tag pointing to the last commit that is also named with the semver and latest commit sha `v3.0.0-<short-git-sha>` (eg: `v3.0.0-abcd123`)
-git tag -a v3.0.0-$(git rev-parse --short HEAD) -m "manta-pc and my awesome feature"
+git tag -a v3.0.0-$(git rev-parse --short HEAD) -m "manta and my awesome feature"
 
 # push my awesome feature branch **and** my new tag to origin (github)
 git push origin my-awesome-feature --tags


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
