### PR TITLE
[manta] Fix CI integration test false negatives

### DIFF
--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -750,6 +750,8 @@ jobs:
         name: check if target block is finalized
         run: |
           cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
+          yarn install
+          yarn
           node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
           echo $?
           if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -749,7 +749,7 @@ jobs:
       -
         name: check if target block is finalized
         run: |
-          cd ${{ github.workspace }}/dev-tools/check-finalized-block
+          cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
           node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
           echo $?
           if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -747,9 +747,12 @@ jobs:
         run: |
           grep '\[Parachain\] 💤 Idle (${{ matrix.chain-spec.expected.peer-count.para }} peers)' ${{ github.workspace }}/manta-pc-launch/9921.log
       -
-        name: test - calamari alice finalized block ${{ matrix.chain-spec.expected.block-count.para }}
+        name: check if target block is finalized
         run: |
-          grep '\[Parachain\] .* finalized #${{ matrix.chain-spec.expected.block-count.para }} ' ${{ github.workspace }}/manta-pc-launch/9921.log
+          cd ${{ github.workspace }}/dev-tools/check-finalized-block
+          node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
+          echo $?
+          if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi
 
   build-changelog:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -654,6 +654,15 @@ jobs:
           # todo: implement moonbeam-like js test suite triggers here
           sleep 300
       -
+        name: check if target block is finalized
+        run: |
+          cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
+          yarn install
+          yarn
+          node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
+          echo $?
+          if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi
+      -
         name: stop testnet
         run: |
           cd ${{ github.workspace }}/manta-pc-launch
@@ -746,15 +755,6 @@ jobs:
         name: test - calamari alice peered successfully
         run: |
           grep '\[Parachain\] 💤 Idle (${{ matrix.chain-spec.expected.peer-count.para }} peers)' ${{ github.workspace }}/manta-pc-launch/9921.log
-      -
-        name: check if target block is finalized
-        run: |
-          cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
-          yarn install
-          yarn
-          node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
-          echo $?
-          if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi
 
   build-changelog:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #420

* Our CI integration test frequently failed because it relied on parsing a specific finalized block, for example block 6. However in some cases blocks are finalized but not logged. Their finalization is implied from succeeding finalized blocks. So in those cases our old test would fail.
* The fix is a simple tool to query the chain state directly instead of parsing logs. It succeeds if the block is more than or equal to the specified target block https://github.com/Manta-Network/Dev-Tools/tree/main/check-finalized-block

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If needed, bump `version` for every crate.
- [x] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
- [x] Check if inheriting any upstream runtime storage migrations. If any, perform tests with `try-runtime`.
