### PR TITLE
[manta] Bump client and runtime versions to v3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Pending
 
+## v3.1.3
+### Breaking changes
+
+### Features
+
+### Improvements
+- Bump spec version to **3130**.
+- [\#359](https://github.com/Manta-Network/Manta/pull/359) Update upstream dependencies to v0.9.15.
+- [\#337](https://github.com/Manta-Network/Manta/pull/337) Add a congested_chain_simulation test in Calamari.
+- [\#341](https://github.com/Manta-Network/Manta/pull/341) Create Release Checklist Issue Template.
+- [\#350](https://github.com/Manta-Network/Manta/pull/350) Setting minValidatorCount to a default value on runtime upgrade.
+
+### Bug fixes
+
 ## v3.1.2
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "calamari-runtime"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "calamari-vesting",
  "cumulus-pallet-aura-ext",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "calamari-vesting"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "manta"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "async-trait",
  "calamari-runtime",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "manta-collator-selection"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "manta-primitives"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "parity-scale-codec",
  "smallvec",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "manta-runtime"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tx-pause"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'manta'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.1.2'
+version = '3.1.3'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -7,7 +7,7 @@ license     = 'GPL-3.0'
 name        = 'manta-collator-selection'
 readme      = 'README.md'
 repository  = 'https://github.com/Manta-Network/Manta/'
-version     = '3.1.2'
+version     = '3.1.3'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/pallet-tx-pause/Cargo.toml
+++ b/pallets/pallet-tx-pause/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors    = ['Manta Network']
 name       = "pallet-tx-pause"
-version    = '3.1.2'
+version    = '3.1.3'
 edition    = "2021"
 homepage   = 'https://manta.network'
 license    = 'GPL-3.0'

--- a/pallets/vesting/Cargo.toml
+++ b/pallets/vesting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors    = ['Manta Network']
 name       = "calamari-vesting"
-version    = '3.1.2'
+version    = '3.1.3'
 edition    = "2021"
 homepage   = 'https://manta.network'
 license    = 'GPL-3.0'

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'calamari-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.1.2'
+version = '3.1.3'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("calamari"),
 	impl_name: create_runtime_str!("calamari"),
 	authoring_version: 1,
-	spec_version: 3120,
+	spec_version: 3130,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/manta/Cargo.toml
+++ b/runtime/manta/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'manta-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.1.2'
+version = '3.1.3'
 
 [dependencies]
 smallvec = "1.6.1"

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("manta"),
 	impl_name: create_runtime_str!("manta"),
 	authoring_version: 1,
-	spec_version: 3120,
+	spec_version: 3130,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/primitives/Cargo.toml
+++ b/runtime/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ['Manta Network']
 name = "manta-primitives"
-version = '3.1.2'
+version = '3.1.3'
 edition = "2021"
 homepage = 'https://manta.network'
 license = 'GPL-3.0'


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #368

* Bump client and runtime versions for release v3.1.3
* Update Changelog
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
