### PR TITLE
[Manta] Create Release Checklist Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -5,8 +5,8 @@ title: Manta {{ SET_VERSION }} Release checklist
 ---
 # Release Checklist
 
-**All** following checks should be completed before publishing a new release of the
-Calamari/Manta runtime or client.
+Most of the following checks should be completed before officially publishing the new release
+of the Calamari/Manta runtime or client. Some need to be completed after the new code is deployed.
 
 ### Runtime Releases
 
@@ -95,9 +95,8 @@ as long as the indexes did not change.
 There are three benchmarking machines reserved for updating the weights at
 release-time. To initialise a benchmark run for each production runtime
 (calamari, manta):
-* Go to:
-  -[Calamari Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_calamari_weights_files.yml)
-  -[Manta Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_manta_weights_files.yml)
+* Go to [Calamari Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_calamari_weights_files.yml) 
+  and [Manta Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_manta_weights_files.yml)
 * Open "Run workflow" drop-down menu.
 * Choose your branch and run the workflow.
 * When these jobs have completed (it takes a few hours), custom weights files will

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -25,12 +25,11 @@ candidate branch.
 
 The following checks can be performed after we have forked off to the release branch.
 - [ ] Complete the following [manual QA workflow](https://hackmd.io/TbFmorG2RnOPmLuFcg9JOQ?view).
-- [ ] Verify [new migrations](#new-migrations) complete successfully, and the
-    runtime state is correctly updated for any public (non-private/test)
-    networks.
 - [ ] Verify [Polkadot JS API](#polkadot-js) are up to date with the latest
     runtime changes.
-- [ ] Push runtime upgrade to Baikal and verify network stability.
+- [ ] Execute runtime upgrade to Como and verify network stability.
+- [ ] Execute runtime upgrade to Baikal and verify network stability.
+- [ ] Prepare a governance post and submit to our forum with description and motivation for changes.
 
 ### All Releases
 
@@ -41,6 +40,7 @@ The following checks can be performed after we have forked off to the release br
     notes](#release-notes)
 - [ ] Check that [build artifacts](#build-artifacts) have been added to the
     draft-release
+- [ ] Coordinate with marketing team for documenation updates and other relevant tasks.
 
 ### After Runtime Upgrade
 - [ ] Notify subscan team. Ensure subscan service can continue to scan calamari blocks.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -24,7 +24,7 @@ candidate branch.
     runtime logic.
 
 The following checks can be performed after we have forked off to the release branch.
-
+- [ ] Complete the following [manual QA workflow](https://hackmd.io/TbFmorG2RnOPmLuFcg9JOQ?view).
 - [ ] Verify [new migrations](#new-migrations) complete successfully, and the
     runtime state is correctly updated for any public (non-private/test)
     networks.
@@ -41,6 +41,10 @@ The following checks can be performed after we have forked off to the release br
     notes](#release-notes)
 - [ ] Check that [build artifacts](#build-artifacts) have been added to the
     draft-release
+
+### After Runtime Upgrade
+- [ ] Notify subscan team. Ensure subscan service can continue to scan calamari blocks.
+- [ ] Sidecar [update](https://github.com/paritytech/substrate-api-sidecar/blob/master/src/chains-config/metadata-consts/calamariConsts.ts#L6)
 
 ## Notes
 
@@ -101,8 +105,3 @@ release-time. To initialise a benchmark run for each production runtime
 * Commit the changes to your branch and push to the remote branch for review.
 * The weights should be (Currently manually) checked to make sure there are no
     big outliers (i.e., twice or half the weight).
-
-### Polkadot JS
-
-Ensure that a release of [Polkadot JS API]() contains any new types or
-interfaces necessary to interact with the new runtime.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -37,7 +37,7 @@ The following checks can be performed after we have forked off to the release br
 - [ ] Check that the new client versions have [run on the network](#burn-in)
     without issue for 12 hours.
 - [ ] Check that a draft release has been created at
-    https://github.com/paritytech/polkadot/releases with relevant [release
+    https://github.com/Manta-Network/Manta/releases with relevant [release
     notes](#release-notes)
 - [ ] Check that [build artifacts](#build-artifacts) have been added to the
     draft-release
@@ -46,7 +46,7 @@ The following checks can be performed after we have forked off to the release br
 
 ### Burn In
 
-Ensure that Parity DevOps has run the new release on Como and Baikal nodes
+Ensure that Manta DevOps has run the new release on Como and Baikal nodes
 for at least 12 hours prior to publishing the release.
 
 ### Release notes
@@ -78,8 +78,6 @@ functions. Compare the metadata of the current and new runtimes and ensure that
 the `module index, call index` tuples map to the same set of functions. In case
 of a breaking change, increase `transaction_version`.
 
-To verify the order has not changed, you may manually start the following [Github Action](https://github.com/paritytech/polkadot/actions/workflows/extrinsic-ordering-check-from-bin.yml). It takes around a minute to run and will produce the report as artifact you need to manually check.
-
 The things to look for in the output are lines like:
   - `[Identity] idx 28 -> 25 (calls 15)` - indicates the index for `Identity` has changed
   - `[+] Society, Recovery` - indicates the new version includes 2 additional modules/pallets.
@@ -94,8 +92,8 @@ There are three benchmarking machines reserved for updating the weights at
 release-time. To initialise a benchmark run for each production runtime
 (calamari, manta):
 * Go to:
-  -For Calamari: https://github.com/Manta-Network/Manta/actions/workflows/generate_calamari_weights_files.yml
-  -For Manta: https://github.com/Manta-Network/Manta/actions/workflows/generate_manta_weights_files.yml
+  -[Calamari Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_calamari_weights_files.yml)
+  -[Manta Benchmarking Github Action](https://github.com/Manta-Network/Manta/actions/workflows/generate_manta_weights_files.yml)
 * Open "Run workflow" drop-down menu.
 * Choose your branch and run the workflow.
 * When these jobs have completed (it takes a few hours), custom weights files will

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,14 +1,12 @@
 ---
 name: Release issue template
 about: Tracking issue for new releases
-title: Manta {{ env.VERSION }} Release checklist
+title: Manta {{ SET_VERSION }} Release checklist
 ---
 # Release Checklist
 
-This is the release checklist for Polkadot {{ env.VERSION }}. **All** following
-checks should be completed before publishing a new release of the
-Polkadot/Kusama/Westend runtime or client. The current release candidate can be
-checked out with `git checkout release-{{ env.VERSION }}`
+**All** following checks should be completed before publishing a new release of the
+Calamari/Manta runtime or client.
 
 ### Runtime Releases
 
@@ -21,8 +19,7 @@ candidate branch.
     the `spec_version` or `impl` must be bumped.
 - [ ] Verify pallet and [extrinsic ordering](#extrinsic-ordering) has stayed
     the same. Bump `transaction_version` if not.
-- [ ] Verify new extrinsics have been correctly whitelisted/blacklisted for
-    [proxy filters](#proxy-filtering).
+- [ ] Verify new extrinsics have been correctly whitelisted/blacklisted
 - [ ] Verify [benchmarks](#benchmarks) have been updated for any modified
     runtime logic.
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -41,6 +41,7 @@ The following checks can be performed after we have forked off to the release br
 - [ ] Check that [build artifacts](#build-artifacts) have been added to the
     draft-release
 - [ ] Coordinate with marketing team for documenation updates and other relevant tasks.
+- [ ] Update changelog.
 
 ### After Runtime Upgrade
 - [ ] Notify subscan team. Ensure subscan service can continue to scan calamari blocks.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #342

* Template for Release Checklist Issues.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
