### PR TITLE
[Dolphin] Dolphin testnet assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4484,8 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-manta-pay"
-version = "0.2.0"
-source = "git+https://github.com/Manta-Network/pallet-manta-pay#a8a3ab1f1047f28c49052aa2d01a1c56036be241"
+version = "0.2.1"
 dependencies = [
  "ark-serialize",
  "ark-std",

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ cargo build --release -p manta
 
 ## Manta Developement
 Currently, there are two developing branches:
-* `manta`: Manta Network's testnet/mainnet node
-* `manta-pc`: Manta Network's parachain node
+* `manta`: Manta/Calamari Network's node
+* `dolphin`: Dolphin testnet's node
 
 ## Contributing
 * use `[Manta]` as the prefix to submit a PR to `manta` branch, use `[Manta-PC]` as the prefix to submit a PR to `manta-pc` branch.

--- a/README.md
+++ b/README.md
@@ -22,50 +22,6 @@ Currently, there are two developing branches:
 * `manta`: Manta Network's testnet/mainnet node
 * `manta-pc`: Manta Network's parachain node
 
-## Using Docker
-You can run manta nodes using docker.
-
-* Pull latest image.
-```
-docker pull mantanetwork/manta:latest
-```
-
-* Run one dev node locally.
-```
-docker run -it -p 9944:9944 mantanetwork/manta:latest --dev --tmp --alice --unsafe-ws-external
-```
-
-* Run two nodes locally.
-```
-# Alice node
-docker run \
--p 9944:9944 \
--p 30333:30333 \
---name=alice mantanetwork/manta:latest \
---chain=local \
---tmp \
---alice \
---node-key 0000000000000000000000000000000000000000000000000000000000000001 \
---unsafe-ws-external \
---validator
-
-docker run \
--p 9945:9944 \
--p 30334:30333 \
---name=bob mantanetwork/manta:latest \
---bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
---chain=local \
---bob \
---unsafe-ws-external \
---validator
-```
-Normally, both nodes will produce and finalize blocks.
-
-* Connect to manta testnet.
-```
-docker run mantanetwork/manta:latest --chain manta-testnet --name "ILoveManta"
-```
-
 ## Contributing
 * use `[Manta]` as the prefix to submit a PR to `manta` branch, use `[Manta-PC]` as the prefix to submit a PR to `manta-pc` branch.
 * please submit your code through PR.

--- a/runtimes/manta/primitives/src/lib.rs
+++ b/runtimes/manta/primitives/src/lib.rs
@@ -30,6 +30,12 @@ pub type AccountIndex = u32;
 /// Balance of an account.
 pub type Balance = u128;
 
+/// Asset id
+pub type AssetId = u32;
+
+/// Asset Balance
+pub type AssetBalance = u128;
+
 /// Index of a transaction in the chain.
 pub type Index = u32;
 
@@ -46,7 +52,7 @@ pub type Moment = u64;
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum TokenSymbol {
-	MA = 0,
+	DOL = 0,
 }
 
 #[cfg(test)]
@@ -55,7 +61,7 @@ mod tests {
 
 	#[test]
 	fn token_symbol_should_work() {
-		let native_token = TokenSymbol::MA;
+		let native_token = TokenSymbol::DOL;
 
 		assert_eq!(native_token as u8, 0);
 	}

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -67,7 +67,7 @@ pallet-election-provider-multi-phase = { git = 'https://github.com/paritytech/su
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
 manta-primitives = { path="../primitives", default-features = false }
-pallet-manta-pay = { git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
+pallet-manta-pay = { path = "../../../../pallet-manta-pay", default-features = false }
 
 [dev-dependencies]
 sp-io = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.10" }

--- a/runtimes/manta/runtime/readme.md
+++ b/runtimes/manta/runtime/readme.md
@@ -1,4 +1,2 @@
 Manta Runtime
 ==============
-
-The code is forked from `fc9d24c` of [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template/tree/fc9d24c429d271ec7d4f5075b8a7ec700c721a87/runtime) (a [Manta Network's local copy](https://github.com/Manta-Network/substrate-node-template/tree/master/runtime)). 

--- a/runtimes/manta/runtime/src/lib.rs
+++ b/runtimes/manta/runtime/src/lib.rs
@@ -607,7 +607,7 @@ construct_runtime!(
 		ElectionProviderMultiPhase: pallet_election_provider_multi_phase::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 37,
 
 		// Manta pay
-		MantaPay: pallet_manta_pay::{Pallet, Call, Storage, Event<T>},
+		MantaPay: pallet_manta_pay::{Pallet, Call, Config<T>, Storage, Event<T>},
 	}
 );
 

--- a/runtimes/manta/src/chain_spec.rs
+++ b/runtimes/manta/src/chain_spec.rs
@@ -60,23 +60,20 @@ fn session_keys(grandpa: GrandpaId, babe: BabeId) -> manta_runtime::opaque::Sess
 	manta_runtime::opaque::SessionKeys { babe, grandpa }
 }
 
-#[inline]
-fn get_testnet_assets() -> Vec<(AssetId, AssetBalance)> {
-	return vec![
-		// DOT, 1.2B, decimal 10
-		(0, 11_200_000_000_000_000_000),
-		// KSM, 11.6M, decimal 12
-		(1, 11_600_000_000_000_000_000),
-		// BTC, 21M, decimal 8
-		(2, 2_100_000_000_000_000),
-		// ETH, 112M, decimal 18
-		(3, 112_000_000_000_000_000_000_000_000),
-		// ACA, 1B, decimal 18
-		(4, 1_000_000_000_000_000_000_000_000_000),
-		// GLMR, 1B, decimal 18
-		(5, 1_000_000_000_000_000_000_000_000_000),
-	];
-}
+const TESTNET_ASSETS: &[(AssetId, AssetBalance)] = &[
+	// DOT, 1.2B, decimal 10
+    (0, 11_200_000_000_000_000_000),
+	// KSM, 11.6M, decimal 12
+    (1, 11_600_000_000_000_000_000),
+	// BTC, 21M, decimal 8
+    (2, 2_100_000_000_000_000),
+	// ETH, 112M, decimal 18
+    (3, 112_000_000_000_000_000_000_000_000),
+	// ACA, 1B, decimal 18
+    (4, 1_000_000_000_000_000_000_000_000_000),
+	// // GLMR, 1B, decimal 18
+    (5, 1_000_000_000_000_000_000_000_000_000),
+];
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -113,8 +110,7 @@ pub fn manta_properties() -> Properties {
 }
 
 /// Helper function to create GenesisConfig for testing
-/// Helper function to create GenesisConfig for testing
-pub fn testnet_genesis(
+pub fn devnet_genesis(
 	initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId)>,
 	initial_nominators: Vec<AccountId>,
 	root_key: AccountId,
@@ -217,13 +213,13 @@ pub fn testnet_genesis(
 		},
 		manta_pay: MantaPayConfig {
 			owner: get_account_id_from_seed::<sr25519::Public>("Alice"),
-			assets: get_testnet_assets(),
+			assets: TESTNET_ASSETS.to_vec(),
 		},
 	}
 }
 
 fn development_config_genesis() -> GenesisConfig {
-	testnet_genesis(
+	devnet_genesis(
 		vec![authority_keys_from_seed("Alice")],
 		vec![],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -247,7 +243,7 @@ pub fn development_config() -> ChainSpec {
 }
 
 fn local_testnet_genesis() -> GenesisConfig {
-	testnet_genesis(
+	devnet_genesis(
 		vec![
 			authority_keys_from_seed("Alice"),
 			authority_keys_from_seed("Bob"),
@@ -274,14 +270,14 @@ pub fn local_testnet_config() -> ChainSpec {
 }
 
 /// Manta testnet config
-pub fn manta_testnet_config() -> ChainSpec {
-	let protocol_id = Some("manta");
+pub fn dolphin_testnet_config() -> ChainSpec {
+	let protocol_id = Some("dolphin");
 
 	ChainSpec::from_genesis(
-		"Manta Testnet",
-		"manta_testnet",
-		ChainType::Custom("Manta Testnet".into()),
-		manta_testnet_genesis,
+		"Dolphin Testnet",
+		"dolphin_testnet",
+		ChainType::Custom("Dolphin Testnet".into()),
+		dolphin_testnet_genesis,
 		vec![
 			"/dns/n1.testnet.manta.network/tcp/30333/p2p/12D3KooWBV7qb2LshmqCr74edBk5h4Fi1Zt71fhpvdyi8ah3KzAa".parse().expect("failed to parse multiaddress."),
 			"/dns/n2.testnet.manta.network/tcp/30333/p2p/12D3KooWBGhNQyzkKEpN7QQnP94BhM8wyhpJwsZ58wbr1r3Pi6gV".parse().expect("failed to parse multiaddress."),
@@ -298,7 +294,7 @@ pub fn manta_testnet_config() -> ChainSpec {
 }
 
 /// Helper function to create GenesisConfig for manta testnets
-pub fn manta_testnet_config_genesis(
+pub fn testnet_genesis(
 	initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId)>,
 	initial_balances: Vec<(AccountId, Balance)>,
 	root_key: AccountId,
@@ -347,13 +343,13 @@ pub fn manta_testnet_config_genesis(
 		},
 		manta_pay: MantaPayConfig {
 			owner: hex!["12b73670c56f4fcd319636bdd6ec4a803ae2d06fdbc715087524a5151395d16c"].into(),
-			assets: get_testnet_assets(),
+			assets: TESTNET_ASSETS.to_vec(),
 		},
 	}
 }
 
 /// Manta testnet genesis
-pub fn manta_testnet_genesis() -> GenesisConfig {
+pub fn dolphin_testnet_genesis() -> GenesisConfig {
 	// (stash_account, controller_account, grandpa_id, babe_id)
 	let initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId)> = vec![
 		(
@@ -412,72 +408,12 @@ pub fn manta_testnet_genesis() -> GenesisConfig {
 
 	initial_balances.push((root_key.clone(), 500_000_000 * MA)); // root_key get half of the stake
 
-	manta_testnet_config_genesis(
+	testnet_genesis(
 		initial_authorities,
 		initial_balances,
 		root_key,
 		STASH,
 		false,
-	)
-}
-
-/// a single node dev testnet genesis
-pub fn manta_local_dev_genesis() -> GenesisConfig {
-	let stash_account: AccountId = hex![
-		// 5EcVwmgGB8GTduy53PpsGBpsEEZAGEWYBeLuwSz76kxUzJid
-		"70b8386b105ab594513031ed15cb9226e7db0ac285cccbcee59e55eae1e4922c"
-	]
-	.into();
-	let controller_account: AccountId = hex![
-		// 5HGdhHoyvPXkmXwNYg2vcNTU9584AfN7EsFM8DySKS53Ehxg
-		"e6461a44f71ac6c43bc6c9df20310211fb3d600ad0f3a51a66e7959caa599e6f"
-	]
-	.into();
-	let root_key: AccountId = hex![
-		//root account: 5DrGMpT3dYm8cWPp6ZDbdkKVfYzAdWBGZjkrtcE5GTqS9EC1
-		"4efbb0ab7942a237b3ce5b2540a0faad8cda8eeef44da6e4a614b3d8c08c0823"
-	]
-	.into();
-
-	let initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId)> = vec![(
-		stash_account.clone(),
-		controller_account.clone(),
-		// Grandpa ID: 5DCj1vKWeHWdni8LwtKVaCuh8vq4HvBUDKAJja5S7BW6M3ho
-		hex!["325a1995421793437bffa10eef55b028e61a02354e6ec66ab58b075349f6e9ca"].unchecked_into(),
-		// Babe ID: 5DAA4avV1euhv9gkNfa4bGsjZRaYTHXVa8t6F6yunAmauR7v
-		hex!["3064ad09d3fb2dd412aeaadf150bd6646ff2ed889e9bcea4068be8f9c2b65657"].unchecked_into(),
-	)];
-
-	let initial_balances = vec![
-		(root_key.clone(), 1000 * MA),
-		(stash_account, 1_000_000_000 * MA),
-		(controller_account, 20_000_000 * MA),
-	];
-
-	manta_testnet_config_genesis(
-		initial_authorities,
-		initial_balances,
-		root_key,
-		100_000_000 * MA,
-		false,
-	)
-}
-
-/// Manta testnet dev config
-pub fn manta_local_dev_config() -> ChainSpec {
-	ChainSpec::from_genesis(
-		"Manta local dev",
-		"manta_local_dev",
-		ChainType::Custom("Manta Local Dev".into()),
-		manta_local_dev_genesis,
-		vec![],
-		Some(
-			TelemetryEndpoints::new(vec![(STAGING_TELEMETRY_URL.to_string(), 0)])
-				.expect("Manta testnet telemetry url is valid; qed"),
-		),
-		Some("manta_local_dev"),
-		Some(manta_properties()),
-		Default::default(),
 	)
 }
 
@@ -488,7 +424,7 @@ pub(crate) mod tests {
 
 	#[allow(dead_code)]
 	fn local_testnet_genesis_instant_single() -> GenesisConfig {
-		testnet_genesis(
+		devnet_genesis(
 			vec![authority_keys_from_seed("Alice")],
 			vec![],
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -528,24 +464,6 @@ pub(crate) mod tests {
 		)
 	}
 
-	//TODO: see whether we can recover this test
-	// #[test]
-	// #[ignore]
-	// fn test_connectivity() {
-	// 	sc_service_test::connectivity(
-	// 		integration_test_config_with_two_authorities(),
-	// 		|config| {
-	// 			let NewFullBase { task_manager, client, network, transaction_pool, .. }
-	// 				= new_full_base(config,|_, _| ())?;
-	// 			Ok(sc_service_test::TestNetComponents::new(task_manager, client, network, transaction_pool))
-	// 		},
-	// 		|config| {
-	// 			let (keep_alive, _, _, client, network, transaction_pool) = new_light_base(config)?;
-	// 			Ok(sc_service_test::TestNetComponents::new(keep_alive, client, network, transaction_pool))
-	// 		}
-	// 	);
-	// }
-
 	#[test]
 	fn test_create_development_chain_spec() {
 		assert!(development_config().build_storage().is_ok());
@@ -557,23 +475,8 @@ pub(crate) mod tests {
 	}
 
 	#[test]
-	fn test_staging_test_net_chain_spec() {
-		assert!(staging_testnet_config().build_storage().is_ok());
-	}
-
-	#[test]
 	fn test_manta_testnet_chain_spec() {
-		assert!(manta_testnet_config().build_storage().is_ok());
-	}
-
-	#[test]
-	fn test_manta_local_dev_genesis() {
-		assert!(manta_local_dev_genesis().build_storage().is_ok());
-	}
-
-	#[test]
-	fn test_manta_local_dev_config() {
-		assert!(manta_local_dev_config().build_storage().is_ok());
+		assert!(dolphin_testnet_config().build_storage().is_ok());
 	}
 
 	#[test]

--- a/runtimes/manta/src/chain_spec.rs
+++ b/runtimes/manta/src/chain_spec.rs
@@ -1,9 +1,11 @@
 use hex_literal::hex;
-use manta_primitives::{constants::currency::MA, AccountId, Balance, Signature};
+use manta_primitives::{
+	constants::currency::MA, AccountId, AssetBalance, AssetId, Balance, Signature,
+};
 use manta_runtime::{
 	wasm_binary_unwrap, BabeConfig, BalancesConfig, Block, CouncilConfig, GenesisConfig,
-	GrandpaConfig, SessionConfig, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
-	MAX_NOMINATIONS,
+	GrandpaConfig, MantaPayConfig, SessionConfig, StakerStatus, StakingConfig, SudoConfig,
+	SystemConfig, MAX_NOMINATIONS,
 };
 use sc_chain_spec::ChainSpecExtension;
 use sc_service::{ChainType, Properties};
@@ -58,100 +60,22 @@ fn session_keys(grandpa: GrandpaId, babe: BabeId) -> manta_runtime::opaque::Sess
 	manta_runtime::opaque::SessionKeys { babe, grandpa }
 }
 
-#[allow(dead_code)]
-fn staging_testnet_config_genesis() -> GenesisConfig {
-	// stash, controller, session-key
-	// generated with secret:
-	// for i in 1 2 3 4 ; do for j in stash controller; do subkey inspect "$secret"/fir/$j/$i; done; done
-	// and
-	// for i in 1 2 3 4 ; do for j in session; do subkey --ed25519 inspect "$secret"//fir//$j//$i; done; done
-
-	let initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId)> = vec![
-		(
-			// 5Fbsd6WXDGiLTxunqeK5BATNiocfCqu9bS1yArVjCgeBLkVy
-			hex!["9c7a2ee14e565db0c69f78c7b4cd839fbf52b607d867e9e9c5a79042898a0d12"].into(),
-			// 5EnCiV7wSHeNhjW3FSUwiJNkcc2SBkPLn5Nj93FmbLtBjQUq
-			hex!["781ead1e2fa9ccb74b44c19d29cb2a7a4b5be3972927ae98cd3877523976a276"].into(),
-			// 5Fb9ayurnxnaXj56CjmyQLBiadfRCqUbL2VWNbbe1nZU6wiC
-			hex!["9becad03e6dcac03cee07edebca5475314861492cdfc96a2144a67bbe9699332"]
-				.unchecked_into(),
-			// 5EZaeQ8djPcq9pheJUhgerXQZt9YaHnMJpiHMRhwQeinqUW8
-			hex!["6e7e4eb42cbd2e0ab4cae8708ce5509580b8c04d11f6758dbf686d50fe9f9106"]
-				.unchecked_into(),
-		),
-		(
-			// 5ERawXCzCWkjVq3xz1W5KGNtVx2VdefvZ62Bw1FEuZW4Vny2
-			hex!["68655684472b743e456907b398d3a44c113f189e56d1bbfd55e889e295dfde78"].into(),
-			// 5Gc4vr42hH1uDZc93Nayk5G7i687bAQdHHc9unLuyeawHipF
-			hex!["c8dc79e36b29395413399edaec3e20fcca7205fb19776ed8ddb25d6f427ec40e"].into(),
-			// 5EockCXN6YkiNCDjpqqnbcqd4ad35nU4RmA1ikM4YeRN4WcE
-			hex!["7932cff431e748892fa48e10c63c17d30f80ca42e4de3921e641249cd7fa3c2f"]
-				.unchecked_into(),
-			// 5DhLtiaQd1L1LU9jaNeeu9HJkP6eyg3BwXA7iNMzKm7qqruQ
-			hex!["482dbd7297a39fa145c570552249c2ca9dd47e281f0c500c971b59c9dcdcd82e"]
-				.unchecked_into(),
-		),
-		(
-			// 5DyVtKWPidondEu8iHZgi6Ffv9yrJJ1NDNLom3X9cTDi98qp
-			hex!["547ff0ab649283a7ae01dbc2eb73932eba2fb09075e9485ff369082a2ff38d65"].into(),
-			// 5FeD54vGVNpFX3PndHPXJ2MDakc462vBCD5mgtWRnWYCpZU9
-			hex!["9e42241d7cd91d001773b0b616d523dd80e13c6c2cab860b1234ef1b9ffc1526"].into(),
-			// 5E1jLYfLdUQKrFrtqoKgFrRvxM3oQPMbf6DfcsrugZZ5Bn8d
-			hex!["5633b70b80a6c8bb16270f82cca6d56b27ed7b76c8fd5af2986a25a4788ce440"]
-				.unchecked_into(),
-			// 5DhKqkHRkndJu8vq7pi2Q5S3DfftWJHGxbEUNH43b46qNspH
-			hex!["482a3389a6cf42d8ed83888cfd920fec738ea30f97e44699ada7323f08c3380a"]
-				.unchecked_into(),
-		),
-		(
-			// 5HYZnKWe5FVZQ33ZRJK1rG3WaLMztxWrrNDb1JRwaHHVWyP9
-			hex!["f26cdb14b5aec7b2789fd5ca80f979cef3761897ae1f37ffb3e154cbcc1c2663"].into(),
-			// 5EPQdAQ39WQNLCRjWsCk5jErsCitHiY5ZmjfWzzbXDoAoYbn
-			hex!["66bc1e5d275da50b72b15de072a2468a5ad414919ca9054d2695767cf650012f"].into(),
-			// 5DMa31Hd5u1dwoRKgC4uvqyrdK45RHv3CpwvpUC1EzuwDit4
-			hex!["3919132b851ef0fd2dae42a7e734fe547af5a6b809006100f48944d7fae8e8ef"]
-				.unchecked_into(),
-			// 5C4vDQxA8LTck2xJEy4Yg1hM9qjDt4LvTQaMo4Y8ne43aU6x
-			hex!["00299981a2b92f878baaf5dbeba5c18d4e70f2a1fcd9c61b32ea18daf38f4378"]
-				.unchecked_into(),
-		),
+#[inline]
+fn get_testnet_assets() -> Vec<(AssetId, AssetBalance)> {
+	return vec![
+		// DOT, 1.2B, decimal 10
+		(0, 11_200_000_000_000_000_000),
+		// KSM, 11.6M, decimal 12
+		(1, 11_600_000_000_000_000_000),
+		// BTC, 21M, decimal 8
+		(2, 2_100_000_000_000_000),
+		// ETH, 112M, decimal 18
+		(3, 112_000_000_000_000_000_000_000_000),
+		// ACA, 1B, decimal 18
+		(4, 1_000_000_000_000_000_000_000_000_000),
+		// GLMR, 1B, decimal 18
+		(5, 1_000_000_000_000_000_000_000_000_000),
 	];
-
-	// generated with secret: subkey inspect "$secret"
-	let root_key: AccountId = hex![
-		// 5Ff3iXP75ruzroPWRP2FYBHWnmGGBSb63857BgnzCoXNxfPo
-		"9ee5e5bdc0ec239eb164f865ecc345ce4c88e76ee002e0f7e318097347471809"
-	]
-	.into();
-
-	let endowed_accounts: Vec<AccountId> = vec![root_key.clone()];
-
-	testnet_genesis(
-		initial_authorities,
-		vec![],
-		root_key,
-		Some(endowed_accounts),
-	)
-}
-
-/// Staging testnet config.
-#[allow(dead_code)]
-pub fn staging_testnet_config() -> ChainSpec {
-	let boot_nodes = vec![];
-	ChainSpec::from_genesis(
-		"Staging Testnet",
-		"staging_testnet",
-		ChainType::Live,
-		staging_testnet_config_genesis,
-		boot_nodes,
-		Some(
-			TelemetryEndpoints::new(vec![(STAGING_TELEMETRY_URL.to_string(), 0)])
-				.expect("Staging telemetry url is valid; qed"),
-		),
-		None,
-		None,
-		Default::default(),
-	)
 }
 
 /// Helper function to generate a crypto pair from seed
@@ -184,7 +108,7 @@ pub fn manta_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), 77.into());
 	p.insert("tokenDecimals".into(), 12.into());
-	p.insert("tokenSymbol".into(), "MA".into());
+	p.insert("tokenSymbol".into(), "DOL".into());
 	p
 }
 
@@ -290,6 +214,10 @@ pub fn testnet_genesis(
 		},
 		grandpa: GrandpaConfig {
 			authorities: vec![],
+		},
+		manta_pay: MantaPayConfig {
+			owner: get_account_id_from_seed::<sr25519::Public>("Alice"),
+			assets: get_testnet_assets(),
 		},
 	}
 }
@@ -416,6 +344,10 @@ pub fn manta_testnet_config_genesis(
 		},
 		grandpa: GrandpaConfig {
 			authorities: vec![],
+		},
+		manta_pay: MantaPayConfig {
+			owner: hex!["12b73670c56f4fcd319636bdd6ec4a803ae2d06fdbc715087524a5151395d16c"].into(),
+			assets: get_testnet_assets(),
 		},
 	}
 }

--- a/runtimes/manta/src/command.rs
+++ b/runtimes/manta/src/command.rs
@@ -42,7 +42,7 @@ use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Manta Node".into()
+		"Dolphin Node".into()
 	}
 
 	fn impl_version() -> String {
@@ -75,8 +75,7 @@ impl SubstrateCli for Cli {
 			}
 			"dev" => Box::new(chain_spec::development_config()),
 			"local" => Box::new(chain_spec::local_testnet_config()),
-			"manta-testnet" => Box::new(chain_spec::manta_testnet_config()),
-			"manta-local-dev" => Box::new(chain_spec::manta_local_dev_config()),
+			"dolphin-testnet" => Box::new(chain_spec::dolphin_testnet_config()),
 			path => Box::new(chain_spec::ChainSpec::from_json_file(
 				std::path::PathBuf::from(path),
 			)?),
@@ -193,6 +192,5 @@ fn test_load_spec() {
 
 	assert!(cli.load_spec("dev").is_ok());
 	assert!(cli.load_spec("local").is_ok());
-	assert!(cli.load_spec("manta-testnet").is_ok());
-	assert!(cli.load_spec("manta-local-dev").is_ok());
+	assert!(cli.load_spec("dolphin-testnet").is_ok());
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Add dolphin testnet assets (need to merge after https://github.com/Manta-Network/pallet-manta-pay/pull/99)

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
