### PR TITLE
[MANTA] : steps to sign DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -22,18 +22,29 @@ jobs:
         uses: tim-actions/dco@master
         with:
           commits: "${{ steps.get-pr-commits.outputs.commits }}"
-      -
-        name: "Check Failure Resolution Steps"
-        if: ${{ failure() }}
-        run: |
-          echo -e "Please follow the steps to resolve the issue: \n
-          $ git config --global user.name 'your_name' \n
-          $ git config --global user.email 'you_email' \n
-          That is  it. \n
-          Git will add the correct paragraph at the end of the your commit message. \n
-          COMMAND: $ git commit -s -S -m 'your_commit_message' \n
-          '-s' = 'Signed-off-by' \n
-          '-S' = 'Verify commit using gpg key' \n
-          ALL COMMITS MUST BE SIGNED"
-          echo -e "How to sign the PR using gpg key ?"
-          echo -e 'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits\'
+  run_if_failure:
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    needs: [commits_check_job]
+    name: Follow steps to sign Developer Certificate of Origin
+    steps:
+      - uses: mshick/add-pr-comment@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            "Please follow the steps to resolve the issue
+             ` $ git config --global user.name 'your_name' `
+             ` $ git config --global user.email 'you_email' `
+             - That is  it. Git will add the correct paragraph at the end of your commit message.
+             - **COMMAND** : ` $ git commit -s -S -m 'your_commit_message' `
+             '-s' = 'Signed-off-by'
+             '-S' = 'Verify commit using gpg key'
+             - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+             ` $ git rebase --signoff HEAD^^ `
+             - Write ` ^ ` as many times as there are commits in your pull request. Then, force push:
+             ` $ git push -f origin <your branch here, probably "master"> `
+             - **ALL COMMITS MUST BE SIGNED**
+             - How to sign the PR using gpg key ?
+               - 'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits'"
+          allow-repeats: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -33,18 +33,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            "Please follow the steps to resolve the issue
-             ` $ git config --global user.name 'your_name' `
-             ` $ git config --global user.email 'you_email' `
-             - That is  it. Git will add the correct paragraph at the end of your commit message.
-             - **COMMAND** : ` $ git commit -s -S -m 'your_commit_message' `
-             '-s' = 'Signed-off-by'
-             '-S' = 'Verify commit using gpg key'
-             - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
-             ` $ git rebase --signoff HEAD^^ `
-             - Write ` ^ ` as many times as there are commits in your pull request. Then, force push:
-             ` $ git push -f origin <your branch here, probably "master"> `
-             - **ALL COMMITS MUST BE SIGNED**
-             - How to sign the PR using gpg key ?
-               - 'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits'"
+            "
+            ```
+            Please follow the steps to resolve the Developer's Certificate of Origin:
+            1. Signoff on all commits with your name and email:
+              $ git config --global user.name 'your_name'
+              $ git config --global user.email 'you_email'
+              That is it. Git will add the correct paragraph at the end of your commit message.
+              COMMAND : $ git commit -s -S -m 'your_commit_message'
+              '-s' = 'Signed-off-by'
+              '-S' = 'Verify commit using gpg key'
+            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+              $ git rebase --signoff HEAD^^
+              Write ^ as many times as there are commits in your pull request. Then, force push:
+              $ git push -f origin <your branch here, probably "master">
+            2. Sign all commits with a gpg signature for verification:
+              https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+            ```
+            "
           allow-repeats: true


### PR DESCRIPTION
Signed-off-by: rishabhfsd <rishabhfsd@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #362 
```
Please follow the steps to resolve the Developer's Certificate of Origin:

1. Signoff on all commits with your name and email:
    $ git config --global user.name 'your_name'
    $ git config --global user.email 'you_email'
    
    That is it. Git will add the correct paragraph at the end of your commit message.
    COMMAND : $ git commit -s -S -m 'your_commit_message'
    '-s' = 'Signed-off-by'
    '-S' = 'Verify commit using gpg key'
   
  - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
    $ git rebase --signoff HEAD^^
    Write ^ as many times as there are commits in your pull request. Then, force push:
    $ git push -f origin <your branch here, probably "master">

2. Sign all commits with a gpg signature for verification:
   https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If needed, bump `version` for every crate.
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
- [ ] Check if inheriting any upstream runtime storage migrations. If any, perform tests with `try-runtime`.
