### PR TITLE
[Manta] CI fixes

### DIFF
--- a/.github/workflows/generate_calamari_weights_files.yml
+++ b/.github/workflows/generate_calamari_weights_files.yml
@@ -2,7 +2,7 @@
 
 # yamllint disable rule:line-length
 
-name: Benchmark Pallets & Generate Weights Files
+name: Benchmark Clamari Runtime & Generate Weights Files
 
 # yamllint disable-line rule:truthy
 on:
@@ -171,7 +171,7 @@ jobs:
       -
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.benchmark.pallet.name }}.rs
+          name: ${{ matrix.benchmark.pallet.id }}-${{ matrix.benchmark.pallet.name }}.rs
           path: ${{ github.workspace }}/${{ matrix.benchmark.pallet.name }}.rs
 
   start-node-builder-current:

--- a/.github/workflows/generate_manta_weights_files.yml
+++ b/.github/workflows/generate_manta_weights_files.yml
@@ -134,7 +134,7 @@ jobs:
         name: run benchmark
         run: |
           manta benchmark \
-            --chain=manta-dev \
+            --chain=manta-local \
             --pallet=${{ matrix.benchmark.pallet.id }} \
             --extrinsic=${{ matrix.benchmark.extrinsic.id }} \
             --execution=Wasm \

