### PR TITLE
[Manta] Manta Asset Manager and XCM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,8 @@ dependencies = [
 name = "manta-primitives"
 version = "3.1.0"
 dependencies = [
+ "frame-support",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "smallvec",
@@ -4340,6 +4342,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "xcm",
+ "xcm-builder",
  "xcm-executor",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "asset-manager"
+version = "3.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
  "once_cell",
  "version_check",
 ]
@@ -99,15 +99,6 @@ checksum = "fbf688625d06217d5b1bb0ea9d9c44a1635fd0ee3534466388d18203174f4d11"
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -117,15 +108,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "approx"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
@@ -247,7 +238,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.2",
+ "socket2 0.4.3",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -310,7 +301,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -338,9 +329,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -357,7 +348,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -370,7 +361,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -422,12 +413,12 @@ dependencies = [
 
 [[package]]
 name = "bae"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107f431ee3d8a8e45e6dd117adab769556ef463959e77bf6a4888d5fd500cf"
+checksum = "33b8de67cc41132507eeece2584804efcb15f85ba516e34c944b7667f480397a"
 dependencies = [
  "heck",
- "proc-macro-error 0.4.12",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -473,7 +464,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "beefy-primitives",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "parity-scale-codec",
  "parking_lot 0.11.2",
@@ -501,7 +492,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -544,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -569,24 +560,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium 0.5.3",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -668,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -742,7 +721,7 @@ name = "bp-messages"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "bp-runtime",
  "frame-support",
  "frame-system",
@@ -900,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
@@ -946,9 +925,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "calamari-runtime"
@@ -993,6 +972,7 @@ dependencies = [
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
+ "polkadot-core-primitives",
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-common",
@@ -1015,6 +995,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-simulator",
 ]
 
 [[package]]
@@ -1037,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -1078,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -1158,7 +1139,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1178,16 +1159,16 @@ checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.7.1",
+ "libloading 0.7.3",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -1244,9 +1225,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1361,18 +1342,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1391,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1404,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1424,7 +1405,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -1434,7 +1415,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -1480,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1490,12 +1471,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-node-primitives",
@@ -1513,12 +1494,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-primitives-core",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1543,11 +1524,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "async-trait",
  "dyn-clone",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-primitives",
  "sc-client-api",
@@ -1563,12 +1544,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-primitives-core",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parking_lot 0.10.2",
  "polkadot-client",
  "sc-client-api",
@@ -1587,10 +1568,10 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -1610,10 +1591,10 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -1633,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1662,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1680,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1698,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1727,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1738,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1751,7 +1732,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1768,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1786,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1803,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1825,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1836,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1853,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -1928,14 +1909,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -1954,7 +1935,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -2043,9 +2024,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
 dependencies = [
  "signature",
 ]
@@ -2060,7 +2041,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -2195,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "exit-future"
@@ -2205,7 +2186,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
 ]
 
 [[package]]
@@ -2222,9 +2203,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -2255,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
 dependencies = [
  "either",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "num-traits",
@@ -2578,9 +2559,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2593,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2603,15 +2584,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2621,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-lite"
@@ -2636,18 +2617,16 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -2666,15 +2645,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-timer"
@@ -2690,11 +2669,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures 0.1.31",
  "futures-channel",
  "futures-core",
@@ -2703,10 +2681,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -2721,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -2744,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2801,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2913,7 +2889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "hmac 0.8.1",
 ]
 
@@ -2930,13 +2906,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -2947,7 +2923,7 @@ checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
 ]
 
 [[package]]
@@ -2958,9 +2934,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
@@ -2979,9 +2955,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2991,9 +2967,9 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
- "pin-project-lite 0.2.7",
- "socket2 0.4.2",
+ "itoa 0.4.8",
+ "pin-project-lite 0.2.8",
+ "socket2 0.4.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3067,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
 dependencies = [
  "async-io",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-lite",
  "if-addrs",
  "ipnet",
@@ -3116,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -3136,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "1.1.7"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
 
 [[package]]
 name = "integer-sqrt"
@@ -3155,7 +3131,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 2.0.2",
 ]
 
@@ -3170,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "ip_network"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b746553d2f4a1ca26fab939943ddfb217a091f34f53571620a8e3d30691303"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
@@ -3194,9 +3170,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -3206,6 +3182,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -3218,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3232,7 +3214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -3247,7 +3229,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-executor",
  "futures-util",
  "log",
@@ -3262,7 +3244,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-client-transports",
 ]
 
@@ -3284,7 +3266,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -3300,7 +3282,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -3315,7 +3297,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -3331,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -3348,7 +3330,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -3397,10 +3379,10 @@ checksum = "9841352dbecf4c2ed5dc71698df9f1660262ae4e0b610e968602529bdbcf7b30"
 dependencies = [
  "async-trait",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpsee-types",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -3435,7 +3417,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "beefy-primitives",
- "bitvec 0.20.4",
+ "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -3577,9 +3559,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libloading"
@@ -3593,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -3615,7 +3597,7 @@ checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "libp2p-deflate",
@@ -3641,7 +3623,7 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "smallvec",
  "wasm-timer",
 ]
