### PR TITLE
[manta] Dziabko/dolphin ci workflows

### DIFF
--- a/.github/workflows/generate_dolphin_weights_files.yml
+++ b/.github/workflows/generate_dolphin_weights_files.yml
@@ -107,14 +107,6 @@ jobs:
           -
             extrinsic:
               id: '*'
-              name: calamari_vesting
-            pallet:
-              id: calamari_vesting
-              name: calamari_vesting
-            iterations: 20
-          -
-            extrinsic:
-              id: '*'
               name: frame_system
             pallet:
               id: frame_system

--- a/.github/workflows/generate_dolphin_weights_files.yml
+++ b/.github/workflows/generate_dolphin_weights_files.yml
@@ -1,0 +1,291 @@
+---
+
+# yamllint disable rule:line-length
+
+name: Benchmark Dolphin Runtime & Generate Weights Files
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+env:
+  AWS_INSTANCE_SSH_PUBLIC_KEY: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+  AWS_REGION: us-east-1
+  AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
+  AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
+  AWS_INSTANCE_TYPE: r5dn.2xlarge
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
+  AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+  AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'  # canonical
+
+jobs:
+
+  build-benchmark:
+    needs:
+      - start-node-builder-current
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: install sccache
+
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      -
+        name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      -
+        name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      -
+        name: start sccache server
+        run: sccache --start-server
+      -
+        name: init
+        run: |
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup toolchain install stable
+          rustup toolchain install nightly
+          rustup default stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
+          rustup update
+      -
+        name: build
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 2G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+          CARGO_TERM_COLOR: always
+        run: |
+          source ${HOME}/.cargo/env
+          CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C codegen-units=1" cargo build --release --verbose --features=runtime-benchmarks
+      -
+        name: stop sccache server
+        run: sccache --stop-server || true
+      -
+        name: upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: manta
+          path: target/release/manta
+
+  run-benchmark:
+    name: benchmark (${{ matrix.benchmark.pallet.name }} ${{ matrix.benchmark.extrinsic.name }})
+    needs:
+      - start-node-builder-current
+      - build-benchmark
+    runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
+    strategy:
+      matrix:
+        benchmark:
+          -
+            extrinsic:
+              id: '*'
+              name: calamari_vesting
+            pallet:
+              id: calamari_vesting
+              name: calamari_vesting
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: frame_system
+            pallet:
+              id: frame_system
+              name: frame_system
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_balances
+            pallet:
+              id: pallet_balances
+              name: pallet_balances
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_collective
+            pallet:
+              id: pallet_collective
+              name: pallet_collective
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_democracy
+            pallet:
+              id: pallet_democracy
+              name: pallet_democracy
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_membership
+            pallet:
+              id: pallet_membership
+              name: pallet_membership
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_multisig
+            pallet:
+              id: pallet_multisig
+              name: pallet_multisig
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_scheduler
+            pallet:
+              id: pallet_scheduler
+              name: pallet_scheduler
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_session
+            pallet:
+              id: pallet_session
+              name: pallet_session
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_tx_pause
+            pallet:
+              id: pallet_tx_pause
+              name: pallet_tx_pause
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_utility
+            pallet:
+              id: pallet_utility
+              name: pallet_utility
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_timestamp
+            pallet:
+              id: pallet_timestamp
+              name: pallet_timestamp
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: pallet_treasury
+            pallet:
+              id: pallet_treasury
+              name: pallet_treasury
+            iterations: 20
+          -
+            extrinsic:
+              id: '*'
+              name: manta_collator_selection
+            pallet:
+              id: manta_collator_selection
+              name: manta_collator_selection
+            iterations: 20
+    steps:
+      -
+        uses: actions/download-artifact@v2
+        with:
+          name: manta
+      -
+        run: |
+          mv manta $HOME/.local/bin/
+          chmod +x $HOME/.local/bin/manta
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      -
+        name: run benchmark
+        run: |
+          manta benchmark \
+            --chain=dolphin-dev \
+            --pallet=${{ matrix.benchmark.pallet.id }} \
+            --extrinsic=${{ matrix.benchmark.extrinsic.id }} \
+            --execution=Wasm \
+            --wasm-execution=Compiled \
+            --heap-pages=4096 \
+            --repeat=${{ matrix.benchmark.iterations }} \
+            --steps=50 \
+            --template=.github/resources/frame-weight-template.hbs \
+            --output=${{ matrix.benchmark.pallet.name }}.rs
+      -
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.benchmark.pallet.id }}-${{ matrix.benchmark.pallet.name }}.rs
+          path: ${{ github.workspace }}/${{ matrix.benchmark.pallet.name }}.rs
+
+  start-node-builder-current:
+    runs-on: ubuntu-20.04
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ${{ env.AWS_INSTANCE_SSH_PUBLIC_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-subnet-id: ${{ env.AWS_SUBNET_ID }}
+          aws-security-group-id: ${{ env.AWS_SECURITY_GROUP_ID }}
+          aws-instance-type: ${{ env.AWS_INSTANCE_TYPE }}  # 32 vcpu, 64gb ram, $1.392 hourly
+          aws-instance-root-volume-size: 32
+          aws-image-search-pattern: ${{ env.AWS_IMAGE_SEARCH_PATTERN }}
+          aws-image-search-owners: ${{ env.AWS_IMAGE_SEARCH_OWNERS }}  # canonical
+
+  stop-node-builder-current:
+    needs:
+      - start-node-builder-current
+      - run-benchmark
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-node-builder-current.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder-current.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder-current.outputs.aws-instance-id }}
+
+# yamllint enable rule:line-length

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -53,6 +53,8 @@ jobs:
             name: calamari
           -
             name: manta
+          -
+            name: dolphin
     steps:
       -
         uses: actions/checkout@v2
@@ -768,6 +770,8 @@ jobs:
             name: calamari
           -
             name: manta
+          -
+            name: dolphin
     if: startsWith(github.ref, 'refs/tags')
     steps:
       -
@@ -1129,6 +1133,8 @@ jobs:
             name: calamari
           -
             name: manta
+          -
+            name: dolphin
     outputs:
       calamari-runtime-current: ${{ steps.get-runtime-current.outputs.calamari-runtime-current }}
       calamari-runtime-base: ${{ steps.get-runtime-base.outputs.calamari-runtime-base }}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a new dolphin runtime CI workflow

closes: #376 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
