### PR TITLE
[Manta] docker: listen on external ips

### DIFF
--- a/docker/calamari.Dockerfile
+++ b/docker/calamari.Dockerfile
@@ -3,7 +3,7 @@ LABEL description="calamari parachain node"
 
 ARG PARA_BINARY_REF
 
-ARG PARA_GENESIS_REF=manta-pc
+ARG PARA_GENESIS_REF=manta
 ARG PARA_BINARY_URL=https://github.com/Manta-Network/Manta/releases/download/$PARA_BINARY_REF/manta
 ARG PARA_BINARY_PATH=/usr/local/bin/parachain
 
@@ -72,8 +72,10 @@ ENTRYPOINT $PARA_BINARY_PATH \
   --base-path $SUBSTRATE_BASE_PATH \
   --parachain-id $SUBSTRATE_PARACHAIN_ID \
   --port $SUBSTRATE_PORT \
-  --rpc-port $SUBSTRATE_RPC_PORT \
   --ws-port $SUBSTRATE_WS_PORT \
+  --ws-external \
+  --rpc-port $SUBSTRATE_RPC_PORT \
+  --rpc-external \
   --rpc-cors $SUBSTRATE_RPC_CORS \
   --rpc-methods $SUBSTRATE_RPC_METHODS \
   --ws-max-connections $SUBSTRATE_WS_MAX_CONNECTIONS \


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

substrate nodes by default only listen on the localhost address (127.0.0.1). when substrate is run inside of a container, docker proxies calls to the host to the container network. so a call to 127.0.0.1:9933 on the host actually arrives inside the container on it's internal ip, not 127.0.0.1. which substrate ignores by default. the fix is to tell substrate to listen on all addresses which is accomplished with the `--rpc-external` and `--ws-external` flags.
this tells substrate to listen on all addresses (0.0.0.0:9933, 0.0.0.0:9944), instead of just localhost (127.0.0.1:9933, 127.0.0.1:9944).

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `manta-pc`) with right title (start with [Manta] or [Manta-PC]),
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
