### PR TITLE
[Calamari]Remove some params from ENTRYPOINT

### DIFF
--- a/docker/calamari.Dockerfile
+++ b/docker/calamari.Dockerfile
@@ -5,7 +5,7 @@ ARG PARA_BINARY_REF
 
 ARG PARA_GENESIS_REF=manta
 ARG PARA_BINARY_URL=https://github.com/Manta-Network/Manta/releases/download/$PARA_BINARY_REF/manta
-ARG PARA_BINARY_PATH=/usr/local/bin/parachain
+ARG PARA_BINARY_PATH=/usr/local/bin/manta
 
 ARG PARA_GENESIS_URL=https://raw.githubusercontent.com/Manta-Network/Manta/$PARA_GENESIS_REF/genesis/calamari-genesis.json
 ARG PARA_GENESIS_PATH=/usr/share/calamari.json
@@ -13,74 +13,36 @@ ARG PARA_GENESIS_PATH=/usr/share/calamari.json
 ARG RELAY_GENESIS_URL=https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/res/kusama.json
 ARG RELAY_GENESIS_PATH=/usr/share/kusama.json
 
-ARG SUBSTRATE_BASE_PATH=/var/lib/substrate
-ARG SUBSTRATE_PORT=30333
-ARG SUBSTRATE_RPC_PORT=9933
-ARG SUBSTRATE_RPC_CORS=all
-ARG SUBSTRATE_RPC_METHODS=safe
-ARG SUBSTRATE_WS_PORT=9944
-ARG SUBSTRATE_WS_MAX_CONNECTIONS=100
-ARG SUBSTRATE_BOOTNODE_0=/dns/crispy.calamari.systems/tcp/30333/p2p/12D3KooWNE4LBfkYB2B7D4r9vL54YMMGsfAsXdkhWfBw8VHJSEQc
-ARG SUBSTRATE_BOOTNODE_1=/dns/crunchy.calamari.systems/tcp/30333/p2p/12D3KooWL3ELxcoMGA6han3wPQoym5DKbYHqkWkCuqyjaCXpyJTt
-ARG SUBSTRATE_BOOTNODE_2=/dns/hotdog.calamari.systems/tcp/30333/p2p/12D3KooWMHdpUCCS9j8hvNLTV8PeqJ16KaVEjb5PVdYgAQUFUcCG
-ARG SUBSTRATE_BOOTNODE_3=/dns/tasty.calamari.systems/tcp/30333/p2p/12D3KooWGs2hfnRQ3Y2eAoUyWKUL3g7Jmcsf8FpyhVYeNpXeBMSu
-ARG SUBSTRATE_BOOTNODE_4=/dns/tender.calamari.systems/tcp/30333/p2p/12D3KooWNXZeUSEKRPsp1yiDH99qSVawQSWHqG4umPjgHsn1joci
-
-# install deps
+# Install deps
 RUN apt-get update
 RUN apt-get upgrade -y
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -yq openssl
-RUN apt-get install -yq libssl-dev
+RUN apt-get install -yq openssl libssl-dev
 
 RUN mkdir -p /usr/local/bin
 RUN mkdir -p /usr/share
-RUN mkdir -p $SUBSTRATE_BASE_PATH
 
+# Dowload latest calamari binary
 ADD $PARA_BINARY_URL $PARA_BINARY_PATH
 RUN chmod +x $PARA_BINARY_PATH
 RUN ldd $PARA_BINARY_PATH
 RUN $PARA_BINARY_PATH --version
 
+# Get calamari and kusama genesis file
 ADD $PARA_GENESIS_URL $PARA_GENESIS_PATH
 ADD $RELAY_GENESIS_URL $RELAY_GENESIS_PATH
 
-EXPOSE $SUBSTRATE_PORT
-EXPOSE $SUBSTRATE_RPC_PORT
-EXPOSE $SUBSTRATE_WS_PORT
+# Expose three ports by default
+EXPOSE 30333 9933 9944
 