@@ -3657,7 +3639,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1 0.5.0",
@@ -3666,13 +3648,13 @@ dependencies = [
  "multihash 0.14.0",
  "multistream-select",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.1",
@@ -3687,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
 dependencies = [
  "flate2",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
 ]
 
@@ -3698,7 +3680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "smallvec",
@@ -3713,7 +3695,7 @@ checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3734,7 +3716,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
@@ -3743,7 +3725,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "unsigned-varint 0.7.1",
  "wasm-timer",
@@ -3755,7 +3737,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3776,14 +3758,14 @@ dependencies = [
  "bytes 1.1.0",
  "either",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.1",
@@ -3800,7 +3782,7 @@ dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.17",
+ "futures 0.3.19",
  "if-watch",
  "lazy_static",
  "libp2p-core",
@@ -3808,7 +3790,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.2",
+ "socket2 0.4.3",
  "void",
 ]
 
@@ -3820,7 +3802,7 @@ checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "nohash-hasher",
@@ -3838,14 +3820,14 @@ checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
  "rand 0.8.4",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3858,7 +3840,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3875,7 +3857,7 @@ checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "prost",
@@ -3890,9 +3872,9 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "salsa20",
  "sha3",
@@ -3906,12 +3888,12 @@ checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3929,7 +3911,7 @@ checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3948,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
 dependencies = [
  "either",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
  "rand 0.7.3",
@@ -3974,14 +3956,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
 dependencies = [
  "async-io",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "if-watch",
  "ipnet",
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.2",
+ "socket2 0.4.3",
 ]
 
 [[package]]
@@ -3991,7 +3973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
 dependencies = [
  "async-std",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "log",
 ]
@@ -4002,7 +3984,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -4017,7 +3999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
 dependencies = [
  "either",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-rustls",
  "libp2p-core",
  "log",
@@ -4034,7 +4016,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p-core",
  "parking_lot 0.11.2",
  "thiserror",
@@ -4068,7 +4050,7 @@ dependencies = [
  "libsecp256k1-gen-genmult 0.2.1",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -4087,7 +4069,7 @@ dependencies = [
  "libsecp256k1-gen-genmult 0.2.1",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -4106,7 +4088,7 @@ dependencies = [
  "libsecp256k1-gen-genmult 0.3.0",
  "rand 0.8.4",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -4243,9 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
 ]
@@ -4305,7 +4287,7 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hex-literal",
  "jsonrpc-core",
  "log",
@@ -4457,9 +4439,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a15b776d9dfaecd44b03c5828c2199cddff5247215858aac14624f8d6b741"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
 dependencies = [
  "rawpointer",
 ]
@@ -4481,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -4532,7 +4514,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "thiserror",
  "tracing",
@@ -4540,12 +4522,12 @@ dependencies = [
 
 [[package]]
 name = "mick-jaeger"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa77fad8461bb1e0d01be11299e24c6e544007715ed442bfec29f165dc487ae"
+checksum = "fd2c2cc134e57461f0898b0e921f0a7819b5e3f3a4335b9aa390ce81a5f36fb9"
 dependencies = [
- "futures 0.3.17",
- "rand 0.7.3",
+ "futures 0.3.19",
+ "rand 0.8.4",
  "thrift",
 ]
 
@@ -4568,6 +4550,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4646,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "multiaddr"
@@ -4689,9 +4677,9 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "multihash-derive",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -4703,9 +4691,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "multihash-derive",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "unsigned-varint 0.7.1",
 ]
 
@@ -4716,7 +4704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -4736,9 +4724,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "smallvec",
  "unsigned-varint 0.7.1",
 ]
@@ -4806,13 +4794,12 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec 0.19.5",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -4890,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -4920,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -4938,9 +4925,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
@@ -5169,7 +5156,7 @@ name = "pallet-bridge-messages"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "bp-message-dispatch",
  "bp-messages",
  "bp-rialto",
@@ -5189,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5847,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#935bac869a72baef17e46d2ae1abc8c0c650cef5"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.12#c02514d8cb66d6860e597f75d53ca07119dbbf32"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -5859,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb5195cb862b13055cf7f7a76c55073dc73885c2a61511e322b8c1666be7332"
+checksum = "78a95abf24f1097c6e3181abbbbfc3630b3b5e681470940f719b69acb4911c7f"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
@@ -5883,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.2",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -5914,7 +5901,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "libc",
  "log",
  "rand 0.7.3",
@@ -6136,27 +6123,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
 dependencies = [
- "pin-project-internal 0.4.28",
+ "pin-project-internal 0.4.29",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
- "pin-project-internal 1.0.8",
+ "pin-project-internal 1.0.10",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6165,9 +6152,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6182,9 +6169,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -6194,9 +6181,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "platforms"
@@ -6209,7 +6196,7 @@ name = "polkadot-approval-distribution"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -6223,7 +6210,7 @@ name = "polkadot-availability-bitfield-distribution"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6237,8 +6224,8 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
- "lru 0.7.0",
+ "futures 0.3.19",
+ "lru 0.7.2",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -6258,8 +6245,8 @@ name = "polkadot-availability-recovery"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
- "lru 0.7.0",
+ "futures 0.3.19",
+ "lru 0.7.2",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -6279,7 +6266,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "frame-benchmarking-cli",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "polkadot-node-core-pvf",
  "polkadot-service",
@@ -6330,7 +6317,7 @@ source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#
 dependencies = [
  "always-assert",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6363,8 +6350,8 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
- "lru 0.7.0",
+ "futures 0.3.19",
+ "lru 0.7.2",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -6398,7 +6385,7 @@ name = "polkadot-gossip-support"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -6419,7 +6406,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "polkadot-node-network-protocol",
@@ -6437,7 +6424,7 @@ name = "polkadot-node-collation-generation"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
@@ -6455,12 +6442,12 @@ name = "polkadot-node-core-approval-voting"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "kvdb",
- "lru 0.7.0",
+ "lru 0.7.2",
  "merlin",
  "parity-scale-codec",
  "polkadot-node-jaeger",
@@ -6483,8 +6470,8 @@ name = "polkadot-node-core-av-store"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
- "futures 0.3.17",
+ "bitvec",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "kvdb",
  "parity-scale-codec",
@@ -6503,8 +6490,8 @@ name = "polkadot-node-core-backing"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
- "futures 0.3.17",
+ "bitvec",
+ "futures 0.3.19",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -6521,7 +6508,7 @@ name = "polkadot-node-core-bitfield-signing"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -6537,7 +6524,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
@@ -6554,7 +6541,7 @@ name = "polkadot-node-core-chain-api"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -6569,7 +6556,7 @@ name = "polkadot-node-core-chain-selection"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "kvdb",
  "parity-scale-codec",
@@ -6586,9 +6573,9 @@ name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6605,7 +6592,7 @@ name = "polkadot-node-core-dispute-participation"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -6619,7 +6606,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "polkadot-node-subsystem",
  "polkadot-primitives",
@@ -6635,8 +6622,8 @@ name = "polkadot-node-core-provisioner"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
- "futures 0.3.17",
+ "bitvec",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -6654,11 +6641,11 @@ dependencies = [
  "assert_matches",
  "async-process",
  "async-std",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libc",
  "parity-scale-codec",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "polkadot-core-primitives",
  "polkadot-node-subsystem-util",
  "polkadot-parachain",
@@ -6681,7 +6668,7 @@ name = "polkadot-node-core-runtime-api"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "memory-lru",
  "parity-util-mem",
  "polkadot-node-subsystem",
@@ -6717,7 +6704,7 @@ name = "polkadot-node-metrics"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "metered-channel",
  "substrate-prometheus-endpoint",
@@ -6730,7 +6717,7 @@ source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
@@ -6747,7 +6734,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "bounded-vec",
- "futures 0.3.17",
+ "futures 0.3.19",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-primitives",
@@ -6779,7 +6766,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -6799,12 +6786,12 @@ source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "itertools",
- "lru 0.7.0",
+ "lru 0.7.2",
  "metered-channel",
  "parity-scale-codec",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "polkadot-node-jaeger",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -6824,9 +6811,9 @@ name = "polkadot-overseer"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
- "lru 0.7.0",
+ "lru 0.7.2",
  "parity-util-mem",
  "parking_lot 0.11.2",
  "polkadot-node-metrics",
@@ -6846,10 +6833,10 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "metered-channel",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-overseer-gen-proc-macro",
@@ -6890,7 +6877,7 @@ name = "polkadot-primitives"
 version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "frame-system",
  "hex-literal",
  "parity-scale-codec",
@@ -6952,7 +6939,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "beefy-primitives",
- "bitvec 0.20.4",
+ "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -7029,7 +7016,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "beefy-primitives",
- "bitvec 0.20.4",
+ "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -7076,7 +7063,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "bitflags",
- "bitvec 0.20.4",
+ "bitvec",
  "derive_more",
  "frame-benchmarking",
  "frame-support",
@@ -7118,12 +7105,12 @@ dependencies = [
  "beefy-gadget",
  "beefy-primitives",
  "frame-system-rpc-runtime-api",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hex-literal",
  "kusama-runtime",
  "kvdb",
  "kvdb-rocksdb",
- "lru 0.7.0",
+ "lru 0.7.2",
  "pallet-babe",
  "pallet-im-online",
  "pallet-mmr-primitives",
@@ -7214,7 +7201,7 @@ source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#
 dependencies = [
  "arrayvec 0.5.2",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "indexmap",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
@@ -7276,9 +7263,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
@@ -7315,40 +7302,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4",
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -7364,22 +7325,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -7494,18 +7443,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radium"
@@ -7574,14 +7517,14 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
 ]
 
 [[package]]
 name = "rand_distr"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.4",
@@ -7666,7 +7609,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
  "redox_syscall 0.2.10",
 ]
 
@@ -7791,9 +7734,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
+checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
 
 [[package]]
 name = "ring"
@@ -7942,6 +7885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7972,16 +7924,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.17",
- "pin-project 0.4.28",
+ "futures 0.3.19",
+ "pin-project 0.4.29",
  "static_assertions",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "salsa20"
@@ -8019,7 +7971,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "ip_network",
  "libp2p",
@@ -8044,7 +7996,7 @@ name = "sc-basic-authorship"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -8112,7 +8064,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "chrono",
  "fdlimit",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hex",
  "libp2p",
  "log",
@@ -8149,7 +8101,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hash-db",
  "log",
  "parity-scale-codec",
@@ -8202,7 +8154,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -8227,7 +8179,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -8257,7 +8209,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "fork-tree",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "merlin",
  "num-bigint",
@@ -8298,7 +8250,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8335,7 +8287,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -8454,7 +8406,7 @@ dependencies = [
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -8488,7 +8440,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "derive_more",
  "finality-grandpa",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8510,8 +8462,8 @@ name = "sc-informant"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "ansi_term 0.12.1",
- "futures 0.3.17",
+ "ansi_term",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-util-mem",
@@ -8570,7 +8522,7 @@ dependencies = [
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
@@ -8581,7 +8533,7 @@ dependencies = [
  "lru 0.6.6",
  "parity-scale-codec",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -8611,7 +8563,7 @@ name = "sc-network-gossip"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -8629,7 +8581,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hex",
  "hyper",
@@ -8654,7 +8606,7 @@ name = "sc-peerset"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p",
  "log",
  "sc-utils",
@@ -8676,7 +8628,7 @@ name = "sc-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -8707,7 +8659,7 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8732,7 +8684,7 @@ name = "sc-rpc-server"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
@@ -8752,7 +8704,7 @@ dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -8761,7 +8713,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -8851,11 +8803,11 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "chrono",
- "futures 0.3.17",
+ "futures 0.3.19",
  "libp2p",
  "log",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -8868,7 +8820,7 @@ name = "sc-tracing"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "atty",
  "chrono",
  "lazy_static",
@@ -8909,7 +8861,7 @@ name = "sc-transaction-pool"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "intervalier",
  "linked-hash-map",
  "log",
@@ -8937,7 +8889,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "serde",
  "sp-blockchain",
@@ -8950,7 +8902,7 @@ name = "sc-utils"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "lazy_static",
  "prometheus",
@@ -8962,7 +8914,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
@@ -9043,9 +8995,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -9056,9 +9008,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9084,6 +9036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9100,18 +9058,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9120,11 +9078,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -9168,9 +9126,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -9208,9 +9166,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -9227,9 +9185,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "simba"
@@ -9272,9 +9230,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "snap"
@@ -9294,8 +9252,8 @@ dependencies = [
  "rand 0.8.4",
  "rand_core 0.6.3",
  "ring",
- "rustc_version",
- "sha2 0.9.8",
+ "rustc_version 0.3.3",
+ "sha2 0.9.9",
  "subtle",
  "x25519-dalek",
 ]
@@ -9313,9 +9271,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -9330,7 +9288,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.17",
+ "futures 0.3.19",
  "httparse",
  "log",
  "rand 0.7.3",
@@ -9345,7 +9303,7 @@ checksum = "a74e48087dbeed4833785c2f3352b59140095dc192dce966a3bfc155020a439f"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
- "futures 0.3.17",
+ "futures 0.3.19",
  "httparse",
  "log",
  "rand 0.8.4",
@@ -9451,7 +9409,7 @@ name = "sp-blockchain"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "lru 0.6.6",
  "parity-scale-codec",
@@ -9470,7 +9428,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "async-trait",
- "futures 0.3.17",
+ "futures 0.3.19",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -9557,7 +9515,7 @@ dependencies = [
  "byteorder",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.17",
+ "futures 0.3.19",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -9577,7 +9535,7 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -9660,7 +9618,7 @@ name = "sp-io"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "hash-db",
  "libsecp256k1 0.6.0",
  "log",
@@ -9697,7 +9655,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.1
 dependencies = [
  "async-trait",
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.19",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.11.2",
@@ -10022,9 +9980,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.5.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66cd4c4bb7ee41dc5b0c13d600574ae825d3a02e8f31326b17ac71558f2c836"
+checksum = "8319f44e20b42e5c11b88b1ad4130c35fe2974665a007b08b02322070177136a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -10092,9 +10050,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -10108,7 +10066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -10183,7 +10141,7 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -10201,7 +10159,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.17",
+ "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -10236,7 +10194,7 @@ name = "substrate-wasm-builder"
 version = "5.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "build-helper",
  "cargo_metadata",
  "sp-maybe-compressed-blob",
@@ -10254,24 +10212,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -10300,13 +10247,13 @@ checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -10370,9 +10317,9 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
  "integer-encoding",
@@ -10404,7 +10351,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -10437,18 +10384,17 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes 1.1.0",
  "libc",
  "memchr",
  "mio 0.7.14",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
@@ -10456,9 +10402,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10483,7 +10429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -10498,7 +10444,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tokio",
 ]
 
@@ -10524,7 +10470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.7",
+ "pin-project-lite 0.2.8",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -10555,7 +10501,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.8",
+ "pin-project 1.0.10",
  "tracing",
 ]
 
@@ -10586,7 +10532,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
@@ -10699,9 +10645,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.4",
@@ -10710,9 +10656,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -10780,7 +10726,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -10867,9 +10813,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -10918,9 +10864,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -10928,9 +10874,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -10943,9 +10889,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -10955,9 +10901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10965,9 +10911,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10978,9 +10924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-gc-api"
@@ -10999,7 +10945,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -11085,7 +11031,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.9",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -11196,9 +11142,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11238,7 +11184,7 @@ version = "0.9.12"
 source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
 dependencies = [
  "beefy-primitives",
- "bitvec 0.20.4",
+ "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -11474,12 +11420,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcm-simulator"
+version = "0.9.12"
+source = "git+https://github.com/paritytech/polkadot.git?branch=release-v0.9.12#5feed981cf0fe671447eabaa9c0d235a8dd0003e"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "paste",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-runtime-parachains",
+ "sp-io",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
 name = "yamux"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
- "futures 0.3.17",
+ "futures 0.3.19",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.2",
@@ -11489,18 +11452,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "81e8f13fef10b63c06356d65d416b070798ddabcadc10d3ece0c5be9b3c7eddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11510,18 +11473,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.9.0+zstd.1.5.0"
+version = "0.9.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
+checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.1+zstd.1.5.0"
+version = "4.1.3+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
+checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -11529,9 +11492,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.1+zstd.1.5.0"
+version = "1.6.2+zstd.1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+source = "git+https://github.com/manta-network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -4954,7 +4954,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+source = "git+https://github.com/manta-network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+source = "git+https://github.com/manta-network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+source = "git+https://github.com/manta-network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,6 +4338,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,19 +161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "asset-manager"
-version = "3.1.0"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +940,9 @@ dependencies = [
  "hex-literal",
  "log",
  "manta-primitives",
+ "orml-xtokens",
+ "pallet-asset-manager",
+ "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
@@ -967,6 +957,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
  "pallet-tx-pause",
  "pallet-utility",
  "pallet-xcm",
@@ -976,6 +967,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "scale-info",
  "serde",
  "smallvec",
@@ -4939,12 +4931,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "orml-traits"
+version = "0.4.1-dev"
+source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples",
+ "num-traits",
+ "orml-utilities",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+]
+
+[[package]]
+name = "orml-utilities"
+version = "0.4.1-dev"
+source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-xcm-support"
+version = "0.4.1-dev"
+source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+dependencies = [
+ "frame-support",
+ "orml-traits",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
+name = "orml-xtokens"
+version = "0.4.1-dev"
+source = "git+https://github.com/Manta-Network/open-runtime-module-library.git?branch=polkadot-v0.9.12#03fe5543968c3774738ab38c64323b1d1c7d58d4"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "orml-xcm-support",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "pallet-asset-manager"
+version = "3.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-assets"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12#d76f39995315ec36980908e4b99709bd14927044"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4332,6 +4332,7 @@ name = "manta-primitives"
 version = "3.1.0"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "smallvec",
  "sp-consensus-aura",
  "sp-core",
@@ -5014,6 +5015,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "manta-primitives",
  "parity-scale-codec",
  "scale-info",
  "sp-io",

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -16,6 +16,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.12", default-features = false, optional = true }
+manta-primitives = { path = '../../runtime/primitives', default-features = false}
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -7,7 +7,6 @@ homepage   = 'https://manta.network'
 license    = 'GPL-3.0'
 repository = 'https://github.com/Manta-Network/Manta/'
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+authors    = ['Manta Network']
+name = "asset-manager"
+version = "3.1.0"
+edition = "2018"
+homepage   = 'https://manta.network'
+license    = 'GPL-3.0'
+repository = 'https://github.com/Manta-Network/Manta/'
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
+frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.12", default-features = false, optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"scale-info/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-std/std",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+]
+
+runtime-benchmarks = [
+	"frame-benchmarking",
+	'frame-support/runtime-benchmarks',
+	'frame-system/runtime-benchmarks',
+]
+

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors    = ['Manta Network']
-name = "asset-manager"
+name = "pallet-asset-manager"
 version = "3.1.0"
 edition = "2018"
 homepage   = 'https://manta.network'
@@ -16,6 +16,9 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.12", default-features = false, optional = true }
+
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -30,7 +30,6 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use super::*;
 
 	use codec::{Codec, HasCompact};
 	use frame_support::{pallet_prelude::*, transactional, PalletId};

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -34,12 +34,12 @@ pub mod pallet {
 	use codec::{Codec, HasCompact};
 	use frame_support::{pallet_prelude::*, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
+	use manta_primitives::AssetIdLocationGetter;
 	use scale_info::TypeInfo;
 	use sp_runtime::{
 		traits::{AccountIdConversion, AtLeast32BitUnsigned, Bounded, CheckedAdd, One},
 		ArithmeticError,
 	};
-	use manta_primitives::AssetIdLocationGetter;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(PhantomData<T>);
@@ -75,12 +75,12 @@ pub mod pallet {
 	}
 
 	/// Convert AssetId and AssetLocation
-	impl<T: Config> AssetIdLocationGetter<T::AssetId, T::AssetLocation> for Pallet<T>{
-		fn get_asset_id(loc: T::AssetLocation) -> Option<T::AssetId>{
+	impl<T: Config> AssetIdLocationGetter<T::AssetId, T::AssetLocation> for Pallet<T> {
+		fn get_asset_id(loc: T::AssetLocation) -> Option<T::AssetId> {
 			LocationAssetId::<T>::get(loc)
 		}
 
-		fn get_asset_location(id: T::AssetId) -> Option<T::AssetLocation>{
+		fn get_asset_location(id: T::AssetId) -> Option<T::AssetLocation> {
 			AssetIdLocation::<T>::get(id)
 		}
 	}

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -253,12 +253,18 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Get and increment the `NextAssetID` by one.
 		fn get_next_asset_id() -> Result<T::AssetId, DispatchError> {
 			NextAssetId::<T>::try_mutate(|current| -> Result<T::AssetId, DispatchError> {
 				let id = *current;
 				*current = current.checked_add(&One::one()).ok_or(ArithmeticError::Overflow)?;
 				Ok(id)
 			})
+		}
+
+		/// The account ID of AssetManager
+		pub fn account_id() -> T::AccountId {
+			PALLET_ID.into_account()
 		}
 	
 	}

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -26,9 +26,9 @@
 
 #[frame_support::pallet]
 pub mod pallet {
-	use frame_support::{pallet_prelude::*, PalletId};
+	use frame_support::{pallet_prelude::*, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
-	use codec::HasCompact;
+	use codec::{HasCompact, Codec};
 	use scale_info::TypeInfo;
 	use sp_runtime::{traits::{AtLeast32BitUnsigned, CheckedAdd, Bounded, One}, ArithmeticError};
 
@@ -37,6 +37,33 @@ pub mod pallet {
 
 	/// The AssetManagers's pallet id
 	pub const PALLET_ID: PalletId = PalletId(*b"asstmngr");
+
+	/// The registrar trait: defines the interface of creating an asset in the asset implementation layer.
+	/// We may revisit this interface design (e.g. add change asset interface). However, change StorageMetadata 
+	/// should be rare.
+	pub trait AssetRegistrar<T: Config> {
+		///
+		/// * `asset_id`: the asset id to be created
+		/// * `min_balance`: the minimum balance to hold this asset
+		/// * `metadata`: the metadata that the implementation layer stores
+		/// * `is_sufficient`: Whether this asset needs users to have an existential deposit to hold
+	    ///  this asset.
+		fn create_asset(
+			asset_id: T::AssetId,
+			min_balance: T::Balance,
+			metadata: T::StorageMetadata,
+			is_sufficient: bool,
+		) -> DispatchResult;
+	}
+
+	/// The AssetMetadata trait:
+	pub trait AssetMetadata<T: Config> {
+		/// Returns the minimum balance to hold this asset
+		fn min_balance(&self) -> T::Balance;
+
+		/// Returns a boolean value indicating whether this asset needs an existential deposit
+		fn is_sufficient(&self) -> bool;
+	}
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -57,6 +84,9 @@ pub mod pallet {
 			+ MaxEncodedLen
 			+ TypeInfo;
 		
+		/// The trait we use to register Assets
+		type AssetRegistrar: AssetRegistrar<Self>;
+		
 		/// The units in which we record balances.
 		type Balance: Member + Parameter + AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen;
 		
@@ -64,7 +94,7 @@ pub mod pallet {
 		type StorageMetadata: Member + Parameter + Default;
 
 		/// The Asset Metadata type stored in this pallet.
-		type AssetRegistrarMetadata: Member + Parameter + Default + Into<Self::StorageMetadata>;
+		type AssetRegistrarMetadata: Member + Parameter + Codec + Default + Into<Self::StorageMetadata> + AssetMetadata<Self>;
 
 		/// The AssetLocation type: could be just a thin wrapper of MultiLocation
 		type AssetLocation: Member + Parameter + Default;
@@ -103,15 +133,15 @@ pub mod pallet {
 		}
 	}
 
-	/// Error for the nicks pallet.
+	/// Error.
 	#[pallet::error]
 	pub enum Error<T> {
-		/// A name is too short.
-		TooShort,
-		/// A name is too long.
-		TooLong,
-		/// An account isn't named.
-		Unnamed,
+		/// Location already exists.
+		LocationAlreadyExists,
+		/// Error creating asset, e.g. error returned from the implementation layer.
+		ErrorCreatingAsset,
+		/// Update a non-exist asset
+		UpdateNonExistAsset,
 	}
 
 	/// AssetId to MultiLocation Map.
@@ -134,15 +164,26 @@ pub mod pallet {
 	pub(super) type AssetIdMetadata<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AssetId, T::AssetRegistrarMetadata>;
 	
-	/// Get the next available AssetId
+	/// Get the next available AssetId.
 	#[pallet::storage]
 	#[pallet::getter(fn next_asset_id)]
 	pub type NextAssetId<T: Config> = StorageValue<_, T::AssetId, ValueQuery>;
+
+	/// XCM transfer cost for different asset.
+	#[pallet::storage]
+	pub type AssetTransferCost<T: Config> = StorageMap<_, Blake2_128Concat, T::AssetId, T::Balance>;
 	
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		//// * `is_sufficient`: Whether this asset needs users to have an existential deposit to hold
+		/// Register a new asset in the asset manager.
+		///
+		/// * `origin`: Caller of this extrinsic, the acess control is specfied by `ForceOrigin`.
+		/// * `location`: Location of the asset.
+		/// * `metadata`: Asset metadata.
+		/// * `min_balance`: Minimum balance to keep an account alive, used in conjunction with `is_sufficient`. 
+		/// * `is_sufficient`: Whether this asset needs users to have an existential deposit to hold
 	    ///  this asset.
+		/// 
 		/// # <weight>
 		/// TODO: get actual weight
 		/// # </weight>
@@ -151,10 +192,61 @@ pub mod pallet {
 			origin: OriginFor<T>, 
 			location: T::AssetLocation,
 			metadata: T::AssetRegistrarMetadata,
-			min_balance: T::Balance,
-			is_sufficient: bool,
 		) -> DispatchResult {
 			T::ForceOrigin::ensure_origin(origin)?;
+			ensure!(
+				LocationAssetId::<T>::get(&location).is_none(),
+				Error::<T>::LocationAlreadyExists
+			);
+			let asset_id = Self::get_next_asset_id()?;
+			T::AssetRegistrar::create_asset(asset_id, metadata.min_balance(), metadata.clone().into(), metadata.is_sufficient()).map_err(|_| Error::<T>::ErrorCreatingAsset)?;
+			AssetIdLocation::<T>::insert(&asset_id, &location);
+			AssetIdMetadata::<T>::insert(&asset_id, &metadata.clone());
+			LocationAssetId::<T>::insert(&location, &asset_id);
+			Self::deposit_event(Event::<T>::AssetRegistered{asset_id, asset_address: location, metadata});
+			Ok(())
+		}
+
+		/// Update an asset by its asset id in the asset manager.
+		///
+		/// * `origin`: Caller of this extrinsic, the acess control is specfied by `ForceOrigin`.
+		/// * `asset_id`: AssetId to be updated.
+		/// * `metadata_option`: `Some(meta)` to update the metadata to `meta`, `None` means no update on metadata.
+		/// * `location_option`: `Some(location)` to update the asset location, `None` means no update on location.
+		/// 
+		/// # <weight>
+		/// TODO: get actual weight
+		/// # </weight>
+		#[pallet::weight(50_000_000)]
+		#[transactional]
+		pub fn update_asset(
+			origin: OriginFor<T>,
+			asset_id: T::AssetId,
+			location_option: Option<T::AssetLocation>,
+			metadata_option: Option<T::AssetRegistrarMetadata>
+		 ) -> DispatchResult {
+			// check validity.
+			T::ForceOrigin::ensure_origin(origin)?;
+			ensure!(
+				AssetIdLocation::<T>::contains_key(&asset_id),
+				Error::<T>::UpdateNonExistAsset
+			);
+			if let Some(location) = location_option.clone() {
+				ensure!(
+					!LocationAssetId::<T>::contains_key(&location),
+					Error::<T>::LocationAlreadyExists
+				)
+			}
+			// write to the ledger state.
+			if let Some(location) = location_option {
+				let old_location = AssetIdLocation::<T>::get(&asset_id).ok_or(Error::<T>::UpdateNonExistAsset)?;
+				LocationAssetId::<T>::remove(&old_location);
+				LocationAssetId::<T>::insert(&location, &asset_id);
+				AssetIdLocation::<T>::insert(&asset_id, &location);			
+			}
+			if let Some(metadata) = metadata_option {
+				AssetIdMetadata::<T>::insert(&asset_id, &metadata)
+			}
 			Ok(())
 		}
 
@@ -164,7 +256,7 @@ pub mod pallet {
 		fn get_next_asset_id() -> Result<T::AssetId, DispatchError> {
 			NextAssetId::<T>::try_mutate(|current| -> Result<T::AssetId, DispatchError> {
 				let id = *current;
-				*current = current.checked_add(One::one()).ok_or(ArithmeticError::Overflow)?;
+				*current = current.checked_add(&One::one()).ok_or(ArithmeticError::Overflow)?;
 				Ok(id)
 			})
 		}

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -17,20 +17,27 @@
 //! # Asset Manager Pallet
 //!
 //! A simple asset manager for native and cross-chain tokens
-//! 
+//!
 //! ## Overview
 //!
 //! The Asset manager module provides functionality for registering cross chain assets
 //!
-//! TODO: detailed doc-string comment 
+//! TODO: detailed doc-string comment
+
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[frame_support::pallet]
 pub mod pallet {
+	use super::*;
+
+	use codec::{Codec, HasCompact};
 	use frame_support::{pallet_prelude::*, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
-	use codec::{HasCompact, Codec};
 	use scale_info::TypeInfo;
-	use sp_runtime::{traits::{AtLeast32BitUnsigned, CheckedAdd, Bounded, One}, ArithmeticError};
+	use sp_runtime::{
+		traits::{AccountIdConversion, AtLeast32BitUnsigned, Bounded, CheckedAdd, One},
+		ArithmeticError,
+	};
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(PhantomData<T>);
@@ -39,7 +46,7 @@ pub mod pallet {
 	pub const PALLET_ID: PalletId = PalletId(*b"asstmngr");
 
 	/// The registrar trait: defines the interface of creating an asset in the asset implementation layer.
-	/// We may revisit this interface design (e.g. add change asset interface). However, change StorageMetadata 
+	/// We may revisit this interface design (e.g. add change asset interface). However, change StorageMetadata
 	/// should be rare.
 	pub trait AssetRegistrar<T: Config> {
 		///
@@ -47,7 +54,7 @@ pub mod pallet {
 		/// * `min_balance`: the minimum balance to hold this asset
 		/// * `metadata`: the metadata that the implementation layer stores
 		/// * `is_sufficient`: Whether this asset needs users to have an existential deposit to hold
-	    ///  this asset.
+		///  this asset.
 		fn create_asset(
 			asset_id: T::AssetId,
 			min_balance: T::Balance,
@@ -83,22 +90,27 @@ pub mod pallet {
 			+ MaybeSerializeDeserialize
 			+ MaxEncodedLen
 			+ TypeInfo;
-		
+
 		/// The trait we use to register Assets
 		type AssetRegistrar: AssetRegistrar<Self>;
-		
+
 		/// The units in which we record balances.
 		type Balance: Member + Parameter + AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen;
-		
+
 		/// Metadata type that required in token storage: e.g. AssetMetadata in Pallet-Assets.
 		type StorageMetadata: Member + Parameter + Default;
 
 		/// The Asset Metadata type stored in this pallet.
-		type AssetRegistrarMetadata: Member + Parameter + Codec + Default + Into<Self::StorageMetadata> + AssetMetadata<Self>;
+		type AssetRegistrarMetadata: Member
+			+ Parameter
+			+ Codec
+			+ Default
+			+ Into<Self::StorageMetadata>
+			+ AssetMetadata<Self>;
 
 		/// The AssetLocation type: could be just a thin wrapper of MultiLocation
 		type AssetLocation: Member + Parameter + Default;
-		
+
 		/// The origin which may forcibly create or destroy an asset or otherwise alter privileged
 		/// attributes.
 		type ForceOrigin: EnsureOrigin<Self::Origin>;
@@ -124,13 +136,9 @@ pub mod pallet {
 			metadata: T::AssetRegistrarMetadata,
 		},
 		/// Asset frozen.
-		AssetFrozen {
-			asset_id: T::AssetId,
-		},
+		AssetFrozen { asset_id: T::AssetId },
 		/// Asset unfrozen.
-		AssetUnfrozen {
-			asset_id: T::AssetId,
-		}
+		AssetUnfrozen { asset_id: T::AssetId },
 	}
 
 	/// Error.
@@ -150,7 +158,7 @@ pub mod pallet {
 	#[pallet::getter(fn asset_id_location)]
 	pub(super) type AssetIdLocation<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AssetId, T::AssetLocation>;
-	
+
 	/// MultiLocation to AssetId Map.
 	/// This is mostly useful when receiving an asset from a foreign location.
 	#[pallet::storage]
@@ -163,7 +171,7 @@ pub mod pallet {
 	#[pallet::getter(fn asset_id_metadata)]
 	pub(super) type AssetIdMetadata<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AssetId, T::AssetRegistrarMetadata>;
-	
+
 	/// Get the next available AssetId.
 	#[pallet::storage]
 	#[pallet::getter(fn next_asset_id)]
@@ -172,7 +180,7 @@ pub mod pallet {
 	/// XCM transfer cost for different asset.
 	#[pallet::storage]
 	pub type AssetTransferCost<T: Config> = StorageMap<_, Blake2_128Concat, T::AssetId, T::Balance>;
-	
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Register a new asset in the asset manager.
@@ -180,16 +188,16 @@ pub mod pallet {
 		/// * `origin`: Caller of this extrinsic, the acess control is specfied by `ForceOrigin`.
 		/// * `location`: Location of the asset.
 		/// * `metadata`: Asset metadata.
-		/// * `min_balance`: Minimum balance to keep an account alive, used in conjunction with `is_sufficient`. 
+		/// * `min_balance`: Minimum balance to keep an account alive, used in conjunction with `is_sufficient`.
 		/// * `is_sufficient`: Whether this asset needs users to have an existential deposit to hold
-	    ///  this asset.
-		/// 
+		///  this asset.
+		///
 		/// # <weight>
 		/// TODO: get actual weight
 		/// # </weight>
 		#[pallet::weight(50_000_000)]
 		pub fn register_asset(
-			origin: OriginFor<T>, 
+			origin: OriginFor<T>,
 			location: T::AssetLocation,
 			metadata: T::AssetRegistrarMetadata,
 		) -> DispatchResult {
@@ -199,11 +207,21 @@ pub mod pallet {
 				Error::<T>::LocationAlreadyExists
 			);
 			let asset_id = Self::get_next_asset_id()?;
-			T::AssetRegistrar::create_asset(asset_id, metadata.min_balance(), metadata.clone().into(), metadata.is_sufficient()).map_err(|_| Error::<T>::ErrorCreatingAsset)?;
+			T::AssetRegistrar::create_asset(
+				asset_id,
+				metadata.min_balance(),
+				metadata.clone().into(),
+				metadata.is_sufficient(),
+			)
+			.map_err(|_| Error::<T>::ErrorCreatingAsset)?;
 			AssetIdLocation::<T>::insert(&asset_id, &location);
 			AssetIdMetadata::<T>::insert(&asset_id, &metadata.clone());
 			LocationAssetId::<T>::insert(&location, &asset_id);
-			Self::deposit_event(Event::<T>::AssetRegistered{asset_id, asset_address: location, metadata});
+			Self::deposit_event(Event::<T>::AssetRegistered {
+				asset_id,
+				asset_address: location,
+				metadata,
+			});
 			Ok(())
 		}
 
@@ -213,7 +231,7 @@ pub mod pallet {
 		/// * `asset_id`: AssetId to be updated.
 		/// * `metadata_option`: `Some(meta)` to update the metadata to `meta`, `None` means no update on metadata.
 		/// * `location_option`: `Some(location)` to update the asset location, `None` means no update on location.
-		/// 
+		///
 		/// # <weight>
 		/// TODO: get actual weight
 		/// # </weight>
@@ -223,8 +241,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			asset_id: T::AssetId,
 			location_option: Option<T::AssetLocation>,
-			metadata_option: Option<T::AssetRegistrarMetadata>
-		 ) -> DispatchResult {
+			metadata_option: Option<T::AssetRegistrarMetadata>,
+		) -> DispatchResult {
 			// check validity.
 			T::ForceOrigin::ensure_origin(origin)?;
 			ensure!(
@@ -239,17 +257,17 @@ pub mod pallet {
 			}
 			// write to the ledger state.
 			if let Some(location) = location_option {
-				let old_location = AssetIdLocation::<T>::get(&asset_id).ok_or(Error::<T>::UpdateNonExistAsset)?;
+				let old_location =
+					AssetIdLocation::<T>::get(&asset_id).ok_or(Error::<T>::UpdateNonExistAsset)?;
 				LocationAssetId::<T>::remove(&old_location);
 				LocationAssetId::<T>::insert(&location, &asset_id);
-				AssetIdLocation::<T>::insert(&asset_id, &location);			
+				AssetIdLocation::<T>::insert(&asset_id, &location);
 			}
 			if let Some(metadata) = metadata_option {
 				AssetIdMetadata::<T>::insert(&asset_id, &metadata)
 			}
 			Ok(())
 		}
-
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -257,7 +275,9 @@ pub mod pallet {
 		fn get_next_asset_id() -> Result<T::AssetId, DispatchError> {
 			NextAssetId::<T>::try_mutate(|current| -> Result<T::AssetId, DispatchError> {
 				let id = *current;
-				*current = current.checked_add(&One::one()).ok_or(ArithmeticError::Overflow)?;
+				*current = current
+					.checked_add(&One::one())
+					.ok_or(ArithmeticError::Overflow)?;
 				Ok(id)
 			})
 		}
@@ -266,6 +286,5 @@ pub mod pallet {
 		pub fn account_id() -> T::AccountId {
 			PALLET_ID.into_account()
 		}
-	
 	}
 }

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -1,0 +1,140 @@
+// Copyright 2020-2022 Manta Network.
+// This file is part of Manta.
+//
+// Manta is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Manta is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Manta.  If not, see <http://www.gnu.org/licenses/>.
+
+//! # Asset Manager Pallet
+//!
+//! A simple asset manager for native and cross-chain tokens
+//! 
+//! ## Overview
+//!
+//! The Asset manager module provides functionality for registering cross chain assets
+//!
+//! TODO: detailed doc-string comment 
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use codec::HasCompact;
+	use scale_info::TypeInfo;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// The asset id type, this have to be consistent with pallet-manta-pay
+		type AssetId: Member
+			+ Parameter
+			+ Default
+			+ Copy
+			+ HasCompact
+			+ MaybeSerializeDeserialize
+			+ MaxEncodedLen
+			+ TypeInfo;
+		
+		/// Metadata type that required in token storage: e.g. AssetMetadata in Pallet-Assets.
+		type StorageMetadata: Member + Parameter + Default;
+
+		/// The Asset Metadata type stored in this pallet.
+		type AssetRegistrarMetadata: Member + Parameter + Default + Into<Self::StorageMetadata>;
+
+		/// The MultiLocation type.
+		type MultiLocation: Member + Parameter + Default;
+		
+		/// The origin which may forcibly create or destroy an asset or otherwise alter privileged
+		/// attributes.
+		type ForceOrigin: EnsureOrigin<Self::Origin>;
+
+		/// The maximum number of assets this pallet can manage
+		#[pallet::constant]
+		type Capacity: Get<u32>;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A new asset registered.
+		AssetRegistered {
+			asset_id: T::AssetId,
+			asset_address: T::MultiLocation,
+			metadata: T::AssetRegistrarMetadata,
+		},
+		/// An asset has been updated.
+		AssetUpdated {
+			asset_id: T::AssetId,
+			asset_address: T::MultiLocation,
+			metadata: T::AssetRegistrarMetadata,
+		},
+		/// Asset frozen.
+		AssetFrozen {
+			asset_id: T::AssetId,
+		},
+		/// Asset unfrozen.
+		AssetUnfrozen {
+			asset_id: T::AssetId,
+		}
+	}
+
+	/// Error for the nicks pallet.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// A name is too short.
+		TooShort,
+		/// A name is too long.
+		TooLong,
+		/// An account isn't named.
+		Unnamed,
+	}
+
+	/// AssetId to MultiLocation Map.
+	/// This is mostly useful when sending an asset to a foreign location.
+	#[pallet::storage]
+	#[pallet::getter(fn asset_id_location)]
+	pub(super) type AssetIdLocation<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AssetId, T::MultiLocation>;
+	
+	/// MultiLocation to AssetId Map.
+	/// This is mostly useful when receiving an asset from a foreign location.
+	#[pallet::storage]
+	#[pallet::getter(fn location_asset_id)]
+	pub(super) type LocationAssetId<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::MultiLocation, T::AssetId>;
+
+	/// AssetId to AssetRegistrar Map.
+	#[pallet::storage]
+	#[pallet::getter(fn asset_id_metadata)]
+	pub(super) type AssetIdMetadata<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AssetId, T::AssetRegistrarMetadata>;
+	
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// 
+		/// # <weight>
+		/// TODO: get actual weight
+		/// # </weight>
+		#[pallet::weight(50_000_000)]
+		pub fn set_name(origin: OriginFor<T>, name: Vec<u8>) -> DispatchResult {
+			
+			Ok(())
+		}
+
+	}
+}

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -80,7 +80,7 @@ xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', default-fea
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 
 # Third party (vendored) dependencies
-orml-xtokens = { git = "https://github.com/Manta-Network/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.12"}
+orml-xtokens = { git = "https://github.com/manta-network/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.12"}
 
 # Self dependencies
 manta-primitives = { path = '../primitives', default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -68,6 +68,7 @@ pallet-collator-selection = { git = 'https://github.com/paritytech/cumulus.git',
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.12" }
 
 # Polkadot dependencies
+polkadot-core-primitives = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 polkadot-primitives = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 polkadot-runtime-common = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 polkadot-parachain = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
@@ -80,6 +81,9 @@ pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-featu
 manta-primitives = { path = '../primitives', default-features = false }
 calamari-vesting = { path = '../../pallets/vesting', default-features = false }
 pallet-tx-pause = { path = '../../pallets/pallet-tx-pause', default-features = false }
+
+[dev-dependencies]
+xcm-simulator = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12"}
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -39,6 +39,7 @@ frame-system-rpc-runtime-api = { git = 'https://github.com/paritytech/substrate.
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.12" }
 
 # Substrate pallets
+pallet-assets = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-aura = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-authorship = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
@@ -46,6 +47,7 @@ pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', default
 pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-sudo = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-timestamp = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
+pallet-treasury = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-transaction-payment = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-transaction-payment-rpc-runtime-api = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 pallet-utility = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
@@ -77,13 +79,18 @@ xcm-builder = { git = 'https://github.com/paritytech/polkadot.git', default-feat
 xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 
+# Third party (vendored) dependencies
+orml-xtokens = { git = "https://github.com/Manta-Network/open-runtime-module-library.git", default-features = false, branch = "polkadot-v0.9.12"}
+
 # Self dependencies
 manta-primitives = { path = '../primitives', default-features = false }
 calamari-vesting = { path = '../../pallets/vesting', default-features = false }
 pallet-tx-pause = { path = '../../pallets/pallet-tx-pause', default-features = false }
+pallet-asset-manager = { path = '../../pallets/asset-manager', default-features = false }
 
 [dev-dependencies]
 xcm-simulator = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12"}
+polkadot-runtime-parachains = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.12" }
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -140,6 +147,7 @@ std = [
 	'frame-system/std',
 	'frame-system-rpc-runtime-api/std',
 	'frame-try-runtime/std',
+	'pallet-asset-manager/std',
 	'pallet-authorship/std',
 	'pallet-balances/std',
 	'pallet-multisig/std',
@@ -150,10 +158,12 @@ std = [
 	'pallet-sudo/std',
 	'pallet-xcm/std',
 	'pallet-transaction-payment/std',
+	'pallet-treasury/std',
 	'pallet-collective/std',
 	'pallet-democracy/std',
 	'pallet-scheduler/std',
 	'pallet-membership/std',
+	'orml-xtokens/std',
 	'manta-primitives/std',
 	'parachain-info/std',
 	"cumulus-pallet-aura-ext/std",

--- a/runtime/calamari/tests/xcm_mock/mod.rs
+++ b/runtime/calamari/tests/xcm_mock/mod.rs
@@ -22,7 +22,7 @@ use sp_runtime::traits::AccountIdConversion;
 use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};
 
 pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0u8; 32]);
-pub const INITIAL_BALANCE: u128 = 1_000_000_000;
+pub const INITIAL_BALANCE: u128 = 10_000_000_000_000_000;
 
 decl_test_parachain! {
 	pub struct ParaA {

--- a/runtime/calamari/tests/xcm_mock/mod.rs
+++ b/runtime/calamari/tests/xcm_mock/mod.rs
@@ -108,8 +108,3 @@ pub fn relay_ext() -> sp_io::TestExternalities {
 
 pub type RelayChainPalletXcm = pallet_xcm::Pallet<relay_chain::Runtime>;
 pub type ParachainPalletXcm = pallet_xcm::Pallet<parachain::Runtime>;
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-}

--- a/runtime/calamari/tests/xcm_mock/mod.rs
+++ b/runtime/calamari/tests/xcm_mock/mod.rs
@@ -1,0 +1,126 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod parachain;
+pub mod relay_chain;
+
+use cumulus_primitives_core::ParaId;
+use polkadot_parachain::primitives::AccountIdConversion;
+use sp_runtime::AccountId32;
+use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};
+pub const PARAALICE: [u8; 20] = [1u8; 20];
+pub const RELAYALICE: AccountId32 = AccountId32::new([0u8; 32]);
+
+pub fn para_a_account() -> AccountId32 {
+	ParaId::from(1).into_account()
+}
+
+decl_test_parachain! {
+	pub struct ParaA {
+		Runtime = parachain::Runtime,
+		XcmpMessageHandler = parachain::MsgQueue,
+		DmpMessageHandler = parachain::MsgQueue,
+		new_ext = para_ext(1),
+	}
+}
+
+decl_test_parachain! {
+	pub struct ParaB {
+		Runtime = parachain::Runtime,
+		XcmpMessageHandler = parachain::MsgQueue,
+		DmpMessageHandler = parachain::MsgQueue,
+		new_ext = para_ext(2),
+	}
+}
+
+decl_test_parachain! {
+	pub struct ParaC {
+		Runtime = parachain::Runtime,
+		XcmpMessageHandler = parachain::MsgQueue,
+		DmpMessageHandler = parachain::MsgQueue,
+		new_ext = para_ext(3),
+	}
+}
+
+decl_test_relay_chain! {
+	pub struct Relay {
+		Runtime = relay_chain::Runtime,
+		XcmConfig = relay_chain::XcmConfig,
+		new_ext = relay_ext(),
+	}
+}
+
+decl_test_network! {
+	pub struct MockNet {
+		relay_chain = Relay,
+		parachains = vec![
+			(1, ParaA),
+			(2, ParaB),
+			(3, ParaC),
+		],
+	}
+}
+
+pub const INITIAL_BALANCE: u128 = 10_000_000_000_000_000;
+
+pub fn para_ext(para_id: u32) -> sp_io::TestExternalities {
+	use parachain::{MsgQueue, Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(PARAALICE.into(), INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		MsgQueue::set_para_id(para_id.into());
+	});
+	ext
+}
+
+pub fn relay_ext() -> sp_io::TestExternalities {
+	use relay_chain::{Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Runtime>()
+		.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(RELAYALICE, INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+pub type RelayChainPalletXcm = pallet_xcm::Pallet<relay_chain::Runtime>;
+pub type ParachainPalletXcm = pallet_xcm::Pallet<parachain::Runtime>;
+pub type Assets = pallet_assets::Pallet<parachain::Runtime>;
+pub type Treasury = pallet_treasury::Pallet<parachain::Runtime>;
+pub type AssetManager = pallet_asset_manager::Pallet<parachain::Runtime>;
+pub type XTokens = orml_xtokens::Pallet<parachain::Runtime>;
+pub type RelayBalances = pallet_balances::Pallet<relay_chain::Runtime>;
+pub type ParaBalances = pallet_balances::Pallet<parachain::Runtime>;
+pub type XcmTransactor = xcm_transactor::Pallet<parachain::Runtime>;

--- a/runtime/calamari/tests/xcm_mock/mod.rs
+++ b/runtime/calamari/tests/xcm_mock/mod.rs
@@ -107,4 +107,5 @@ pub fn relay_ext() -> sp_io::TestExternalities {
 }
 
 pub type RelayChainPalletXcm = pallet_xcm::Pallet<relay_chain::Runtime>;
+pub type RelayBalances = pallet_balances::Pallet<relay_chain::Runtime>;
 pub type ParachainPalletXcm = pallet_xcm::Pallet<parachain::Runtime>;

--- a/runtime/calamari/tests/xcm_mock/mod.rs
+++ b/runtime/calamari/tests/xcm_mock/mod.rs
@@ -42,6 +42,15 @@ decl_test_parachain! {
 	}
 }
 
+decl_test_parachain! {
+	pub struct ParaC {
+		Runtime = parachain::Runtime,
+		XcmpMessageHandler = parachain::MsgQueue,
+		DmpMessageHandler = parachain::MsgQueue,
+		new_ext = para_ext(3),
+	}
+}
+
 decl_test_relay_chain! {
 	pub struct Relay {
 		Runtime = relay_chain::Runtime,
@@ -56,6 +65,7 @@ decl_test_network! {
 		parachains = vec![
 			(1, ParaA),
 			(2, ParaB),
+			(3, ParaC),
 		],
 	}
 }

--- a/runtime/calamari/tests/xcm_mock/parachain.rs
+++ b/runtime/calamari/tests/xcm_mock/parachain.rs
@@ -1,0 +1,790 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Parachain runtime mock.
+
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{Everything, Get, Nothing, PalletInfo as PalletInfoTrait},
+	weights::Weight,
+	PalletId,
+};
+
+use frame_system::EnsureRoot;
+use codec::{Decode, Encode};
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{Hash, IdentityLookup},
+	Permill,
+};
+use sp_std::{convert::TryFrom, prelude::*};
+use xcm::{latest::prelude::*, Version as XcmVersion, VersionedXcm};
+
+use polkadot_core_primitives::BlockNumber as RelayBlockNumber;
+use polkadot_parachain::primitives::{Id as ParaId, Sibling};
+use xcm::latest::{
+	AssetId as XcmAssetId, Error as XcmError, ExecuteXcm,
+	Junction::{PalletInstance, Parachain},
+	Junctions, MultiLocation, NetworkId, Outcome, Xcm,
+};
+use xcm_builder::{
+	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AllowTopLevelPaidExecutionFrom, ConvertedConcreteAssetId,
+	CurrencyAdapter as XcmCurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds,
+	FungiblesAdapter, IsConcrete, LocationInverter, ParentAsSuperuser, ParentIsDefault,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountKey20AsNative, SovereignSignedViaLocation, TakeWeightCredit,
+};
+use xcm_executor::{traits::JustTry, Config, XcmExecutor};
+
+use scale_info::TypeInfo;
+use xcm_simulator::{
+	DmpMessageHandlerT as DmpMessageHandler, XcmpMessageFormat,
+	XcmpMessageHandlerT as XcmpMessageHandler,
+};
+
+pub type AccountId = moonbeam_core_primitives::AccountId;
+pub type Balance = u128;
+pub type AssetId = u128;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Runtime {
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = Nothing;
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+}
+
+parameter_types! {
+	pub ExistentialDeposit: Balance = 1;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Runtime {
+	type MaxLocks = MaxLocks;
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+}
+
+parameter_types! {
+	pub const AssetDeposit: Balance = 0; // Does not really matter as this will be only called by root
+	pub const ApprovalDeposit: Balance = 0;
+	pub const AssetsStringLimit: u32 = 50;
+	pub const MetadataDepositBase: Balance = 0;
+	pub const MetadataDepositPerByte: Balance = 0;
+	pub const ExecutiveBody: xcm::v0::BodyId = xcm::v0::BodyId::Executive;
+}
+
+impl pallet_assets::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = AssetDeposit;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = AssetsStringLimit;
+	type Freezer = ();
+	type Extra = ();
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+}
+
+/// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
+/// when determining ownership of accounts for asset transacting and when attempting to use XCM
+/// `Transact` in order to determine the dispatch Origin.
+pub type LocationToAccountId = (
+	// The parent (Relay-chain) origin converts to the default `AccountId`.
+	ParentIsDefault<AccountId>,
+	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
+	SiblingParachainConvertsVia<Sibling, AccountId>,
+	AccountKey20Aliases<RelayNetwork, AccountId>,
+);
+
+/// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
+/// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
+/// biases the kind of local `Origin` it will become.
+pub type XcmOriginToTransactDispatchOrigin = (
+	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
+	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
+	// foreign chains who want to have a local sovereign account on this chain which they control.
+	SovereignSignedViaLocation<LocationToAccountId, Origin>,
+	// Native converter for Relay-chain (Parent) location; will converts to a `Relay` origin when
+	// recognised.
+	RelayChainAsNative<RelayChainOrigin, Origin>,
+	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
+	// recognised.
+	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
+	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// transaction from the Root origin.
+	ParentAsSuperuser<Origin>,
+	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
+	pallet_xcm::XcmPassthrough<Origin>,
+	SignedAccountKey20AsNative<RelayNetwork, Origin>,
+);
+
+parameter_types! {
+	pub const UnitWeightCost: Weight = 1;
+	pub MaxInstructions: u32 = 100;
+}
+
+// Instructing how incoming xcm assets will be handled
+pub type FungiblesTransactor = FungiblesAdapter<
+	// Use this fungibles implementation:
+	Assets,
+	// Use this currency when it is a fungible asset matching the given location or name:
+	(
+		ConvertedConcreteAssetId<
+			AssetId,
+			Balance,
+			xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>,
+			JustTry,
+		>,
+	),
+	// Do a simple punn to convert an AccountId32 MultiLocation into a native chain account ID:
+	LocationToAccountId,
+	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+	AccountId,
+	// We dont allow teleports.
+	Nothing,
+	// We dont track any teleports
+	(),
+>;
+
+/// The transactor for our own chain currency.
+pub type LocalAssetTransactor = XcmCurrencyAdapter<
+	// Use this currency:
+	Balances,
+	// Use this currency when it is a fungible asset matching the given location or name:
+	IsConcrete<SelfReserve>,
+	// We can convert the MultiLocations with our converter above:
+	LocationToAccountId,
+	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+	AccountId,
+	// We track our teleports in/out to keep total issuance correct.
+	(),
+>;
+
+// These will be our transactors
+pub type AssetTransactors = (LocalAssetTransactor, FungiblesTransactor);
+pub type XcmRouter = super::ParachainXcmRouter<MsgQueue>;
+
+pub type Barrier = (
+	TakeWeightCredit,
+	AllowTopLevelPaidExecutionFrom<Everything>,
+	// Expected responses are OK.
+	AllowKnownQueryResponses<PolkadotXcm>,
+	// Subscriptions for version tracking are OK.
+	AllowSubscriptionsFrom<Everything>,
+);
+
+parameter_types! {
+	/// Xcm fees will go to the treasury account
+	pub XcmFeesAccount: AccountId = Treasury::account_id();
+}
+
+/// This is the struct that will handle the revenue from xcm fees
+pub type XcmFeesToAccount_ = xcm_primitives::XcmFeesToAccount<
+	Assets,
+	(
+		ConvertedConcreteAssetId<
+			AssetId,
+			Balance,
+			xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>,
+			JustTry,
+		>,
+	),
+	AccountId,
+	XcmFeesAccount,
+>;
+
+parameter_types! {
+	// We cannot skip the native trader for some specific tests, so we will have to work with
+	// a native trader that charges same number of units as weight
+	pub ParaTokensPerSecond: (XcmAssetId, u128) = (Concrete(SelfReserve::get()), 1000000000000);
+}
+
+parameter_types! {
+	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
+	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
+	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
+		pub SelfReserve: MultiLocation = MultiLocation {
+		parents:1,
+		interior: Junctions::X2(
+			Parachain(MsgQueue::parachain_id().into()),
+			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
+		)
+	};
+}
+pub struct XcmConfig;
+impl Config for XcmConfig {
+	type Call = Call;
+	type XcmSender = XcmRouter;
+	type AssetTransactor = AssetTransactors;
+	type OriginConverter = XcmOriginToTransactDispatchOrigin;
+	type IsReserve = xcm_primitives::MultiNativeAsset;
+	type IsTeleporter = ();
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Barrier = Barrier;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type Trader = (
+		FixedRateOfFungible<ParaTokensPerSecond, ()>,
+		xcm_primitives::FirstAssetTrader<AssetId, AssetType, AssetManager, XcmFeesToAccount_>,
+	);
+
+	type ResponseHandler = PolkadotXcm;
+	type SubscriptionService = PolkadotXcm;
+	type AssetTrap = PolkadotXcm;
+	type AssetClaims = PolkadotXcm;
+}
+
+impl cumulus_pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+// Our currencyId. We distinguish for now between SelfReserve, and Others, defined by their Id.
+#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
+pub enum CurrencyId {
+	SelfReserve,
+	OtherReserve(AssetId),
+}
+
+// How to convert from CurrencyId to MultiLocation
+pub struct CurrencyIdtoMultiLocation<AssetXConverter>(sp_std::marker::PhantomData<AssetXConverter>);
+impl<AssetXConverter> sp_runtime::traits::Convert<CurrencyId, Option<MultiLocation>>
+	for CurrencyIdtoMultiLocation<AssetXConverter>
+where
+	AssetXConverter: xcm_executor::traits::Convert<MultiLocation, AssetId>,
+{
+	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
+		match currency {
+			CurrencyId::SelfReserve => {
+				let multi: MultiLocation = SelfReserve::get();
+				Some(multi)
+			}
+			CurrencyId::OtherReserve(asset) => AssetXConverter::reverse_ref(asset).ok(),
+		}
+	}
+}
+
+parameter_types! {
+	pub const BaseXcmWeight: Weight = 100;
+	pub SelfLocation: MultiLocation = MultiLocation {
+		parents:1,
+		interior: Junctions::X1(
+			Parachain(MsgQueue::parachain_id().into())
+		)
+	};
+}
+
+// The XCM message wrapper wrapper
+impl orml_xtokens::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type CurrencyId = CurrencyId;
+	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type CurrencyIdConvert =
+		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type SelfLocation = SelfLocation;
+	type Weigher = xcm_builder::FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type BaseXcmWeight = BaseXcmWeight;
+	type LocationInverter = LocationInverter<Ancestry>;
+}
+
+parameter_types! {
+	pub const ProposalBond: Permill = Permill::from_percent(5);
+	pub const ProposalBondMinimum: Balance = 0;
+	pub const SpendPeriod: u64 = 0;
+	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
+	pub const MaxApprovals: u32 = 100;
+}
+
+impl pallet_treasury::Config for Runtime {
+	type PalletId = TreasuryId;
+	type Currency = Balances;
+	type ApproveOrigin = EnsureRoot<AccountId>;
+	type RejectOrigin = EnsureRoot<AccountId>;
+	type Event = Event;
+	type OnSlash = Treasury;
+	type ProposalBond = ProposalBond;
+	type ProposalBondMinimum = ProposalBondMinimum;
+	type SpendPeriod = SpendPeriod;
+	type Burn = ();
+	type BurnDestination = ();
+	type MaxApprovals = MaxApprovals;
+	type WeightInfo = ();
+	type SpendFunds = ();
+}
+
+#[frame_support::pallet]
+pub mod mock_msg_queue {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		type XcmExecutor: ExecuteXcm<Self::Call>;
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	#[pallet::getter(fn parachain_id)]
+	pub(super) type ParachainId<T: Config> = StorageValue<_, ParaId, ValueQuery>;
+
+	impl<T: Config> Get<ParaId> for Pallet<T> {
+		fn get() -> ParaId {
+			Self::parachain_id()
+		}
+	}
+
+	pub type MessageId = [u8; 32];
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		// XCMP
+		/// Some XCM was executed OK.
+		Success(Option<T::Hash>),
+		/// Some XCM failed.
+		Fail(Option<T::Hash>, XcmError),
+		/// Bad XCM version used.
+		BadVersion(Option<T::Hash>),
+		/// Bad XCM format used.
+		BadFormat(Option<T::Hash>),
+
+		// DMP
+		/// Downward message is invalid XCM.
+		InvalidFormat(MessageId),
+		/// Downward message is unsupported version of XCM.
+		UnsupportedVersion(MessageId),
+		/// Downward message executed with the given outcome.
+		ExecutedDownward(MessageId, Outcome),
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn set_para_id(para_id: ParaId) {
+			ParachainId::<T>::put(para_id);
+		}
+
+		fn handle_xcmp_message(
+			sender: ParaId,
+			_sent_at: RelayBlockNumber,
+			xcm: VersionedXcm<T::Call>,
+			max_weight: Weight,
+		) -> Result<Weight, XcmError> {
+			let hash = Encode::using_encoded(&xcm, T::Hashing::hash);
+			let (result, event) = match Xcm::<T::Call>::try_from(xcm) {
+				Ok(xcm) => {
+					let location = MultiLocation::new(1, Junctions::X1(Parachain(sender.into())));
+					match T::XcmExecutor::execute_xcm(location, xcm, max_weight) {
+						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
+						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
+						// As far as the caller is concerned, this was dispatched without error, so
+						// we just report the weight used.
+						Outcome::Incomplete(w, e) => (Ok(w), Event::Fail(Some(hash), e)),
+					}
+				}
+				Err(()) => (
+					Err(XcmError::UnhandledXcmVersion),
+					Event::BadVersion(Some(hash)),
+				),
+			};
+			Self::deposit_event(event);
+			result
+		}
+	}
+
+	impl<T: Config> XcmpMessageHandler for Pallet<T> {
+		fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
+			iter: I,
+			max_weight: Weight,
+		) -> Weight {
+			for (sender, sent_at, data) in iter {
+				let mut data_ref = data;
+				let _ = XcmpMessageFormat::decode(&mut data_ref)
+					.expect("Simulator encodes with versioned xcm format; qed");
+
+				let mut remaining_fragments = &data_ref[..];
+				while !remaining_fragments.is_empty() {
+					if let Ok(xcm) = VersionedXcm::<T::Call>::decode(&mut remaining_fragments) {
+						let _ = Self::handle_xcmp_message(sender, sent_at, xcm, max_weight);
+					} else {
+						debug_assert!(false, "Invalid incoming XCMP message data");
+					}
+				}
+			}
+			max_weight
+		}
+	}
+
+	impl<T: Config> DmpMessageHandler for Pallet<T> {
+		fn handle_dmp_messages(
+			iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+			limit: Weight,
+		) -> Weight {
+			for (_i, (_sent_at, data)) in iter.enumerate() {
+				let id = sp_io::hashing::blake2_256(&data[..]);
+				let maybe_msg =
+					VersionedXcm::<T::Call>::decode(&mut &data[..]).map(Xcm::<T::Call>::try_from);
+				match maybe_msg {
+					Err(_) => {
+						Self::deposit_event(Event::InvalidFormat(id));
+					}
+					Ok(Err(())) => {
+						Self::deposit_event(Event::UnsupportedVersion(id));
+					}
+					Ok(Ok(x)) => {
+						let outcome = T::XcmExecutor::execute_xcm(Parent, x, limit);
+
+						Self::deposit_event(Event::ExecutedDownward(id, outcome));
+					}
+				}
+			}
+			limit
+		}
+	}
+}
+
+// Pallet to provide the version, used to test runtime upgrade version changes
+#[frame_support::pallet]
+pub mod mock_version_changer {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	#[pallet::getter(fn current_version)]
+	pub(super) type CurrentVersion<T: Config> = StorageValue<_, XcmVersion, ValueQuery>;
+
+	impl<T: Config> Get<XcmVersion> for Pallet<T> {
+		fn get() -> XcmVersion {
+			Self::current_version()
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		// XCMP
+		/// Some XCM was executed OK.
+		VersionChanged(XcmVersion),
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn set_version(version: XcmVersion) {
+			CurrentVersion::<T>::put(version);
+			Self::deposit_event(Event::VersionChanged(version));
+		}
+	}
+}
+
+impl mock_msg_queue::Config for Runtime {
+	type Event = Event;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+impl mock_version_changer::Config for Runtime {
+	type Event = Event;
+}
+
+pub type LocalOriginToLocation =
+	xcm_primitives::SignedToAccountId20<Origin, AccountId, RelayNetwork>;
+
+impl pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecuteFilter = frame_support::traits::Nothing;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	// Do not allow teleports
+	type XcmTeleportFilter = Nothing;
+	type XcmReserveTransferFilter = Everything;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = xcm_builder::LocationInverter<Ancestry>;
+	type Origin = Origin;
+	type Call = Call;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	// We use a custom one to test runtime ugprades
+	type AdvertisedXcmVersion = XcmVersioner;
+}
+
+// Our AssetType. For now we only handle Xcm Assets
+#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
+pub enum AssetType {
+	Xcm(MultiLocation),
+}
+impl Default for AssetType {
+	fn default() -> Self {
+		Self::Xcm(MultiLocation::here())
+	}
+}
+
+impl From<MultiLocation> for AssetType {
+	fn from(location: MultiLocation) -> Self {
+		Self::Xcm(location)
+	}
+}
+
+impl Into<Option<MultiLocation>> for AssetType {
+	fn into(self: Self) -> Option<MultiLocation> {
+		match self {
+			Self::Xcm(location) => Some(location),
+		}
+	}
+}
+
+// Implementation on how to retrieve the AssetId from an AssetType
+// We simply hash the AssetType and take the lowest 128 bits
+impl From<AssetType> for AssetId {
+	fn from(asset: AssetType) -> AssetId {
+		match asset {
+			AssetType::Xcm(id) => {
+				let mut result: [u8; 16] = [0u8; 16];
+				let hash: H256 = id.using_encoded(<Runtime as frame_system::Config>::Hashing::hash);
+				result.copy_from_slice(&hash.as_fixed_bytes()[0..16]);
+				u128::from_le_bytes(result)
+			}
+		}
+	}
+}
+
+// We instruct how to register the Assets
+// In this case, we tell it to Create an Asset in pallet-assets
+pub struct AssetRegistrar;
+use frame_support::pallet_prelude::DispatchResult;
+impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
+	fn create_asset(
+		asset: AssetId,
+		min_balance: Balance,
+		metadata: AssetMetadata,
+		is_sufficient: bool,
+	) -> DispatchResult {
+		Assets::force_create(
+			Origin::root(),
+			asset,
+			AssetManager::account_id(),
+			is_sufficient,
+			min_balance,
+		)?;
+
+		Assets::force_set_metadata(
+			Origin::root(),
+			asset,
+			metadata.name,
+			metadata.symbol,
+			metadata.decimals,
+			false,
+		)
+	}
+}
+
+#[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
+pub struct AssetMetadata {
+	pub name: Vec<u8>,
+	pub symbol: Vec<u8>,
+	pub decimals: u8,
+}
+
+impl pallet_asset_manager::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type AssetRegistrarMetadata = AssetMetadata;
+	type AssetType = AssetType;
+	type AssetRegistrar = AssetRegistrar;
+	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type WeightInfo = ();
+}
+
+impl xcm_transactor::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type Transactor = MockTransactors;
+	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
+	type SovereignAccountDispatcherOrigin = frame_system::EnsureRoot<AccountId>;
+	type CurrencyId = CurrencyId;
+	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type CurrencyIdToMultiLocation =
+		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type SelfLocation = SelfLocation;
+	type Weigher = xcm_builder::FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type XcmSender = XcmRouter;
+	type BaseXcmWeight = BaseXcmWeight;
+	type AssetTransactor = AssetTransactors;
+}
+
+pub struct NormalFilter;
+impl frame_support::traits::Contains<Call> for NormalFilter {
+	fn contains(c: &Call) -> bool {
+		match c {
+			_ => true,
+		}
+	}
+}
+
+// We need to use the encoding from the relay mock runtime
+#[derive(Encode, Decode)]
+pub enum RelayCall {
+	#[codec(index = 5u8)]
+	// the index should match the position of the module in `construct_runtime!`
+	Utility(UtilityCall),
+}
+
+#[derive(Encode, Decode)]
+pub enum UtilityCall {
+	#[codec(index = 1u8)]
+	AsDerivative(u16),
+}
+
+#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
+pub enum MockTransactors {
+	Relay,
+}
+
+impl xcm_primitives::XcmTransact for MockTransactors {
+	fn destination(self) -> MultiLocation {
+		match self {
+			MockTransactors::Relay => MultiLocation::parent(),
+		}
+	}
+	fn max_transact_weight(self) -> Weight {
+		match self {
+			// Westend is 20,000,000,000
+			// This needs to take into account the rest of the message
+			// We use 12,000,000,000 to be safe
+			MockTransactors::Relay => 12_000_000_000,
+		}
+	}
+}
+
+impl xcm_primitives::UtilityEncodeCall for MockTransactors {
+	fn encode_call(self, call: xcm_primitives::UtilityAvailableCalls) -> Vec<u8> {
+		match self {
+			MockTransactors::Relay => match call {
+				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
+					let mut call =
+						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
+					call.append(&mut b.clone());
+					call
+				}
+			},
+		}
+	}
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		MsgQueue: mock_msg_queue::{Pallet, Storage, Event<T>},
+		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
+
+		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
+		Assets: pallet_assets::{Pallet, Storage, Event<T>},
+		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
+		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
+		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},
+		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>},
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call}
+	}
+);
+
+pub(crate) fn para_events() -> Vec<Event> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| Some(e))
+		.collect::<Vec<_>>()
+}
+
+use frame_support::traits::{OnFinalize, OnInitialize, OnRuntimeUpgrade};
+pub(crate) fn on_runtime_upgrade() {
+	PolkadotXcm::on_runtime_upgrade();
+}
+
+pub(crate) fn para_roll_to(n: u64) {
+	while System::block_number() < n {
+		PolkadotXcm::on_finalize(System::block_number());
+		Balances::on_finalize(System::block_number());
+		System::on_finalize(System::block_number());
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+		Balances::on_initialize(System::block_number());
+		PolkadotXcm::on_initialize(System::block_number());
+	}
+}
+

--- a/runtime/calamari/tests/xcm_mock/parachain.rs
+++ b/runtime/calamari/tests/xcm_mock/parachain.rs
@@ -17,6 +17,7 @@
 //! Parachain runtime mock.
 
 use codec::{Decode, Encode};
+use frame_system::EnsureRoot;
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Nothing},
@@ -43,9 +44,11 @@ use xcm_builder::{
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
+use manta_primitives::MultiNativeAsset;
 
 pub type AccountId = AccountId32;
 pub type Balance = u128;
+pub type AssetId = u32; // Manta plans to use u32 as AssetId
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -106,6 +109,30 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
+parameter_types! {
+	pub const AssetDeposit: Balance = 0; // Does not really matter as this will be only called by root
+	pub const ApprovalDeposit: Balance = 0;
+	pub const AssetsStringLimit: u32 = 50;
+	pub const MetadataDepositBase: Balance = 0;
+	pub const MetadataDepositPerByte: Balance = 0;
+}
+
+impl pallet_assets::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = AssetDeposit;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = AssetsStringLimit;
+	type Freezer = ();
+	type Extra = ();
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+}
+
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
 /// when determining ownership of accounts for asset transacting and when attempting to use XCM
 /// `Transact` in order to determine the dispatch Origin.
@@ -135,7 +162,7 @@ pub type XcmOriginToCallOrigin = (
 
 parameter_types! {
 	pub const UnitWeightCost: Weight = 1;
-	pub KsmPerSecond: (AssetId, u128) = (Concrete(Parent.into()), 1);
+	pub KsmPerSecond: (xcm::v1::AssetId, u128) = (Concrete(Parent.into()), 1);
 	pub const MaxInstructions: u32 = 100;
 }
 
@@ -149,9 +176,10 @@ pub struct XcmConfig;
 impl Config for XcmConfig {
 	type Call = Call;
 	type XcmSender = XcmRouter;
+	// Defines how to withdraw and deposit an asset.
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = XcmOriginToCallOrigin;
-	type IsReserve = NativeAsset;
+	type IsReserve = MultiNativeAsset;
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
@@ -159,7 +187,7 @@ impl Config for XcmConfig {
 	// Trader is the means to purchasing weight credit for XCM execution.
 	// We need customize this.
 	// 
-	// Moonbase uses the following logic:
+	// Moonbase mock runtime uses the following logic:
 	// When receiving the self-reserve asset, they use pallet-transaction-payment.
 	// When receiving a non-reserve asset, they use AssetManager to fetch how many
 	// units per second we should charge.
@@ -358,6 +386,7 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Assets: pallet_assets::{Pallet, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		MsgQueue: mock_msg_queue::{Pallet, Storage, Event<T>},
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},

--- a/runtime/calamari/tests/xcm_mock/parachain.rs
+++ b/runtime/calamari/tests/xcm_mock/parachain.rs
@@ -40,7 +40,7 @@ use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
-	NativeAsset, ParentIsDefault, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	ParentIsDefault, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation,
 };
 use xcm_executor::{Config, XcmExecutor};
@@ -179,6 +179,7 @@ impl Config for XcmConfig {
 	// Defines how to withdraw and deposit an asset.
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = XcmOriginToCallOrigin;
+	// Combinations of (Location, Asset) pairs which we trust as reserves.
 	type IsReserve = MultiNativeAsset;
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;

--- a/runtime/calamari/tests/xcm_mock/parachain.rs
+++ b/runtime/calamari/tests/xcm_mock/parachain.rs
@@ -16,50 +16,36 @@
 
 //! Parachain runtime mock.
 
+use codec::{Decode, Encode};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Everything, Get, Nothing, PalletInfo as PalletInfoTrait},
-	weights::Weight,
-	PalletId,
+	traits::{Everything, Nothing},
+	weights::{constants::WEIGHT_PER_SECOND, Weight},
 };
-
-use frame_system::EnsureRoot;
-use codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{Hash, IdentityLookup},
-	Permill,
+	AccountId32,
 };
 use sp_std::{convert::TryFrom, prelude::*};
-use xcm::{latest::prelude::*, Version as XcmVersion, VersionedXcm};
 
+use pallet_xcm::XcmPassthrough;
 use polkadot_core_primitives::BlockNumber as RelayBlockNumber;
-use polkadot_parachain::primitives::{Id as ParaId, Sibling};
-use xcm::latest::{
-	AssetId as XcmAssetId, Error as XcmError, ExecuteXcm,
-	Junction::{PalletInstance, Parachain},
-	Junctions, MultiLocation, NetworkId, Outcome, Xcm,
+use polkadot_parachain::primitives::{
+	DmpMessageHandler, Id as ParaId, Sibling, XcmpMessageFormat, XcmpMessageHandler,
 };
+use xcm::{latest::prelude::*, VersionedXcm};
 use xcm_builder::{
-	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-	AllowTopLevelPaidExecutionFrom, ConvertedConcreteAssetId,
-	CurrencyAdapter as XcmCurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds,
-	FungiblesAdapter, IsConcrete, LocationInverter, ParentAsSuperuser, ParentIsDefault,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountKey20AsNative, SovereignSignedViaLocation, TakeWeightCredit,
+	AccountId32Aliases, AllowUnpaidExecutionFrom, CurrencyAdapter as XcmCurrencyAdapter,
+	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete, LocationInverter,
+	NativeAsset, ParentIsDefault, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation,
 };
-use xcm_executor::{traits::JustTry, Config, XcmExecutor};
+use xcm_executor::{Config, XcmExecutor};
 
-use scale_info::TypeInfo;
-use xcm_simulator::{
-	DmpMessageHandlerT as DmpMessageHandler, XcmpMessageFormat,
-	XcmpMessageHandlerT as XcmpMessageHandler,
-};
-
-pub type AccountId = moonbeam_core_primitives::AccountId;
+pub type AccountId = AccountId32;
 pub type Balance = u128;
-pub type AssetId = u128;
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -73,7 +59,7 @@ impl frame_system::Config for Runtime {
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
-	type Lookup = IdentityLookup<AccountId>;
+	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
@@ -85,7 +71,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type DbWeight = ();
-	type BaseCallFilter = Nothing;
+	type BaseCallFilter = Everything;
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
@@ -110,28 +96,14 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 0; // Does not really matter as this will be only called by root
-	pub const ApprovalDeposit: Balance = 0;
-	pub const AssetsStringLimit: u32 = 50;
-	pub const MetadataDepositBase: Balance = 0;
-	pub const MetadataDepositPerByte: Balance = 0;
-	pub const ExecutiveBody: xcm::v0::BodyId = xcm::v0::BodyId::Executive;
+	pub const ReservedXcmpWeight: Weight = WEIGHT_PER_SECOND / 4;
+	pub const ReservedDmpWeight: Weight = WEIGHT_PER_SECOND / 4;
 }
 
-impl pallet_assets::Config for Runtime {
-	type Event = Event;
-	type Balance = Balance;
-	type AssetId = AssetId;
-	type Currency = Balances;
-	type ForceOrigin = EnsureRoot<AccountId>;
-	type AssetDeposit = AssetDeposit;
-	type MetadataDepositBase = MetadataDepositBase;
-	type MetadataDepositPerByte = MetadataDepositPerByte;
-	type ApprovalDeposit = ApprovalDeposit;
-	type StringLimit = AssetsStringLimit;
-	type Freezer = ();
-	type Extra = ();
-	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+parameter_types! {
+	pub const KsmLocation: MultiLocation = MultiLocation::parent();
+	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
+	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -142,224 +114,71 @@ pub type LocationToAccountId = (
 	ParentIsDefault<AccountId>,
 	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
 	SiblingParachainConvertsVia<Sibling, AccountId>,
-	AccountKey20Aliases<RelayNetwork, AccountId>,
+	AccountId32Aliases<RelayNetwork, AccountId>,
 );
 
-/// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
-/// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
-/// biases the kind of local `Origin` it will become.
-pub type XcmOriginToTransactDispatchOrigin = (
+/// This is the type to convert an (incoming) XCM origin into a local `Origin` instance,
+/// ready for dispatching a transaction with Xcm's `Transact`.
+/// It uses some Rust magic macro to do the pattern matching sequentially.
+/// There is an `OriginKind` which can biases the kind of local `Origin` it will become.
+pub type XcmOriginToCallOrigin = (
 	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
 	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
 	// foreign chains who want to have a local sovereign account on this chain which they control.
 	SovereignSignedViaLocation<LocationToAccountId, Origin>,
-	// Native converter for Relay-chain (Parent) location; will converts to a `Relay` origin when
-	// recognised.
-	RelayChainAsNative<RelayChainOrigin, Origin>,
-	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
-	// recognised.
-	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
-	// transaction from the Root origin.
-	ParentAsSuperuser<Origin>,
+	// If the incoming XCM origin is of type `AccountId32` and the Network is Network::Any 
+	// or `RelayNetwork`, convert it to a Native 32 byte account. 
+	SignedAccountId32AsNative<RelayNetwork, Origin>,
 	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
-	pallet_xcm::XcmPassthrough<Origin>,
-	SignedAccountKey20AsNative<RelayNetwork, Origin>,
+	XcmPassthrough<Origin>,
 );
 
 parameter_types! {
 	pub const UnitWeightCost: Weight = 1;
-	pub MaxInstructions: u32 = 100;
+	pub KsmPerSecond: (AssetId, u128) = (Concrete(Parent.into()), 1);
+	pub const MaxInstructions: u32 = 100;
 }
 
-// Instructing how incoming xcm assets will be handled
-pub type FungiblesTransactor = FungiblesAdapter<
-	// Use this fungibles implementation:
-	Assets,
-	// Use this currency when it is a fungible asset matching the given location or name:
-	(
-		ConvertedConcreteAssetId<
-			AssetId,
-			Balance,
-			xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>,
-			JustTry,
-		>,
-	),
-	// Do a simple punn to convert an AccountId32 MultiLocation into a native chain account ID:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
-	AccountId,
-	// We dont allow teleports.
-	Nothing,
-	// We dont track any teleports
-	(),
->;
+pub type LocalAssetTransactor =
+	XcmCurrencyAdapter<Balances, IsConcrete<KsmLocation>, LocationToAccountId, AccountId, ()>;
 
-/// The transactor for our own chain currency.
-pub type LocalAssetTransactor = XcmCurrencyAdapter<
-	// Use this currency:
-	Balances,
-	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<SelfReserve>,
-	// We can convert the MultiLocations with our converter above:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
-	AccountId,
-	// We track our teleports in/out to keep total issuance correct.
-	(),
->;
-
-// These will be our transactors
-pub type AssetTransactors = (LocalAssetTransactor, FungiblesTransactor);
 pub type XcmRouter = super::ParachainXcmRouter<MsgQueue>;
+pub type Barrier = AllowUnpaidExecutionFrom<Everything>;
 
-pub type Barrier = (
-	TakeWeightCredit,
-	AllowTopLevelPaidExecutionFrom<Everything>,
-	// Expected responses are OK.
-	AllowKnownQueryResponses<PolkadotXcm>,
-	// Subscriptions for version tracking are OK.
-	AllowSubscriptionsFrom<Everything>,
-);
-
-parameter_types! {
-	/// Xcm fees will go to the treasury account
-	pub XcmFeesAccount: AccountId = Treasury::account_id();
-}
-
-/// This is the struct that will handle the revenue from xcm fees
-pub type XcmFeesToAccount_ = xcm_primitives::XcmFeesToAccount<
-	Assets,
-	(
-		ConvertedConcreteAssetId<
-			AssetId,
-			Balance,
-			xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>,
-			JustTry,
-		>,
-	),
-	AccountId,
-	XcmFeesAccount,
->;
-
-parameter_types! {
-	// We cannot skip the native trader for some specific tests, so we will have to work with
-	// a native trader that charges same number of units as weight
-	pub ParaTokensPerSecond: (XcmAssetId, u128) = (Concrete(SelfReserve::get()), 1000000000000);
-}
-
-parameter_types! {
-	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
-	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
-	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
-		pub SelfReserve: MultiLocation = MultiLocation {
-		parents:1,
-		interior: Junctions::X2(
-			Parachain(MsgQueue::parachain_id().into()),
-			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
-		)
-	};
-}
 pub struct XcmConfig;
 impl Config for XcmConfig {
 	type Call = Call;
 	type XcmSender = XcmRouter;
-	type AssetTransactor = AssetTransactors;
-	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = xcm_primitives::MultiNativeAsset;
+	type AssetTransactor = LocalAssetTransactor;
+	type OriginConverter = XcmOriginToCallOrigin;
+	type IsReserve = NativeAsset;
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type Trader = (
-		FixedRateOfFungible<ParaTokensPerSecond, ()>,
-		xcm_primitives::FirstAssetTrader<AssetId, AssetType, AssetManager, XcmFeesToAccount_>,
-	);
-
-	type ResponseHandler = PolkadotXcm;
-	type SubscriptionService = PolkadotXcm;
-	type AssetTrap = PolkadotXcm;
-	type AssetClaims = PolkadotXcm;
-}
-
-impl cumulus_pallet_xcm::Config for Runtime {
-	type Event = Event;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-}
-
-// Our currencyId. We distinguish for now between SelfReserve, and Others, defined by their Id.
-#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
-pub enum CurrencyId {
-	SelfReserve,
-	OtherReserve(AssetId),
-}
-
-// How to convert from CurrencyId to MultiLocation
-pub struct CurrencyIdtoMultiLocation<AssetXConverter>(sp_std::marker::PhantomData<AssetXConverter>);
-impl<AssetXConverter> sp_runtime::traits::Convert<CurrencyId, Option<MultiLocation>>
-	for CurrencyIdtoMultiLocation<AssetXConverter>
-where
-	AssetXConverter: xcm_executor::traits::Convert<MultiLocation, AssetId>,
-{
-	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
-		match currency {
-			CurrencyId::SelfReserve => {
-				let multi: MultiLocation = SelfReserve::get();
-				Some(multi)
-			}
-			CurrencyId::OtherReserve(asset) => AssetXConverter::reverse_ref(asset).ok(),
-		}
-	}
-}
-
-parameter_types! {
-	pub const BaseXcmWeight: Weight = 100;
-	pub SelfLocation: MultiLocation = MultiLocation {
-		parents:1,
-		interior: Junctions::X1(
-			Parachain(MsgQueue::parachain_id().into())
-		)
-	};
-}
-
-// The XCM message wrapper wrapper
-impl orml_xtokens::Config for Runtime {
-	type Event = Event;
-	type Balance = Balance;
-	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
-	type CurrencyIdConvert =
-		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type SelfLocation = SelfLocation;
-	type Weigher = xcm_builder::FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type BaseXcmWeight = BaseXcmWeight;
-	type LocationInverter = LocationInverter<Ancestry>;
-}
-
-parameter_types! {
-	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const ProposalBondMinimum: Balance = 0;
-	pub const SpendPeriod: u64 = 0;
-	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
-	pub const MaxApprovals: u32 = 100;
-}
-
-impl pallet_treasury::Config for Runtime {
-	type PalletId = TreasuryId;
-	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
-	type Event = Event;
-	type OnSlash = Treasury;
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = ();
-	type BurnDestination = ();
-	type MaxApprovals = MaxApprovals;
-	type WeightInfo = ();
-	type SpendFunds = ();
+	// Trader is the means to purchasing weight credit for XCM execution.
+	// We need customize this.
+	// 
+	// Moonbase uses the following logic:
+	// When receiving the self-reserve asset, they use pallet-transaction-payment.
+	// When receiving a non-reserve asset, they use AssetManager to fetch how many
+	// units per second we should charge.
+	//
+	// type Trader = (
+	// 	UsingComponents<
+	// 		IdentityFee<Balance>,
+	// 		SelfReserve,
+	// 		AccountId,
+	// 		Balances,
+	// 		DealWithFees<Runtime>,
+	// 	>,
+	// 	FirstAssetTrader<AssetId, AssetType, AssetManager, XcmFeesToAccount_>,
+	// );
+	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
+	type ResponseHandler = ();
+	type AssetTrap = ();
+	type AssetClaims = ();
+	type SubscriptionService = ();
 }
 
 #[frame_support::pallet]
@@ -383,6 +202,11 @@ pub mod mock_msg_queue {
 	#[pallet::storage]
 	#[pallet::getter(fn parachain_id)]
 	pub(super) type ParachainId<T: Config> = StorageValue<_, ParaId, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn received_dmp)]
+	/// A queue of received DMP messages
+	pub(super) type ReceivedDmp<T: Config> = StorageValue<_, Vec<Xcm<T::Call>>, ValueQuery>;
 
 	impl<T: Config> Get<ParaId> for Pallet<T> {
 		fn get() -> ParaId {
@@ -428,7 +252,7 @@ pub mod mock_msg_queue {
 			let hash = Encode::using_encoded(&xcm, T::Hashing::hash);
 			let (result, event) = match Xcm::<T::Call>::try_from(xcm) {
 				Ok(xcm) => {
-					let location = MultiLocation::new(1, Junctions::X1(Parachain(sender.into())));
+					let location = (1, Parachain(sender.into()));
 					match T::XcmExecutor::execute_xcm(location, xcm, max_weight) {
 						Outcome::Error(e) => (Err(e.clone()), Event::Fail(Some(hash), e)),
 						Outcome::Complete(w) => (Ok(w), Event::Success(Some(hash))),
@@ -487,8 +311,8 @@ pub mod mock_msg_queue {
 						Self::deposit_event(Event::UnsupportedVersion(id));
 					}
 					Ok(Ok(x)) => {
-						let outcome = T::XcmExecutor::execute_xcm(Parent, x, limit);
-
+						let outcome = T::XcmExecutor::execute_xcm(Parent, x.clone(), limit);
+						<ReceivedDmp<T>>::append(x);
 						Self::deposit_event(Event::ExecutedDownward(id, outcome));
 					}
 				}
@@ -498,245 +322,30 @@ pub mod mock_msg_queue {
 	}
 }
 
-// Pallet to provide the version, used to test runtime upgrade version changes
-#[frame_support::pallet]
-pub mod mock_version_changer {
-	use super::*;
-	use frame_support::pallet_prelude::*;
-
-	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-	}
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
-
-	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(_);
-
-	#[pallet::storage]
-	#[pallet::getter(fn current_version)]
-	pub(super) type CurrentVersion<T: Config> = StorageValue<_, XcmVersion, ValueQuery>;
-
-	impl<T: Config> Get<XcmVersion> for Pallet<T> {
-		fn get() -> XcmVersion {
-			Self::current_version()
-		}
-	}
-
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		// XCMP
-		/// Some XCM was executed OK.
-		VersionChanged(XcmVersion),
-	}
-
-	impl<T: Config> Pallet<T> {
-		pub fn set_version(version: XcmVersion) {
-			CurrentVersion::<T>::put(version);
-			Self::deposit_event(Event::VersionChanged(version));
-		}
-	}
-}
-
 impl mock_msg_queue::Config for Runtime {
 	type Event = Event;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 }
 
-impl mock_version_changer::Config for Runtime {
-	type Event = Event;
-}
-
-pub type LocalOriginToLocation =
-	xcm_primitives::SignedToAccountId20<Origin, AccountId, RelayNetwork>;
+pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNetwork>;
 
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmExecuteFilter = frame_support::traits::Nothing;
+	type XcmExecuteFilter = Everything;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	// Do not allow teleports
 	type XcmTeleportFilter = Nothing;
 	type XcmReserveTransferFilter = Everything;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type LocationInverter = xcm_builder::LocationInverter<Ancestry>;
+	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
-	// We use a custom one to test runtime ugprades
-	type AdvertisedXcmVersion = XcmVersioner;
-}
-
-// Our AssetType. For now we only handle Xcm Assets
-#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
-pub enum AssetType {
-	Xcm(MultiLocation),
-}
-impl Default for AssetType {
-	fn default() -> Self {
-		Self::Xcm(MultiLocation::here())
-	}
-}
-
-impl From<MultiLocation> for AssetType {
-	fn from(location: MultiLocation) -> Self {
-		Self::Xcm(location)
-	}
-}
-
-impl Into<Option<MultiLocation>> for AssetType {
-	fn into(self: Self) -> Option<MultiLocation> {
-		match self {
-			Self::Xcm(location) => Some(location),
-		}
-	}
-}
-
-// Implementation on how to retrieve the AssetId from an AssetType
-// We simply hash the AssetType and take the lowest 128 bits
-impl From<AssetType> for AssetId {
-	fn from(asset: AssetType) -> AssetId {
-		match asset {
-			AssetType::Xcm(id) => {
-				let mut result: [u8; 16] = [0u8; 16];
-				let hash: H256 = id.using_encoded(<Runtime as frame_system::Config>::Hashing::hash);
-				result.copy_from_slice(&hash.as_fixed_bytes()[0..16]);
-				u128::from_le_bytes(result)
-			}
-		}
-	}
-}
-
-// We instruct how to register the Assets
-// In this case, we tell it to Create an Asset in pallet-assets
-pub struct AssetRegistrar;
-use frame_support::pallet_prelude::DispatchResult;
-impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
-	fn create_asset(
-		asset: AssetId,
-		min_balance: Balance,
-		metadata: AssetMetadata,
-		is_sufficient: bool,
-	) -> DispatchResult {
-		Assets::force_create(
-			Origin::root(),
-			asset,
-			AssetManager::account_id(),
-			is_sufficient,
-			min_balance,
-		)?;
-
-		Assets::force_set_metadata(
-			Origin::root(),
-			asset,
-			metadata.name,
-			metadata.symbol,
-			metadata.decimals,
-			false,
-		)
-	}
-}
-
-#[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
-pub struct AssetMetadata {
-	pub name: Vec<u8>,
-	pub symbol: Vec<u8>,
-	pub decimals: u8,
-}
-
-impl pallet_asset_manager::Config for Runtime {
-	type Event = Event;
-	type Balance = Balance;
-	type AssetId = AssetId;
-	type AssetRegistrarMetadata = AssetMetadata;
-	type AssetType = AssetType;
-	type AssetRegistrar = AssetRegistrar;
-	type AssetModifierOrigin = EnsureRoot<AccountId>;
-	type WeightInfo = ();
-}
-
-impl xcm_transactor::Config for Runtime {
-	type Event = Event;
-	type Balance = Balance;
-	type Transactor = MockTransactors;
-	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
-	type SovereignAccountDispatcherOrigin = frame_system::EnsureRoot<AccountId>;
-	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
-	type CurrencyIdToMultiLocation =
-		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type SelfLocation = SelfLocation;
-	type Weigher = xcm_builder::FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type LocationInverter = LocationInverter<Ancestry>;
-	type XcmSender = XcmRouter;
-	type BaseXcmWeight = BaseXcmWeight;
-	type AssetTransactor = AssetTransactors;
-}
-
-pub struct NormalFilter;
-impl frame_support::traits::Contains<Call> for NormalFilter {
-	fn contains(c: &Call) -> bool {
-		match c {
-			_ => true,
-		}
-	}
-}
-
-// We need to use the encoding from the relay mock runtime
-#[derive(Encode, Decode)]
-pub enum RelayCall {
-	#[codec(index = 5u8)]
-	// the index should match the position of the module in `construct_runtime!`
-	Utility(UtilityCall),
-}
-
-#[derive(Encode, Decode)]
-pub enum UtilityCall {
-	#[codec(index = 1u8)]
-	AsDerivative(u16),
-}
-
-#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
-pub enum MockTransactors {
-	Relay,
-}
-
-impl xcm_primitives::XcmTransact for MockTransactors {
-	fn destination(self) -> MultiLocation {
-		match self {
-			MockTransactors::Relay => MultiLocation::parent(),
-		}
-	}
-	fn max_transact_weight(self) -> Weight {
-		match self {
-			// Westend is 20,000,000,000
-			// This needs to take into account the rest of the message
-			// We use 12,000,000,000 to be safe
-			MockTransactors::Relay => 12_000_000_000,
-		}
-	}
-}
-
-impl xcm_primitives::UtilityEncodeCall for MockTransactors {
-	fn encode_call(self, call: xcm_primitives::UtilityAvailableCalls) -> Vec<u8> {
-		match self {
-			MockTransactors::Relay => match call {
-				xcm_primitives::UtilityAvailableCalls::AsDerivative(a, b) => {
-					let mut call =
-						RelayCall::Utility(UtilityCall::AsDerivative(a.clone())).encode();
-					call.append(&mut b.clone());
-					call
-				}
-			},
-		}
-	}
+	// May consider using a customized one like Moonbase to test runtime upgrades
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
@@ -751,40 +360,6 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		MsgQueue: mock_msg_queue::{Pallet, Storage, Event<T>},
-		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
-
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::{Pallet, Storage, Event<T>},
-		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
-		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
-		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},
-		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>},
-		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call}
 	}
 );
-
-pub(crate) fn para_events() -> Vec<Event> {
-	System::events()
-		.into_iter()
-		.map(|r| r.event)
-		.filter_map(|e| Some(e))
-		.collect::<Vec<_>>()
-}
-
-use frame_support::traits::{OnFinalize, OnInitialize, OnRuntimeUpgrade};
-pub(crate) fn on_runtime_upgrade() {
-	PolkadotXcm::on_runtime_upgrade();
-}
-
-pub(crate) fn para_roll_to(n: u64) {
-	while System::block_number() < n {
-		PolkadotXcm::on_finalize(System::block_number());
-		Balances::on_finalize(System::block_number());
-		System::on_finalize(System::block_number());
-		System::set_block_number(System::block_number() + 1);
-		System::on_initialize(System::block_number());
-		Balances::on_initialize(System::block_number());
-		PolkadotXcm::on_initialize(System::block_number());
-	}
-}
-

--- a/runtime/calamari/tests/xcm_mock/relay_chain.rs
+++ b/runtime/calamari/tests/xcm_mock/relay_chain.rs
@@ -32,7 +32,7 @@ use xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, ChildParachainAsNative, ChildParachainConvertsVia,
 	ChildSystemParachainAsSuperuser, CurrencyAdapter as XcmCurrencyAdapter, FixedRateOfFungible,
 	FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, ConvertedConcreteAssetId,
 };
 use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;

--- a/runtime/calamari/tests/xcm_mock/relay_chain.rs
+++ b/runtime/calamari/tests/xcm_mock/relay_chain.rs
@@ -1,0 +1,228 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Relay chain runtime mock.
+
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{Everything, Nothing},
+	weights::Weight,
+};
+use sp_core::H256;
+use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
+
+use polkadot_parachain::primitives::Id as ParaId;
+use polkadot_runtime_parachains::{configuration, origin, shared, ump};
+use xcm::latest::prelude::*;
+use xcm_builder::{
+	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AllowTopLevelPaidExecutionFrom, ChildParachainAsNative, ChildParachainConvertsVia,
+	ChildSystemParachainAsSuperuser, CurrencyAdapter as XcmCurrencyAdapter, FixedRateOfFungible,
+	FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+};
+use xcm_executor::{Config, XcmExecutor};
+pub type AccountId = AccountId32;
+pub type Balance = u128;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+}
+
+impl frame_system::Config for Runtime {
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = Everything;
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+}
+
+parameter_types! {
+	pub ExistentialDeposit: Balance = 1;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Runtime {
+	type MaxLocks = MaxLocks;
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+}
+
+impl pallet_utility::Config for Runtime {
+	type Event = Event;
+	type Call = Call;
+	type WeightInfo = ();
+}
+
+impl shared::Config for Runtime {}
+
+impl configuration::Config for Runtime {
+	type WeightInfo = configuration::TestWeightInfo;
+}
+
+parameter_types! {
+	pub const KsmLocation: MultiLocation = Here.into();
+	pub const KusamaNetwork: NetworkId = NetworkId::Kusama;
+	pub const AnyNetwork: NetworkId = NetworkId::Any;
+	pub Ancestry: MultiLocation = Here.into();
+	pub UnitWeightCost: Weight = 1_000;
+}
+
+pub type SovereignAccountOf = (
+	ChildParachainConvertsVia<ParaId, AccountId>,
+	AccountId32Aliases<KusamaNetwork, AccountId>,
+);
+
+pub type LocalAssetTransactor =
+	XcmCurrencyAdapter<Balances, IsConcrete<KsmLocation>, SovereignAccountOf, AccountId, ()>;
+
+type LocalOriginConverter = (
+	SovereignSignedViaLocation<SovereignAccountOf, Origin>,
+	ChildParachainAsNative<origin::Origin, Origin>,
+	SignedAccountId32AsNative<KusamaNetwork, Origin>,
+	ChildSystemParachainAsSuperuser<ParaId, Origin>,
+);
+
+parameter_types! {
+	pub const BaseXcmWeight: Weight = 1_000;
+	pub KsmPerSecond: (AssetId, u128) = (Concrete(KsmLocation::get()), 1);
+	pub const MaxInstructions: u32 = 100;
+}
+
+pub type XcmRouter = super::RelayChainXcmRouter;
+pub type Barrier = (
+	TakeWeightCredit,
+	AllowTopLevelPaidExecutionFrom<Everything>,
+	// Expected responses are OK.
+	AllowKnownQueryResponses<XcmPallet>,
+	// Subscriptions for version tracking are OK.
+	AllowSubscriptionsFrom<Everything>,
+);
+
+pub struct XcmConfig;
+impl Config for XcmConfig {
+	type Call = Call;
+	type XcmSender = XcmRouter;
+	type AssetTransactor = LocalAssetTransactor;
+	type OriginConverter = LocalOriginConverter;
+	type IsReserve = ();
+	type IsTeleporter = ();
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Barrier = Barrier;
+	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
+	type Trader = FixedRateOfFungible<KsmPerSecond, ()>;
+	type ResponseHandler = XcmPallet;
+	type AssetTrap = XcmPallet;
+	type AssetClaims = XcmPallet;
+	type SubscriptionService = XcmPallet;
+}
+
+pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, KusamaNetwork>;
+
+impl pallet_xcm::Config for Runtime {
+	type Event = Event;
+	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	// Anyone can execute XCM messages locally...
+	type ExecuteXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecuteFilter = Nothing;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type XcmTeleportFilter = Everything;
+	type XcmReserveTransferFilter = Everything;
+	type Weigher = FixedWeightBounds<BaseXcmWeight, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type Origin = Origin;
+	type Call = Call;
+	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
+	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+}
+
+parameter_types! {
+	pub const FirstMessageFactorPercent: u64 = 100;
+}
+
+impl ump::Config for Runtime {
+	type Event = Event;
+	type UmpSink = ump::XcmSink<XcmExecutor<XcmConfig>, Runtime>;
+	type FirstMessageFactorPercent = FirstMessageFactorPercent;
+	type ExecuteOverweightOrigin = frame_system::EnsureRoot<AccountId>;
+}
+
+impl origin::Config for Runtime {}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		ParasOrigin: origin::{Pallet, Origin},
+		ParasUmp: ump::{Pallet, Call, Storage, Event},
+		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
+		Utility: pallet_utility::{Pallet, Call, Event},
+	}
+);
+
+pub(crate) fn relay_events() -> Vec<Event> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| Some(e))
+		.collect::<Vec<_>>()
+}
+
+use frame_support::traits::{OnFinalize, OnInitialize};
+pub(crate) fn relay_roll_to(n: u64) {
+	while System::block_number() < n {
+		XcmPallet::on_finalize(System::block_number());
+		Balances::on_finalize(System::block_number());
+		System::on_finalize(System::block_number());
+		System::set_block_number(System::block_number() + 1);
+		System::on_initialize(System::block_number());
+		Balances::on_initialize(System::block_number());
+		XcmPallet::on_initialize(System::block_number());
+	}
+}

--- a/runtime/calamari/tests/xcm_mock/relay_chain.rs
+++ b/runtime/calamari/tests/xcm_mock/relay_chain.rs
@@ -32,7 +32,7 @@ use xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, ChildParachainAsNative, ChildParachainConvertsVia,
 	ChildSystemParachainAsSuperuser, CurrencyAdapter as XcmCurrencyAdapter, FixedRateOfFungible,
 	FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, ConvertedConcreteAssetId,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;

--- a/runtime/calamari/tests/xcm_tests.rs
+++ b/runtime/calamari/tests/xcm_tests.rs
@@ -187,7 +187,7 @@ fn reserve_transfer_relaychain_to_parachain_a_then_back() {
 		));
 	});
 
-	let withdraw_amount = 123;
+	let amount = 123;
 
 	Relay::execute_with(|| {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
@@ -201,12 +201,12 @@ fn reserve_transfer_relaychain_to_parachain_a_then_back() {
 				.into()
 				.into()
 			),
-			Box::new((Here, withdraw_amount).into()),
+			Box::new((Here, amount).into()),
 			0,
 		));
 		assert_eq!(
 			parachain::Balances::free_balance(&para_account_id(1)),
-			INITIAL_BALANCE + withdraw_amount
+			INITIAL_BALANCE + amount
 		);
 	});
 
@@ -214,7 +214,7 @@ fn reserve_transfer_relaychain_to_parachain_a_then_back() {
 		// free execution, full amount received
 		assert_eq!(
 			pallet_assets::Pallet::<parachain::Runtime>::balance(relay_asset_id, &ALICE.into()),
-			withdraw_amount
+			amount
 		);
 	});
 
@@ -237,20 +237,21 @@ fn reserve_transfer_relaychain_to_parachain_a_then_back() {
 	 	assert_ok!(parachain::XTokens::transfer(
 	 		parachain::Origin::signed(ALICE.into()),
 	 		parachain::CurrencyId::MantaCurrency(relay_asset_id),
-	 		withdraw_amount,
+	 		amount,
 	 		Box::new(VersionedMultiLocation::V1(dest)),
 	 		40000
 	 	));
 	});
 
 	ParaA::execute_with(|| {
-	 	// free execution, full amount received
+	 	// free execution, this will drain the parachain asset account
 	 	assert_eq!(parachain::Assets::balance(relay_asset_id, &ALICE.into()), 0);
 	});
 
 	Relay::execute_with(|| {
-	 	// free execution,x	 full amount received
-	 	assert!(RelayBalances::free_balance(&ALICE) > balance_before_sending);
+	 	// free execution, full amount received
+		let relay_balance = RelayBalances::free_balance(&ALICE);
+	 	assert_eq!(RelayBalances::free_balance(&ALICE), balance_before_sending + amount);
 	});
 		
 }

--- a/runtime/calamari/tests/xcm_tests.rs
+++ b/runtime/calamari/tests/xcm_tests.rs
@@ -1,0 +1,66 @@
+mod xcm_mock;
+use frame_support::{assert_ok, traits::PalletInfo};
+use xcm::{VersionedMultiLocation, WrapVersion};
+use xcm_mock::parachain;
+use xcm_mock::relay_chain;
+use xcm_mock::*;
+use xcm_primitives::UtilityEncodeCall;
+
+use xcm::latest::prelude::QueryResponse;
+use xcm::latest::{
+	Junction::{self, AccountId32, AccountKey20, PalletInstance, Parachain},
+	Junctions::*,
+	MultiLocation, NetworkId, Response, Xcm,
+};
+use xcm_simulator::TestExt;
+
+// Send a relay asset (like DOT) to a parachain A
+#[test]
+fn receive_relay_asset_from_relay() {
+	MockNet::reset();
+
+	let source_location = parachain::AssetType::Xcm(MultiLocation::parent());
+	let source_id: parachain::AssetId = source_location.clone().into();
+	let asset_metadata = parachain::AssetMetadata {
+		name: b"RelayToken".to_vec(),
+		symbol: b"Relay".to_vec(),
+		decimals: 12,
+	};
+	// register relay asset in parachain A
+	ParaA::execute_with(|| {
+		assert_ok!(AssetManager::register_asset(
+			parachain::Origin::root(),
+			source_location,
+			asset_metadata,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::Origin::root(),
+			source_id,
+			0u128
+		));
+	});
+
+	// Actually send relay asset to parachain
+	let dest: MultiLocation = AccountKey20 {
+		network: NetworkId::Any,
+		key: PARAALICE,
+	}
+	.into();
+	Relay::execute_with(|| {
+		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
+			relay_chain::Origin::signed(RELAYALICE),
+			Box::new(Parachain(1).into().into()),
+			Box::new(VersionedMultiLocation::V1(dest).clone().into()),
+			Box::new((Here, 123).into()),
+			0,
+		));
+	});
+
+	// Verify that parachain received the asset
+	ParaA::execute_with(|| {
+		// free execution, full amount received
+		assert_eq!(Assets::balance(source_id, &PARAALICE.into()), 123);
+	});
+}

--- a/runtime/calamari/tests/xcm_tests.rs
+++ b/runtime/calamari/tests/xcm_tests.rs
@@ -1,66 +1,234 @@
 mod xcm_mock;
-use frame_support::{assert_ok, traits::PalletInfo};
-use xcm::{VersionedMultiLocation, WrapVersion};
-use xcm_mock::parachain;
-use xcm_mock::relay_chain;
-use xcm_mock::*;
-use xcm_primitives::UtilityEncodeCall;
 
-use xcm::latest::prelude::QueryResponse;
-use xcm::latest::{
-	Junction::{self, AccountId32, AccountKey20, PalletInstance, Parachain},
-	Junctions::*,
-	MultiLocation, NetworkId, Response, Xcm,
-};
+use codec::Encode;
+use frame_support::assert_ok;
+use xcm::latest::prelude::*;
+use xcm_mock::*;
 use xcm_simulator::TestExt;
 
-// Send a relay asset (like DOT) to a parachain A
+// Helper function for forming buy execution message
+fn buy_execution<C>(fees: impl Into<MultiAsset>) -> Instruction<C> {
+	BuyExecution {
+		fees: fees.into(),
+		weight_limit: Unlimited,
+	}
+}
+
 #[test]
-fn receive_relay_asset_from_relay() {
+fn dmp() {
 	MockNet::reset();
 
-	let source_location = parachain::AssetType::Xcm(MultiLocation::parent());
-	let source_id: parachain::AssetId = source_location.clone().into();
-	let asset_metadata = parachain::AssetMetadata {
-		name: b"RelayToken".to_vec(),
-		symbol: b"Relay".to_vec(),
-		decimals: 12,
-	};
-	// register relay asset in parachain A
-	ParaA::execute_with(|| {
-		assert_ok!(AssetManager::register_asset(
-			parachain::Origin::root(),
-			source_location,
-			asset_metadata,
-			1u128,
-			true
-		));
-		assert_ok!(AssetManager::set_asset_units_per_second(
-			parachain::Origin::root(),
-			source_id,
-			0u128
+	let remark = parachain::Call::System(
+		frame_system::Call::<parachain::Runtime>::remark_with_event {
+			remark: vec![1, 2, 3],
+		},
+	);
+	Relay::execute_with(|| {
+		assert_ok!(RelayChainPalletXcm::send_xcm(
+			Here,
+			Parachain(1),
+			Xcm(vec![Transact {
+				origin_type: OriginKind::SovereignAccount,
+				require_weight_at_most: INITIAL_BALANCE as u64,
+				call: remark.encode().into(),
+			}]),
 		));
 	});
 
-	// Actually send relay asset to parachain
-	let dest: MultiLocation = AccountKey20 {
-		network: NetworkId::Any,
-		key: PARAALICE,
-	}
-	.into();
+	ParaA::execute_with(|| {
+		use parachain::{Event, System};
+		assert!(System::events()
+			.iter()
+			.any(|r| matches!(r.event, Event::System(frame_system::Event::Remarked { .. }))));
+	});
+}
+
+#[test]
+fn ump() {
+	MockNet::reset();
+
+	let remark = relay_chain::Call::System(
+		frame_system::Call::<relay_chain::Runtime>::remark_with_event {
+			remark: vec![1, 2, 3],
+		},
+	);
+	ParaA::execute_with(|| {
+		assert_ok!(ParachainPalletXcm::send_xcm(
+			Here,
+			Parent,
+			Xcm(vec![Transact {
+				origin_type: OriginKind::SovereignAccount,
+				require_weight_at_most: INITIAL_BALANCE as u64,
+				call: remark.encode().into(),
+			}]),
+		));
+	});
+
+	Relay::execute_with(|| {
+		use relay_chain::{Event, System};
+		assert!(System::events()
+			.iter()
+			.any(|r| matches!(r.event, Event::System(frame_system::Event::Remarked { .. }))));
+	});
+}
+
+#[test]
+fn xcmp() {
+	MockNet::reset();
+
+	let remark = parachain::Call::System(
+		frame_system::Call::<parachain::Runtime>::remark_with_event {
+			remark: vec![1, 2, 3],
+		},
+	);
+	ParaA::execute_with(|| {
+		assert_ok!(ParachainPalletXcm::send_xcm(
+			Here,
+			(Parent, Parachain(2)),
+			Xcm(vec![Transact {
+				origin_type: OriginKind::SovereignAccount,
+				require_weight_at_most: INITIAL_BALANCE as u64,
+				call: remark.encode().into(),
+			}]),
+		));
+	});
+
+	ParaB::execute_with(|| {
+		use parachain::{Event, System};
+		assert!(System::events()
+			.iter()
+			.any(|r| matches!(r.event, Event::System(frame_system::Event::Remarked { .. }))));
+	});
+}
+
+#[test]
+fn reserve_transfer() {
+	MockNet::reset();
+
+	let withdraw_amount = 123;
+
 	Relay::execute_with(|| {
 		assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
-			relay_chain::Origin::signed(RELAYALICE),
-			Box::new(Parachain(1).into().into()),
-			Box::new(VersionedMultiLocation::V1(dest).clone().into()),
-			Box::new((Here, 123).into()),
+			relay_chain::Origin::signed(ALICE),
+			Box::new(X1(Parachain(1)).into().into()),
+			Box::new(
+				X1(AccountId32 {
+					network: Any,
+					id: ALICE.into()
+				})
+				.into()
+				.into()
+			),
+			Box::new((Here, withdraw_amount).into()),
 			0,
 		));
+		assert_eq!(
+			parachain::Balances::free_balance(&para_account_id(1)),
+			INITIAL_BALANCE + withdraw_amount
+		);
 	});
 
-	// Verify that parachain received the asset
 	ParaA::execute_with(|| {
 		// free execution, full amount received
-		assert_eq!(Assets::balance(source_id, &PARAALICE.into()), 123);
+		assert_eq!(
+			pallet_balances::Pallet::<parachain::Runtime>::free_balance(&ALICE),
+			INITIAL_BALANCE + withdraw_amount
+		);
+	});
+}
+
+/// Scenario:
+/// A parachain transfers funds on the relay chain to another parachain account.
+///
+/// Asserts that the parachain accounts are updated as expected.
+#[test]
+fn withdraw_and_deposit() {
+	MockNet::reset();
+
+	let send_amount = 10;
+
+	ParaA::execute_with(|| {
+		let message = Xcm(vec![
+			WithdrawAsset((Here, send_amount).into()),
+			buy_execution((Here, send_amount)),
+			DepositAsset {
+				assets: All.into(),
+				max_assets: 1,
+				beneficiary: Parachain(2).into(),
+			},
+		]);
+		// Send withdraw and deposit
+		assert_ok!(ParachainPalletXcm::send_xcm(Here, Parent, message.clone()));
+	});
+
+	Relay::execute_with(|| {
+		assert_eq!(
+			relay_chain::Balances::free_balance(para_account_id(1)),
+			INITIAL_BALANCE - send_amount
+		);
+		assert_eq!(
+			relay_chain::Balances::free_balance(para_account_id(2)),
+			send_amount
+		);
+	});
+}
+
+/// Scenario:
+/// A parachain wants to be notified that a transfer worked correctly.
+/// It sends a `QueryHolding` after the deposit to get notified on success.
+///
+/// Asserts that the balances are updated correctly and the expected XCM is sent.
+#[test]
+fn query_holding() {
+	MockNet::reset();
+
+	let send_amount = 10;
+	let query_id_set = 1234;
+
+	// Send a message which fully succeeds on the relay chain
+	ParaA::execute_with(|| {
+		let message = Xcm(vec![
+			WithdrawAsset((Here, send_amount).into()),
+			buy_execution((Here, send_amount)),
+			DepositAsset {
+				assets: All.into(),
+				max_assets: 1,
+				beneficiary: Parachain(2).into(),
+			},
+			QueryHolding {
+				query_id: query_id_set,
+				dest: Parachain(1).into(),
+				assets: All.into(),
+				max_response_weight: 1_000_000_000,
+			},
+		]);
+		// Send withdraw and deposit with query holding
+		assert_ok!(ParachainPalletXcm::send_xcm(Here, Parent, message.clone(),));
+	});
+
+	// Check that transfer was executed
+	Relay::execute_with(|| {
+		// Withdraw executed
+		assert_eq!(
+			relay_chain::Balances::free_balance(para_account_id(1)),
+			INITIAL_BALANCE - send_amount
+		);
+		// Deposit executed
+		assert_eq!(
+			relay_chain::Balances::free_balance(para_account_id(2)),
+			send_amount
+		);
+	});
+
+	// Check that QueryResponse message was received
+	ParaA::execute_with(|| {
+		assert_eq!(
+			parachain::MsgQueue::received_dmp(),
+			vec![Xcm(vec![QueryResponse {
+				query_id: query_id_set,
+				response: Response::Assets(MultiAssets::new()),
+				max_weight: 1_000_000_000,
+			}])],
+		);
 	});
 }

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -12,6 +12,7 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = [ "derive" ] }
 smallvec = "1.6.1"
 
 # Substrate primitives
@@ -28,6 +29,7 @@ default = ["std"]
 std = [
 	'codec/std',
 	'sp-consensus-aura/std',
+	'scale-info/std',
 	'sp-io/std',
 	'sp-std/std',
 ]

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -14,14 +14,17 @@ targets = ['x86_64-unknown-linux-gnu']
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = [ "derive" ] }
 smallvec = "1.6.1"
+log = "0.4.14"
 
 # Substrate primitives
+frame-support = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-consensus-aura = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-core = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-std = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-io = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-runtime = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12"}
+xcm-builder = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12"}
 xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 
 [features]
@@ -32,4 +35,5 @@ std = [
 	'scale-info/std',
 	'sp-io/std',
 	'sp-std/std',
+	'log/std',
 ]

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -20,6 +20,8 @@ sp-core = { git = 'https://github.com/paritytech/substrate.git', default-feature
 sp-std = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-io = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
 sp-runtime = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.12" }
+xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12"}
+xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/runtime/primitives/src/assets.rs
+++ b/runtime/primitives/src/assets.rs
@@ -14,13 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
-///! Manta/Calamari/Dolphin Asset
-
-use xcm::{v1::{MultiLocation, Junctions}, VersionedMultiLocation};
-use codec::{Encode, Decode};
+use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_std::{marker::PhantomData, borrow::Borrow};
-
+use sp_std::{borrow::Borrow, marker::PhantomData};
+///! Manta/Calamari/Dolphin Asset
+use xcm::{
+	v1::{Junctions, MultiLocation},
+	VersionedMultiLocation,
+};
 
 #[derive(Clone, Eq, Debug, PartialEq, Encode, Decode, TypeInfo)]
 pub struct AssetLocation(pub VersionedMultiLocation);
@@ -28,16 +29,19 @@ pub struct AssetLocation(pub VersionedMultiLocation);
 /// This cannot act as the default before v0.9.16 and need overwrite
 /// https://docs.google.com/document/d/1W8y00IcJb0JXPBF59aP4nm-c7DY8Ld02-yIAO7UxR80
 impl Default for AssetLocation {
-    fn default() -> Self {
-        AssetLocation(VersionedMultiLocation::V1(MultiLocation {parents: 0, interior: Junctions::Here}))
-    }
+	fn default() -> Self {
+		AssetLocation(VersionedMultiLocation::V1(MultiLocation {
+			parents: 0,
+			interior: Junctions::Here,
+		}))
+	}
 }
 
 /// Convert a `MultiLocaiton` to an `AssetLocation`
 /// Note: This does not guaranttee the `AssetLocation` is registered (i.e. have an AssetId)
 impl From<MultiLocation> for AssetLocation {
 	fn from(location: MultiLocation) -> Self {
-       AssetLocation(VersionedMultiLocation::V1(location))
+		AssetLocation(VersionedMultiLocation::V1(location))
 	}
 }
 
@@ -45,55 +49,53 @@ impl From<MultiLocation> for AssetLocation {
 /// If Native, retrun none.
 impl Into<Option<MultiLocation>> for AssetLocation {
 	fn into(self: Self) -> Option<MultiLocation> {
-        // only support specific version
+		// only support specific version
 		if let AssetLocation(VersionedMultiLocation::V1(loc)) = self {
-            Some(loc)
-        } else {
-            None
-        }
+			Some(loc)
+		} else {
+			None
+		}
 	}
 }
 
 /// Defines the trait to obtain a generic AssetId
-pub trait AssetIdLocationGetter<AssetId, AssetLocation>{
-    // get AssetLocation from AssetId
-    fn get_asset_location(asset_id: AssetId) -> Option<AssetLocation>;
+pub trait AssetIdLocationGetter<AssetId, AssetLocation> {
+	// get AssetLocation from AssetId
+	fn get_asset_location(asset_id: AssetId) -> Option<AssetLocation>;
 
-    // get AssetId from AssetLocation
-    fn get_asset_id(loc: AssetLocation) -> Option<AssetId>;
+	// get AssetId from AssetLocation
+	fn get_asset_id(loc: AssetLocation) -> Option<AssetId>;
 }
 
 /// Converter struct implementing `Convert`.
-/// This enforce the `AssetInfoGetter` implements `AssetIdLocationGetter` 
+/// This enforce the `AssetInfoGetter` implements `AssetIdLocationGetter`
 pub struct AssetIdLocationConvert<AssetId, AssetLocation, AssetInfoGetter>(
-    PhantomData<(AssetId, AssetLocation, AssetInfoGetter)>,
+	PhantomData<(AssetId, AssetLocation, AssetInfoGetter)>,
 );
-impl<AssetId, AssetLocation, AssetInfoGetter> xcm_executor::traits::Convert<MultiLocation, AssetId> 
-    for AssetIdLocationConvert<AssetId, AssetLocation, AssetInfoGetter>
+impl<AssetId, AssetLocation, AssetInfoGetter> xcm_executor::traits::Convert<MultiLocation, AssetId>
+	for AssetIdLocationConvert<AssetId, AssetLocation, AssetInfoGetter>
 where
-    AssetId: Clone,
-    AssetLocation: From<MultiLocation> + Into<Option<MultiLocation>> + Clone,
-    AssetInfoGetter: AssetIdLocationGetter<AssetId, AssetLocation>,
+	AssetId: Clone,
+	AssetLocation: From<MultiLocation> + Into<Option<MultiLocation>> + Clone,
+	AssetInfoGetter: AssetIdLocationGetter<AssetId, AssetLocation>,
 {
-    fn convert_ref(loc: impl Borrow<MultiLocation>) -> Result<AssetId, ()> {
-        if let Some(asset_id) = AssetInfoGetter::get_asset_id(loc.borrow().clone().into()){
-            Ok(asset_id)
-        } else {
-            Err(())
-        }
-    }
+	fn convert_ref(loc: impl Borrow<MultiLocation>) -> Result<AssetId, ()> {
+		if let Some(asset_id) = AssetInfoGetter::get_asset_id(loc.borrow().clone().into()) {
+			Ok(asset_id)
+		} else {
+			Err(())
+		}
+	}
 
-    fn reverse_ref(id: impl Borrow<AssetId>) -> Result<MultiLocation, ()> {
-        if let Some(asset_loc) = AssetInfoGetter::get_asset_location(id.borrow().clone()) {
-            if let Some(location) = asset_loc.into() {
-                Ok(location)
-            } else {
-                Err(())
-            }
-        } else {
-            Err(())
-        }
-    }
+	fn reverse_ref(id: impl Borrow<AssetId>) -> Result<MultiLocation, ()> {
+		if let Some(asset_loc) = AssetInfoGetter::get_asset_location(id.borrow().clone()) {
+			if let Some(location) = asset_loc.into() {
+				Ok(location)
+			} else {
+				Err(())
+			}
+		} else {
+			Err(())
+		}
+	}
 }
-
-

--- a/runtime/primitives/src/assets.rs
+++ b/runtime/primitives/src/assets.rs
@@ -46,7 +46,7 @@ impl From<MultiLocation> for AssetLocation {
 }
 
 /// Convert an `AssetLocation` to a MultiLocation
-/// If Native, retrun none.
+/// If Native, return none.
 impl Into<Option<MultiLocation>> for AssetLocation {
 	fn into(self: Self) -> Option<MultiLocation> {
 		// only support specific version
@@ -66,6 +66,13 @@ pub trait AssetIdLocationGetter<AssetId, AssetLocation> {
 	// get AssetId from AssetLocation
 	fn get_asset_id(loc: AssetLocation) -> Option<AssetId>;
 }
+
+/// Defines the units per second charged given an `AssetId`.
+pub trait UnitsToWeightRatio<AssetId> {
+	/// Get units per second from asset id
+	fn get_units_per_second(asset_id: AssetId) -> Option<u128>;
+}
+
 
 /// Converter struct implementing `Convert`.
 /// This enforce the `AssetInfoGetter` implements `AssetIdLocationGetter`

--- a/runtime/primitives/src/assets.rs
+++ b/runtime/primitives/src/assets.rs
@@ -34,6 +34,8 @@ impl Default for AssetLocation {
     }
 }
 
+/// Convert a `MultiLocaiton` to an `AssetLocation`
+/// Note: This does not guaranttee the `AssetLocation` is registered (i.e. have an AssetId)
 impl From<MultiLocation> for AssetLocation {
 	fn from(location: MultiLocation) -> Self {
         match location {
@@ -43,6 +45,8 @@ impl From<MultiLocation> for AssetLocation {
 	}
 }
 
+/// Convert an `AssetLocation` to a MultiLocation
+/// If Native, retrun none.
 impl Into<Option<MultiLocation>> for AssetLocation {
 	fn into(self: Self) -> Option<MultiLocation> {
 		match self {

--- a/runtime/primitives/src/assets.rs
+++ b/runtime/primitives/src/assets.rs
@@ -1,0 +1,97 @@
+// Copyright 2020-2021 Manta Network.
+// This file is part of Manta.
+//
+// Manta is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Manta is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Manta.  If not, see <http://www.gnu.org/licenses/>.
+
+///! Manta/Calamari/Dolphin Asset
+
+use xcm::v1::{MultiLocation, Junctions};
+use codec::{Encode, Decode};
+use scale_info::TypeInfo;
+use sp_std::{marker::PhantomData, borrow::Borrow};
+
+
+#[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
+pub enum AssetLocation {
+    Native, // Native Currency, e.g KMA, MANTA, DOL
+    Xcm(MultiLocation),
+}
+
+impl Default for AssetLocation {
+    fn default() -> Self {
+        Self::Native
+    }
+}
+
+impl From<MultiLocation> for AssetLocation {
+	fn from(location: MultiLocation) -> Self {
+        match location {
+            MultiLocation {parents: 0, interior: Junctions::Here} => Self::Native,
+            _ => Self::Xcm(location)
+        }
+	}
+}
+
+impl Into<Option<MultiLocation>> for AssetLocation {
+	fn into(self: Self) -> Option<MultiLocation> {
+		match self {
+			Self::Xcm(location) => Some(location),
+            Self::Native => None
+		}
+	}
+}
+
+/// Defines the trait to obtain a generic AssetId
+pub trait AssetIdLocationGetter<AssetId, AssetLocation>{
+    // get AssetLocation from AssetId
+    fn get_asset_location(asset_id: AssetId) -> Option<AssetLocation>;
+
+    // get AssetId from AssetLocation
+    fn get_asset_id(loc: AssetLocation) -> Option<AssetId>;
+}
+
+/// Converter struct implementing `Convert`.
+/// This enforce the `AssetInfoGetter` implements `AssetIdLocationGetter` 
+pub struct AssetIdLocationConvert<AssetId, AssetLocation, AssetInfoGetter>(
+    PhantomData<(AssetId, AssetLocation, AssetInfoGetter)>,
+);
+impl<AssetId, AssetLocation, AssetInfoGetter> xcm_executor::traits::Convert<MultiLocation, AssetId> 
+    for AssetIdLocationConvert<AssetId, AssetLocation, AssetInfoGetter>
+where
+    AssetId: Clone,
+    AssetLocation: From<MultiLocation> + Into<Option<MultiLocation>> + Clone,
+    AssetInfoGetter: AssetIdLocationGetter<AssetId, AssetLocation>,
+{
+    fn convert_ref(loc: impl Borrow<MultiLocation>) -> Result<AssetId, ()> {
+        if let Some(asset_id) = AssetInfoGetter::get_asset_id(loc.borrow().clone().into()){
+            Ok(asset_id)
+        } else {
+            Err(())
+        }
+    }
+
+    fn reverse_ref(id: impl Borrow<AssetId>) -> Result<MultiLocation, ()> {
+        if let Some(asset_loc) = AssetInfoGetter::get_asset_location(id.borrow().clone()) {
+            if let Some(location) = asset_loc.into() {
+                Ok(location)
+            } else {
+                Err(())
+            }
+        } else {
+            Err(())
+        }
+    }
+}
+
+

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -21,8 +21,10 @@
 
 pub mod constants;
 mod xcm;
+mod assets;
 pub use constants::time;
 pub use crate::xcm::MultiNativeAsset;
+pub use crate::assets::{AssetLocation, AssetIdLocationConvert, AssetIdLocationGetter};
 
 use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
 

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -20,7 +20,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod constants;
+mod xcm;
 pub use constants::time;
+pub use crate::xcm::MultiNativeAsset;
 
 use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
 

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -19,12 +19,14 @@
 #![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod assets;
 pub mod constants;
 mod xcm;
-mod assets;
+pub use crate::{
+	assets::{AssetIdLocationConvert, AssetIdLocationGetter, AssetLocation},
+	xcm::{AccountIdToMultiLocation, MultiNativeAsset},
+};
 pub use constants::time;
-pub use crate::xcm::{MultiNativeAsset, AccountIdToMultiLocation};
-pub use crate::assets::{AssetLocation, AssetIdLocationConvert, AssetIdLocationGetter};
 
 use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};
 

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -23,8 +23,8 @@ mod assets;
 pub mod constants;
 mod xcm;
 pub use crate::{
-	assets::{AssetIdLocationConvert, AssetIdLocationGetter, AssetLocation},
-	xcm::{AccountIdToMultiLocation, MultiNativeAsset},
+	assets::{AssetIdLocationConvert, AssetIdLocationGetter, AssetLocation, UnitsToWeightRatio},
+	xcm::{AccountIdToMultiLocation, MultiNativeAsset, FirstAssetTrader, XcmFeesToAccount},
 };
 pub use constants::time;
 

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -59,3 +59,6 @@ pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
 
 // Moment
 pub type Moment = u64;
+
+// AssetId
+pub type AssetId = u32;

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -23,7 +23,7 @@ pub mod constants;
 mod xcm;
 mod assets;
 pub use constants::time;
-pub use crate::xcm::MultiNativeAsset;
+pub use crate::xcm::{MultiNativeAsset, AccountIdToMultiLocation};
 pub use crate::assets::{AssetLocation, AssetIdLocationConvert, AssetIdLocationGetter};
 
 use sp_runtime::traits::{BlakeTwo256, IdentifyAccount, Verify};

--- a/runtime/primitives/src/xcm.rs
+++ b/runtime/primitives/src/xcm.rs
@@ -16,14 +16,14 @@
 
 use sp_std::marker::PhantomData;
 
-use xcm_executor::traits::FilterAssetLocation;
 use sp_runtime::traits::Convert;
-use xcm::{v1::{
-	MultiAsset, MultiLocation, AssetId as xcmAssetId,
-    Junction::{Parachain, AccountId32}, 
-    Junctions::*,
-	NetworkId,
-}};
+use xcm::v1::{
+	AssetId as xcmAssetId,
+	Junction::{AccountId32, Parachain},
+	Junctions::*,
+	MultiAsset, MultiLocation, NetworkId,
+};
+use xcm_executor::traits::FilterAssetLocation;
 
 pub trait Reserve {
 	/// Returns assets reserve location.
@@ -33,7 +33,7 @@ pub trait Reserve {
 // Takes the chain part of a MultiAsset
 impl Reserve for MultiAsset {
 	fn reserve(&self) -> Option<MultiLocation> {
-        // We only care about concrete location now.
+		// We only care about concrete location now.
 		if let xcmAssetId::Concrete(location) = self.id.clone() {
 			let first_interior = location.first_interior();
 			let parents = location.parent_count();
@@ -65,7 +65,9 @@ impl FilterAssetLocation for MultiNativeAsset {
 
 pub struct AccountIdToMultiLocation<AccountId>(PhantomData<AccountId>);
 impl<AccountId> Convert<AccountId, MultiLocation> for AccountIdToMultiLocation<AccountId>
-where AccountId: Into<[u8; 32]> + Clone {
+where
+	AccountId: Into<[u8; 32]> + Clone,
+{
 	fn convert(account: AccountId) -> MultiLocation {
 		MultiLocation {
 			parents: 0,

--- a/runtime/primitives/src/xcm.rs
+++ b/runtime/primitives/src/xcm.rs
@@ -1,0 +1,60 @@
+// Copyright 2020-2021 Manta Network.
+// This file is part of Manta.
+//
+// Manta is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Manta is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Manta.  If not, see <http://www.gnu.org/licenses/>.
+
+use xcm_executor::traits::FilterAssetLocation;
+use xcm::v1::{
+	MultiAsset, MultiLocation, AssetId as xcmAssetId,
+    Junction::Parachain, 
+    Junctions::*
+};
+
+pub trait Reserve {
+	/// Returns assets reserve location.
+	fn reserve(&self) -> Option<MultiLocation>;
+}
+
+// Takes the chain part of a MultiAsset
+impl Reserve for MultiAsset {
+	fn reserve(&self) -> Option<MultiLocation> {
+        // We only care about concrete location now.
+		if let xcmAssetId::Concrete(location) = self.id.clone() {
+			let first_interior = location.first_interior();
+			let parents = location.parent_count();
+			match (parents, first_interior.clone()) {
+				(0, Some(Parachain(id))) => Some(MultiLocation::new(0, X1(Parachain(id.clone())))),
+				(1, Some(Parachain(id))) => Some(MultiLocation::new(1, X1(Parachain(id.clone())))),
+				(1, _) => Some(MultiLocation::parent()),
+				_ => None,
+			}
+		} else {
+			None
+		}
+	}
+}
+
+/// A `FilterAssetLocation` implementation. Filters multi native assets whose
+/// reserve is same with `origin`.
+pub struct MultiNativeAsset;
+impl FilterAssetLocation for MultiNativeAsset {
+	fn filter_asset_location(asset: &MultiAsset, origin: &MultiLocation) -> bool {
+		if let Some(ref reserve) = asset.reserve() {
+			if reserve == origin {
+				return true;
+			}
+		}
+		false
+	}
+}

--- a/runtime/primitives/src/xcm.rs
+++ b/runtime/primitives/src/xcm.rs
@@ -14,12 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+use sp_std::marker::PhantomData;
+
 use xcm_executor::traits::FilterAssetLocation;
-use xcm::v1::{
+use sp_runtime::traits::Convert;
+use xcm::{v1::{
 	MultiAsset, MultiLocation, AssetId as xcmAssetId,
-    Junction::Parachain, 
-    Junctions::*
-};
+    Junction::{Parachain, AccountId32}, 
+    Junctions::*,
+	NetworkId,
+}};
 
 pub trait Reserve {
 	/// Returns assets reserve location.
@@ -56,5 +60,19 @@ impl FilterAssetLocation for MultiNativeAsset {
 			}
 		}
 		false
+	}
+}
+
+pub struct AccountIdToMultiLocation<AccountId>(PhantomData<AccountId>);
+impl<AccountId> Convert<AccountId, MultiLocation> for AccountIdToMultiLocation<AccountId>
+where AccountId: Into<[u8; 32]> + Clone {
+	fn convert(account: AccountId) -> MultiLocation {
+		MultiLocation {
+			parents: 0,
+			interior: X1(AccountId32 {
+				network: NetworkId::Any,
+				id: account.into(),
+			}),
+		}
 	}
 }

--- a/runtime/primitives/src/xcm.rs
+++ b/runtime/primitives/src/xcm.rs
@@ -15,15 +15,23 @@
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
 use sp_std::marker::PhantomData;
+use sp_runtime::traits::{Convert, Zero};
 
-use sp_runtime::traits::Convert;
+use frame_support::{weights::{Weight, constants::WEIGHT_PER_SECOND}};
+use frame_support::traits::fungibles::Mutate;
+use frame_support::pallet_prelude::Get;
+
 use xcm::v1::{
 	AssetId as xcmAssetId,
 	Junction::{AccountId32, Parachain},
 	Junctions::*,
-	MultiAsset, MultiLocation, NetworkId,
+	MultiAsset, MultiLocation, NetworkId, Fungibility
 };
-use xcm_executor::traits::FilterAssetLocation;
+use xcm::latest::Error as XcmError;
+use xcm_builder::TakeRevenue;
+use xcm_executor::traits::{FilterAssetLocation, WeightTrader, MatchesFungibles};
+use crate::{UnitsToWeightRatio, AssetIdLocationGetter};
+
 
 pub trait Reserve {
 	/// Returns assets reserve location.
@@ -75,6 +83,151 @@ where
 				network: NetworkId::Any,
 				id: account.into(),
 			}),
+		}
+	}
+}
+
+// This trader defines how to charge a XCM call.
+// This takes the first fungible asset, and takes UnitPerSecondGetter that implements
+// UnitToWeightRatio trait.
+pub struct FirstAssetTrader<
+	AssetId: Clone,
+	AssetLocation: From<MultiLocation> + Clone,
+	AssetIdInfoGetter: UnitsToWeightRatio<AssetId> + AssetIdLocationGetter<AssetId, AssetLocation>,
+	R: TakeRevenue,
+>(	
+	Weight,
+	Option<(MultiLocation, u128, u128)>,
+	sp_std::marker::PhantomData<(AssetId, AssetLocation, AssetIdInfoGetter, R)>);
+impl <
+	AssetId: Clone,
+	AssetLocation: From<MultiLocation> + Clone,
+	AssetIdInfoGetter: UnitsToWeightRatio<AssetId> + AssetIdLocationGetter<AssetId, AssetLocation>,
+	R: TakeRevenue,
+> WeightTrader for FirstAssetTrader<AssetId, AssetLocation, AssetIdInfoGetter, R>{
+	fn new() -> Self {
+		FirstAssetTrader(Zero::zero(), None, sp_std::marker::PhantomData)
+	}
+
+	/// buy weight for XCM execution. We always return `TooExpensive` error if this fails.
+	fn buy_weight(&mut self, weight: Weight, payment: xcm_executor::Assets) -> Result<xcm_executor::Assets, XcmError> {
+		let first_asset = payment
+			.clone()
+			.fungible_assets_iter()
+			.next()
+			.ok_or(XcmError::TooExpensive)?;
+		
+		// Check the first asset
+		match (first_asset.id, first_asset.fun) {
+			(xcmAssetId::Concrete(id), Fungibility::Fungible(_)) => {
+				let asset_loc: AssetLocation = id.clone().into();
+				let asset_id = AssetIdInfoGetter::get_asset_id(asset_loc).ok_or(XcmError::TooExpensive)?;
+				let units_per_second = AssetIdInfoGetter::get_units_per_second(asset_id).ok_or(XcmError::TooExpensive)?;
+				let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+				// we don't need to proceed if amount is zero. 
+				// This is very useful in tests.
+				if amount.is_zero() {
+					return Ok(payment);
+				}
+				let required = MultiAsset {
+					fun: Fungibility::Fungible(amount.into()),
+					id: xcmAssetId::Concrete(id.clone()),
+				};
+				let unused = payment
+					.checked_sub(required)
+					.map_err(|_| XcmError::TooExpensive)?;
+				self.0 = self.0.saturating_add(weight);
+
+				// In case the asset matches the one the trader already stored before, add
+				// to later refund
+
+				// Else we are always going to substract the weight if we can, but we latter do
+				// not refund it
+
+				// In short, we only refund on the asset the trader first succesfully was able
+				// to pay for an execution
+				let new_asset = match self.1.clone() {
+					Some((prev_id, prev_amount, units_per_second)) => {
+						if prev_id == id.clone() {
+							Some((id, prev_amount.saturating_add(amount), units_per_second))
+						} else {
+							None
+						}
+					}
+					None => Some((id, amount, units_per_second)),
+				};
+
+				// Due to the trait bound, we can only refund one asset.
+				if let Some(new_asset) = new_asset {
+					self.0 = self.0.saturating_add(weight);
+					self.1 = Some(new_asset);
+				};
+				return Ok(unused);
+			}
+			_ => Err(XcmError::TooExpensive)
+		}
+	}
+
+	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+		if let Some((id, prev_amount, units_per_second)) = self.1.clone() {
+			let weight = weight.min(self.0);
+			self.0 -= weight;
+			let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+			self.1 = Some((
+				id.clone(),
+				prev_amount.saturating_sub(amount),
+				units_per_second,
+			));
+			Some(MultiAsset {
+				fun: Fungibility::Fungible(amount),
+				id: xcmAssetId::Concrete(id.clone()),
+			})
+		} else {
+			None
+		} 
+	}
+}
+
+/// Handle spent fees, deposit them as defined by R
+impl <
+	AssetId: Clone,
+	AssetLocation: From<MultiLocation> + Clone,
+	AssetIdInfoGetter: UnitsToWeightRatio<AssetId> + AssetIdLocationGetter<AssetId, AssetLocation>,
+	R: TakeRevenue,
+> Drop for FirstAssetTrader<AssetId, AssetLocation, AssetIdInfoGetter, R>
+{
+	fn drop(&mut self) {
+		if let Some((id, amount, _)) = self.1.clone() {
+			R::take_revenue((id, amount).into());
+		}	
+	}
+}
+
+/// XCM fee depositor to which we implement the TakeRevenue trait
+/// It receives a fungibles::Mutate implemented argument, a matcher to convert MultiAsset into
+/// AssetId and amount, and the fee receiver account
+pub struct XcmFeesToAccount<Assets, Matcher, AccountId, ReceiverAccount>(
+	PhantomData<(Assets, Matcher, AccountId, ReceiverAccount)>,
+);
+impl<
+		Assets: Mutate<AccountId>,
+		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
+		AccountId: Clone,
+		ReceiverAccount: Get<AccountId>,
+	> TakeRevenue for XcmFeesToAccount<Assets, Matcher, AccountId, ReceiverAccount>
+{
+	fn take_revenue(revenue: MultiAsset) {
+		match Matcher::matches_fungibles(&revenue) {
+			Ok((asset_id, amount)) => {
+				if !amount.is_zero() {
+					let ok = Assets::mint_into(asset_id, &ReceiverAccount::get(), amount).is_ok();
+					debug_assert!(ok, "`mint_into` cannot generally fail; qed");
+				}
+			}
+			Err(_) => log::debug!(
+				target: "xcm",
+				"take revenue failed matching fungible"
+			),
 		}
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

This should be merged after #371 

Manta Assets and XCM Implementation. 

- Introducing `manta-asset-manager` for asset management, i.e. creating and change asset
- create XCM related utilities 

Note: This code is intentionally based on `0.9.12` (for now), for easy testing with Moonbeam. 

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
