### PR TITLE
Add to-do item to update CHANGELOG.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ write a little note why.
 - [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
 - [ ] Wrote unit tests.
 - [ ] Updated relevant documentation in the code.
+- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
 - [ ] Re-reviewed `Files changed` in the Github PR explorer.
 - [ ] If runtime changes, need to update the version numbers properly:
    * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.


### PR DESCRIPTION
as noted here: https://github.com/Manta-Network/Manta/pull/407#issuecomment-1045343519

every PR should add a line describing its changes to the CHANGELOG.md file.
This just adds a reminder to the PR template

It also removes a trailing space mistakenly checked in