### PR TITLE
[manta] Adjust Calamari weight to fee calculation

### DIFF
--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -54,11 +54,11 @@ impl WeightToFeePolynomial for WeightToFee {
 		// daily_cost_to_fully_congest = 0.000281626 * coeff * 1134 * 7200 * 0.02 = 45.988399296 * coeff
 		// Assuming we want the daily cost to be around $250000 we get:
 		// 250000 = 45.988399296 * coeff
-		// coeff = 5436
+		// coeff = ~5436
 
 		// Keep in mind this is a rough worst-case scenario calculation.
-		// The length_fee could not be negligible, and the targeted_fee_adjustment will hike the fees,
-		// as the network gets congested more and more congested, and this will further increase the costs.
+		// The `length_fee` could not be negligible, and the `targeted_fee_adjustment` will hike the fees
+		// as the network gets more and more congested, which will further increase the costs.
 		smallvec![WeightToFeeCoefficient {
 			coeff_integer: 5000u32.into(),
 			coeff_frac: Perbill::zero(),

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -40,16 +40,11 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		// in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
-		// in Manta Parachain, we map to 1/10 of that, or 1/100 CENT
-		// TODO, revisit here to figure out why use this polynomial
-		let p = currency::cKMA;
-		let q = 100 * Balance::from(ExtrinsicBaseWeight::get());
-		smallvec![WeightToFeeCoefficient {
-			degree: 1,
+		smallvec!(WeightToFeeCoefficient {
+			coeff_integer: 5000u32.into(),
+			coeff_frac: Perbill::zero(),
 			negative: false,
-			coeff_frac: Perbill::from_rational(p % q, q),
-			coeff_integer: p / q,
-		}]
+			degree: 1,
+		})
 	}
 }

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -38,6 +38,7 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		// fee = coeff_integer * (weight ^ degree) + coeff_friction * (weight ^ degree)
 		smallvec![WeightToFeeCoefficient {
 			coeff_integer: 5000u32.into(),
 			coeff_frac: Perbill::zero(),

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -14,10 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::currency;
 use frame_support::weights::{
-	constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
-	WeightToFeePolynomial,
+	WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
 };
 use manta_primitives::Balance;
 use smallvec::smallvec;
@@ -40,11 +38,11 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		smallvec!(WeightToFeeCoefficient {
+		smallvec![WeightToFeeCoefficient {
 			coeff_integer: 5000u32.into(),
 			coeff_frac: Perbill::zero(),
 			negative: false,
 			degree: 1,
-		})
+		}]
 	}
 }

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -39,6 +39,10 @@ impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
 		// fee = coeff_integer * (weight ^ degree) + coeff_friction * (weight ^ degree)
+		// We want to choose a coefficient so that it's expensive to fully congest our network for days at a time.
+		// For example make it as expensive as some large number like ~$250k for the first day alone.
+		// It can be calculated by: `transfer_fee * transfers_per_block * blocks_per_day * kma_price`
+		// currently `transfers_per_block` is ~1134 and `blocks_per_day` is 7200. `kma_price` can be checked daily.
 		smallvec![WeightToFeeCoefficient {
 			coeff_integer: 5000u32.into(),
 			coeff_frac: Perbill::zero(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #299

* Adjust weight to fee calculation so our tx fees are at least as expensive as Polkadot/Kusama/Moonbeam/Acala. Compared `balance.transfer` and `system.remark` :
* transfer on Polkadot is roughly $0.47
* transfer on Kusama is roughly $0.016
* transfer on Acala is roughly $0.01
* transfer on Moonriver is roughly $0.25
* transfer on Calamari was $0.000036 and now is roughly $0.036

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