--- a/.github/workflows/generate_manta_weights_files.yml
+++ b/.github/workflows/generate_manta_weights_files.yml
@@ -1,0 +1,195 @@
+---
+
+# yamllint disable rule:line-length
+
+name: Benchmark Manta Runtime & Generate Weights Files
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+env:
+  AWS_INSTANCE_SSH_PUBLIC_KEY: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+  AWS_REGION: us-east-1
+  AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
+  AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
+  AWS_INSTANCE_TYPE: r5ad.2xlarge  # 8 vcpu, 64gb ram, $0.524 hourly
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
+  AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+  AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'  # canonical
+
+jobs:
+
+  build-benchmark:
+    needs:
+      - start-node-builder-current
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: install sccache
+
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      -
+        name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      -
+        name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      -
+        name: start sccache server
+        run: sccache --start-server
+      -
+        name: init
+        run: |
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup toolchain install stable
+          rustup toolchain install nightly
+          rustup default stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
+          rustup update
+      -
+        name: build
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 2G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+          CARGO_TERM_COLOR: always
+        run: |
+          source ${HOME}/.cargo/env
+          cargo build --verbose --release --features=runtime-benchmarks
+      -
+        name: stop sccache server
+        run: sccache --stop-server || true
+      -
+        name: upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: manta
+          path: target/release/manta
+
+  run-benchmark:
+    name: benchmark (${{ matrix.benchmark.pallet.name }} ${{ matrix.benchmark.extrinsic.name }})
+    needs:
+      - start-node-builder-current
+      - build-benchmark
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
+    strategy:
+      matrix:
+        benchmark:
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_scheduler
+            pallet:
+              id: pallet_scheduler
+              name: pallet_scheduler
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_balances
+            pallet:
+              id: pallet_balances
+              name: pallet_balances
+            iterations: 20
+    steps:
+      -
+        uses: actions/download-artifact@v2
+        with:
+          name: manta
+      -
+        run: |
+          mv manta $HOME/.local/bin/
+          chmod +x $HOME/.local/bin/manta
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      -
+        name: run benchmark
+        run: |
+          manta benchmark \
+            --chain=manta-dev \
+            --pallet=${{ matrix.benchmark.pallet.id }} \
+            --extrinsic=${{ matrix.benchmark.extrinsic.id }} \
+            --execution=Wasm \
+            --wasm-execution=Compiled \
+            --heap-pages=4096 \
+            --repeat=${{ matrix.benchmark.iterations }} \
+            --steps=50 \
+            --template=.github/resources/frame-weight-template.hbs \
+            --output=${{ matrix.benchmark.pallet.name }}.rs
+      -
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.benchmark.pallet.id }}-${{ matrix.benchmark.pallet.name }}.rs
+          path: ${{ github.workspace }}/${{ matrix.benchmark.pallet.name }}.rs
+
+  start-node-builder-current:
+    runs-on: ubuntu-20.04
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ${{ env.AWS_INSTANCE_SSH_PUBLIC_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-subnet-id: ${{ env.AWS_SUBNET_ID }}
+          aws-security-group-id: ${{ env.AWS_SECURITY_GROUP_ID }}
+          aws-instance-type: ${{ env.AWS_INSTANCE_TYPE }}  # 32 vcpu, 64gb ram, $1.392 hourly
+          aws-instance-root-volume-size: 32
+          aws-image-search-pattern: ${{ env.AWS_IMAGE_SEARCH_PATTERN }}
+          aws-image-search-owners: ${{ env.AWS_IMAGE_SEARCH_OWNERS }}  # canonical
+
+  stop-node-builder-current:
+    needs:
+      - start-node-builder-current
+      - run-benchmark
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-node-builder-current.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder-current.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder-current.outputs.aws-instance-id }}
+
+# yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1177,11 +1177,9 @@ jobs:
           echo "::set-output name=match::true"
           if [[ ${{ needs.parse-runtimes.outputs.manta-runtime-base }} != ${{ needs.parse-runtimes.outputs.manta-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
           if [[ ${{ needs.parse-runtimes.outputs.calamari-runtime-base }} != ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
-      -
-        name: print result
-        id: print-result
+      -  
+        name: force fail if new versions don't match
         run: |
-          echo ${{ steps.check-match.outputs.match }}
-          echo ....................
+          if [[  ${{ needs.parse-runtimes.outputs.manta-runtime-current }} !=  ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then exit 1; fi
 
 # yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1177,7 +1177,7 @@ jobs:
           echo "::set-output name=match::true"
           if [[ ${{ needs.parse-runtimes.outputs.manta-runtime-base }} != ${{ needs.parse-runtimes.outputs.manta-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
           if [[ ${{ needs.parse-runtimes.outputs.calamari-runtime-base }} != ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
-      -  
+      -
         name: force fail if new versions don't match
         run: |
           if [[  ${{ needs.parse-runtimes.outputs.manta-runtime-current }} !=  ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then exit 1; fi

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1117,12 +1117,20 @@ jobs:
           runner-label: ${{ needs.start-runtime-upgrade-tester.outputs.runner-label }}
           aws-instance-id: ${{ needs.start-runtime-upgrade-tester.outputs.aws-instance-id }}
 
-  check-for-runtime-upgrade:
+  parse-runtimes:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        runtime:
+          -
+            name: calamari
+          -
+            name: manta
     outputs:
-      runtime-version-current: ${{ steps.get-runtime-version.outputs.runtime-ver-current }}
-      runtime-version-base: ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}
-      do-versions-match: ${{ steps.check-match.outputs.match }}
+      calamari-runtime-current: ${{ steps.get-runtime-current.outputs.calamari-runtime-current }}
+      calamari-runtime-base: ${{ steps.get-runtime-base.outputs.calamari-runtime-base }}
+      manta-runtime-current: ${{ steps.get-runtime-current.outputs.manta-runtime-current }}
+      manta-runtime-base: ${{ steps.get-runtime-base.outputs.manta-runtime-base }}
     steps:
       -
         uses: actions/checkout@v2
@@ -1132,41 +1140,49 @@ jobs:
         with:
           ruby-version: 2.7
       -
-        name: get runtime version
-        id: get-runtime-version-current
+        name: get ${{ matrix.runtime.name }} runtime version current
+        id: get-runtime-current
         run: |
-          runtime_ver_current="$(ruby -e '
+          runtime_current="$(ruby -e '
             require "./scripts/github/lib.rb";
-            puts get_runtime("calamari")
+            puts get_runtime("${{ matrix.runtime.name }}")
           ')"
-          echo "::set-output name=runtime-ver-current::$runtime_ver_current"
-          echo $runtime_ver_current
+          echo "::set-output name=${{ matrix.runtime.name }}-runtime-current::$runtime_current"
           echo ....................
-      - name: Show new runtime version
-        run: echo "The selected value is ${{ steps.get-runtime-version-current.outputs.runtime-ver-current }}"
       -
-        name: get base runtime version
-        id: get-runtime-version-base
+        name: get ${{ matrix.runtime.name }} runtime version base
+        id: get-runtime-base
         run: |
           mkdir temp_for_run
           cd temp_for_run
           git clone -b manta https://github.com/Manta-Network/Manta.git
           cd Manta
-          runtime_ver_base="$(ruby -e '
+          runtime_base="$(ruby -e '
             require "./scripts/github/lib.rb";
-            puts get_runtime("calamari")
+            puts get_runtime("${{ matrix.runtime.name }}")
           ')"
-          echo "::set-output name=runtime-ver-base::$runtime_ver_base"
-          echo $runtime_ver_base
+          echo "::set-output name=${{ matrix.runtime.name }}-runtime-base::$runtime_base"
           echo ....................
-      - name: Show base runtime version
-        run: echo "The selected value is ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }}"
+
+  check-for-runtime-upgrade:
+    needs:
+      - parse-runtimes
+    runs-on: ubuntu-20.04
+    outputs:
+      do-versions-match: ${{ steps.check-match.outputs.match }}
+    steps:
       -
-        name: check-match
+        name: check if runtime versions match
         id: check-match
         run: |
-          echo "::set-output name=match::false"
-          if [[ ${{ steps.get-runtime-version-base.outputs.runtime-ver-base }} == ${{ steps.get-runtime-version-current.outputs.runtime-ver-current }} ]]; then echo "::set-output name=match::true"
-          fi
+          echo "::set-output name=match::true"
+          if [[ ${{ needs.parse-runtimes.outputs.manta-runtime-base }} != ${{ needs.parse-runtimes.outputs.manta-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
+          if [[ ${{ needs.parse-runtimes.outputs.calamari-runtime-base }} != ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
+      -  
+        name: print result
+        id: print-result
+        run: |
+          echo ${{ steps.check-match.outputs.match }}
+          echo ....................
 
 # yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -805,8 +805,7 @@ jobs:
       - build-changelog
       - build-runtimes
       - integration-test
-      # a work around of rococo bug
-      # - runtime-upgrade-test
+      - runtime-upgrade-test
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1178,7 +1178,7 @@ jobs:
           echo "::set-output name=match::true"
           if [[ ${{ needs.parse-runtimes.outputs.manta-runtime-base }} != ${{ needs.parse-runtimes.outputs.manta-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
           if [[ ${{ needs.parse-runtimes.outputs.calamari-runtime-base }} != ${{ needs.parse-runtimes.outputs.calamari-runtime-current }} ]]; then echo "::set-output name=match::false"; fi
-      -  
+      -
         name: print result
         id: print-result
         run: |

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 3090,
+	spec_version: 3091,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 3091,
+	spec_version: 3090,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #252 

* Revert the rococo runtime upgrade workaround
* Fix erroneous skipping of runtime upgrade test in CI. Now we parse both calamari and manta runtime versions. If any one of them differs from the base branch version, runtime upgrades are triggered for both. 
* Force fail the CI workflow if the new Calamari and Manta runtime versions don't match, as we want to enforce synchronized updates.
* Add a separate manual workflow for Manta runtime weights generation.
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