-ENV PARA_BINARY_PATH=$PARA_BINARY_PATH
-ENV PARA_GENESIS_PATH=$PARA_GENESIS_PATH
-ENV SUBSTRATE_BASE_PATH=$SUBSTRATE_BASE_PATH
-ENV SUBSTRATE_PORT=$SUBSTRATE_PORT
-ENV SUBSTRATE_RPC_PORT=$SUBSTRATE_RPC_PORT
-ENV SUBSTRATE_WS_PORT=$SUBSTRATE_WS_PORT
-ENV SUBSTRATE_RPC_CORS=$SUBSTRATE_RPC_CORS
-ENV SUBSTRATE_RPC_METHODS=$SUBSTRATE_RPC_METHODS
-ENV SUBSTRATE_WS_MAX_CONNECTIONS=$SUBSTRATE_WS_MAX_CONNECTIONS
-ENV SUBSTRATE_BOOTNODE_0=$SUBSTRATE_BOOTNODE_0
-ENV SUBSTRATE_BOOTNODE_1=$SUBSTRATE_BOOTNODE_1
-ENV SUBSTRATE_BOOTNODE_2=$SUBSTRATE_BOOTNODE_2
-ENV SUBSTRATE_BOOTNODE_3=$SUBSTRATE_BOOTNODE_3
-ENV SUBSTRATE_BOOTNODE_4=$SUBSTRATE_BOOTNODE_4
-ENV RELAY_GENESIS_PATH=$RELAY_GENESIS_PATH
-
-ENTRYPOINT $PARA_BINARY_PATH \
-  --chain $PARA_GENESIS_PATH \
-  --base-path $SUBSTRATE_BASE_PATH \
-  --port $SUBSTRATE_PORT \
-  --ws-port $SUBSTRATE_WS_PORT \
-  --ws-external \
-  --rpc-port $SUBSTRATE_RPC_PORT \
-  --rpc-external \
-  --rpc-cors $SUBSTRATE_RPC_CORS \
-  --rpc-methods $SUBSTRATE_RPC_METHODS \
-  --ws-max-connections $SUBSTRATE_WS_MAX_CONNECTIONS \
-  --bootnodes \
-    $SUBSTRATE_BOOTNODE_0 \
-    $SUBSTRATE_BOOTNODE_1 \
-    $SUBSTRATE_BOOTNODE_2 \
-    $SUBSTRATE_BOOTNODE_3 \
-    $SUBSTRATE_BOOTNODE_4 \
-  -- \
-  --chain $RELAY_GENESIS_PATH
+ENTRYPOINT [\
+  "/usr/local/bin/manta",\
+  "--chain",\
+  "/usr/share/calamari.json",\
+  "--bootnodes",\
+  "/dns/crispy.calamari.systems/tcp/30333/p2p/12D3KooWNE4LBfkYB2B7D4r9vL54YMMGsfAsXdkhWfBw8VHJSEQc", \
+  "/dns/crunchy.calamari.systems/tcp/30333/p2p/12D3KooWL3ELxcoMGA6han3wPQoym5DKbYHqkWkCuqyjaCXpyJTt", \
+  "/dns/hotdog.calamari.systems/tcp/30333/p2p/12D3KooWMHdpUCCS9j8hvNLTV8PeqJ16KaVEjb5PVdYgAQUFUcCG", \
+  "/dns/tasty.calamari.systems/tcp/30333/p2p/12D3KooWGs2hfnRQ3Y2eAoUyWKUL3g7Jmcsf8FpyhVYeNpXeBMSu", \
+  "/dns/tender.calamari.systems/tcp/30333/p2p/12D3KooWNXZeUSEKRPsp1yiDH99qSVawQSWHqG4umPjgHsn1joci" \
+]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Now, some of params are hardcoded in dockerfile. Use cannot input his own value while start a container.

closes: #352 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
