### PR TITLE
[Dolphin] Update manta pay dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
 [[package]]
 name = "pallet-manta-pay"
 version = "0.2.1"
+source = "git+https://github.com/Manta-Network/pallet-manta-pay#a94e0a9b835f3950e6984fc45118617bbefbe2bc"
 dependencies = [
  "ark-serialize",
  "ark-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,8 +3693,8 @@ dependencies = [
 
 [[package]]
 name = "manta-asset"
-version = "0.3.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#e281d37b047ea705c96ebb70655a28f2788f98cf"
+version = "0.3.2"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#d4c14964217c0e598085913fa84bbe17a263ed94"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ed-on-bls12-381",
@@ -3710,8 +3710,8 @@ dependencies = [
 
 [[package]]
 name = "manta-crypto"
-version = "0.3.1"
-source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#d32ab9589e05d00b579b5443260104e457a360cc"
+version = "0.3.2"
+source = "git+https://github.com/Manta-Network/manta-crypto?branch=manta#46939c35fd24a42bc8550046822c3cb14623d83f"
 dependencies = [
  "aes-gcm",
  "ark-bls12-381",
@@ -3736,8 +3736,8 @@ dependencies = [
 
 [[package]]
 name = "manta-data"
-version = "0.3.0"
-source = "git+https://github.com/Manta-Network/manta-types?branch=manta#e281d37b047ea705c96ebb70655a28f2788f98cf"
+version = "0.3.2"
+source = "git+https://github.com/Manta-Network/manta-types?branch=manta#d4c14964217c0e598085913fa84bbe17a263ed94"
 dependencies = [
  "ark-ed-on-bls12-381",
  "ark-groth16",
@@ -8600,7 +8600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.4",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/runtimes/manta/runtime/Cargo.toml
+++ b/runtimes/manta/runtime/Cargo.toml
@@ -67,7 +67,7 @@ pallet-election-provider-multi-phase = { git = 'https://github.com/paritytech/su
 # If you need to change any of the below lines, make sure to reflect the changes in whichever script is supposed to modify them.
 # Search for "Check Manta-Node" in Manta-Network repositories to find the relevant scripts.
 manta-primitives = { path="../primitives", default-features = false }
-pallet-manta-pay = { path = "../../../../pallet-manta-pay", default-features = false }
+pallet-manta-pay = { git = "https://github.com/Manta-Network/pallet-manta-pay", default-features = false }
 
 [dev-dependencies]
 sp-io = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.10" }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
