### PR TITLE
Instructions for DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -42,7 +42,7 @@ jobs:
               COMMAND : `git commit -s -S -m your_commit_message`
               '-s' = 'Signed-off-by'
               '-S' = 'Verify commit using gpg key'
-              If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+              If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
                `git rebase --signoff HEAD^^`
               Write ^ as many times as there are commits in your pull request. Then, force push:
                `git push -f origin <your branch here, probably "master">`

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -34,17 +34,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            Please follow the following steps to sign the Developer's Certificate of Origin:
+            Please follow the below instruction to signoff the Developer's Certificate of Origin and verify your identity:
             1. Signoff on all commits with your name and email:
-              $ git config --global user.name 'your_name'
-              $ git config --global user.email 'you_email'
+               `git config --global user.name your_name`
+               `git config --global user.email you_email`
               Git will add the correct paragraph at the end of your commit message.
-              COMMAND : $ git commit -s -S -m 'your_commit_message'
+              COMMAND : `git commit -s -S -m your_commit_message`
               '-s' = 'Signed-off-by'
               '-S' = 'Verify commit using gpg key'
-            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
-              $ git rebase --signoff HEAD^^
+              If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+               `git rebase --signoff HEAD^^`
               Write ^ as many times as there are commits in your pull request. Then, force push:
-              $ git push -f origin <your branch here, probably "master">
+               `git push -f origin <your branch here, probably "master">`
             2. Sign all commits with a gpg key for verification:
               https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -34,17 +34,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            Please follow the below instruction to signoff the Developer's Certificate of Origin and verify your identity:
-            1. Signoff on all commits with your name and email:
+            Please signoff on all commits with your name, email and (gpg key)[https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits] for the Developer's Certificate of Origin:
                `git config --global user.name your_name`
                `git config --global user.email you_email`
               Git will add the correct paragraph at the end of your commit message.
               COMMAND : `git commit -s -S -m your_commit_message`
-              '-s' = 'Signed-off-by'
-              '-S' = 'Verify commit using gpg key'
+              `-s` = `Signed-off-by`
+              `-S` = `Verify commit using gpg key`
               If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
-               `git rebase --signoff HEAD^^`
-              Write ^ as many times as there are commits in your pull request. Then, force push:
-               `git push -f origin <your branch here, probably "master">`
-            2. Sign all commits with a gpg key for verification:
-              https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+               `git rebase --signoff HEAD~<number_of_commits>` 
+               Then, force push:
+               `git push -f origin <your_branch>`

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -44,7 +44,7 @@ jobs:
               COMMAND : $ git commit -s -S -m 'your_commit_message'
               '-s' = 'Signed-off-by'
               '-S' = 'Verify commit using gpg key'
-            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
               $ git rebase --signoff HEAD^^
               Write ^ as many times as there are commits in your pull request. Then, force push:
               $ git push -f origin <your branch here, probably "master">

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -34,13 +34,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            Please signoff on all commits with your name, email and (gpg key)[https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits] for the Developer's Certificate of Origin:
-               `git config --global user.name your_name`
-               `git config --global user.email you_email`
-              COMMAND : `git commit -s -S -m your_commit_message`
-              `-s` = `Signed-off-by`
-              `-S` = `Verify commit using gpg key`
-              If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
+            Please signoff on all commits with your name, email and gpg key for the Developer's Certificate of Origin.
+                `git config --global user.name your_name`
+                `git config --global user.email you_email`
+            COMMAND : `git commit -s -S -m your_commit_message`
+                `-s` = `Signed-off-by`
+                `-S` = `Verify commit using gpg key`
+            If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
                `git rebase --signoff HEAD~<number_of_commits>` 
-               Then, force push:
+            Then, force push:
                `git push -f origin <your_branch>`
+            For instructions on managing gpg signature verification please visit: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -22,18 +22,34 @@ jobs:
         uses: tim-actions/dco@master
         with:
           commits: "${{ steps.get-pr-commits.outputs.commits }}"
-      -
-        name: "Check Failure Resolution Steps"
-        if: ${{ failure() }}
-        run: |
-          echo -e "Please follow the steps to resolve the issue: \n
-          $ git config --global user.name 'your_name' \n
-          $ git config --global user.email 'you_email' \n
-          That is  it. \n
-          Git will add the correct paragraph at the end of the your commit message. \n
-          COMMAND: $ git commit -s -S -m 'your_commit_message' \n
-          '-s' = 'Signed-off-by' \n
-          '-S' = 'Verify commit using gpg key' \n
-          ALL COMMITS MUST BE SIGNED"
-          echo -e "How to sign the PR using gpg key ?"
-          echo -e 'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits\'
+
+  run_if_failure:
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    needs: [commits_check_job]
+    name: Follow steps to sign Developer Certificate of Origin
+    steps:
+      - uses: mshick/add-pr-comment@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            "
+            ```
+            Please follow the following steps to sign the Developer's Certificate of Origin:
+            1. Signoff on all commits with your name and email:
+              $ git config --global user.name 'your_name'
+              $ git config --global user.email 'you_email'
+              Git will add the correct paragraph at the end of your commit message.
+              COMMAND : $ git commit -s -S -m 'your_commit_message'
+              '-s' = 'Signed-off-by'
+              '-S' = 'Verify commit using gpg key'
+            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
+              $ git rebase --signoff HEAD^^
+              Write ^ as many times as there are commits in your pull request. Then, force push:
+              $ git push -f origin <your branch here, probably "master">
+            2. Sign all commits with a gpg key for verification:
+              https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+            ```
+            "
+

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -41,7 +41,7 @@ jobs:
                 `-s` = `Signed-off-by`
                 `-S` = `Verify commit using gpg key`
             If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
-               `git rebase --signoff HEAD~<number_of_commits>` 
+               `git rebase --signoff HEAD~<number_of_commits>`
             Then, force push:
                `git push -f origin <your_branch>`
             For instructions on managing gpg signature verification please visit: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -34,8 +34,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            "
-            ```
             Please follow the following steps to sign the Developer's Certificate of Origin:
             1. Signoff on all commits with your name and email:
               $ git config --global user.name 'your_name'
@@ -44,12 +42,9 @@ jobs:
               COMMAND : $ git commit -s -S -m 'your_commit_message'
               '-s' = 'Signed-off-by'
               '-S' = 'Verify commit using gpg key'
-            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
+            - If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff
               $ git rebase --signoff HEAD^^
               Write ^ as many times as there are commits in your pull request. Then, force push:
               $ git push -f origin <your branch here, probably "master">
             2. Sign all commits with a gpg key for verification:
               https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
-            ```
-            "
-

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -37,7 +37,6 @@ jobs:
             Please signoff on all commits with your name, email and (gpg key)[https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits] for the Developer's Certificate of Origin:
                `git config --global user.name your_name`
                `git config --global user.email you_email`
-              Git will add the correct paragraph at the end of your commit message.
               COMMAND : `git commit -s -S -m your_commit_message`
               `-s` = `Signed-off-by`
               `-S` = `Verify commit using gpg key`

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -659,7 +659,7 @@ jobs:
           cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
           yarn install
           yarn
-          node index.js --para_address=ws://127.0.0.1:9921 --relay_address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
+          node index.js --para_address=ws://127.0.0.1:9921 --relay_address=ws://127.0.0.1:9911 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
           echo $?
           if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi
       -

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -659,7 +659,7 @@ jobs:
           cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
           yarn install
           yarn
-          node index.js --address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
+          node index.js --para_address=ws://127.0.0.1:9921 --relay_address=ws://127.0.0.1:9921 --target_block=${{ matrix.chain-spec.expected.block-count.para }}
           echo $?
           if [ $? == 1 ]; then echo "Failed to finalize the target block - ${{ matrix.chain-spec.expected.block-count.para }}"; exit 1; fi
       -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to Manta Network
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to the Manta Network codebase. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for Manta Network. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+* **Perform a cursory search in the Manta Network organization to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). 
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact network configuraiton** include parachain node version, relay chain node version and any tooling you may be using, such as polkadot-launch and its configurations.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started the Manta node, e.g. which command exactly you used in the terminal, how you started the relay chain, etc.
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots or video** if possible.
+* **If the problem is related to performance or memory**, include a CPU profile capture.
+* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened.
+
+Furthermore, provide more context by answering these questions:
+
+* **Did the problem start happening recently** (e.g. after updating to a new version of Manta/Calamari) or was this always a problem?
+* If the problem started happening recently, **can you reproduce the problem in an older version of Manta/Calamari?** What's the most recent version in which the problem doesn't happen? You can download older versions from [the releases page](https://github.com/Manta-Network/Manta/releases).
+* **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+
+### Always include details about your configuration and environment
+
+* **Are you working with the Manta/Calamari mainnets or have you depoloyed locally**
+* **Wich version of Manta/Calamari are you using?**
+* **What relay chain and version are you using?**
+* **What's the name and version of the OS you're using**?
+* **Are you running Manta/Calamari with Docker?** 
+* **Did you compile the code on your own?** and if so, what compiler and version did you use?
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Manta/Calamari, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Before creating enhancement suggestions, please check the existing issues as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).  including the steps that you imagine you would take if the feature you're requesting existed.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).Create an issue on that repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots or video** which help you demonstrate the steps or point out the part of Manta/Calamari which the suggestion is related to.
+* **Explain why this enhancement would be useful** to most Manta users.
+* **List some other places where this enhancement exists.**
+
+### Pull Requests
+
+The process described here has several goals:
+
+- Maintain code quality
+- Fix problems that are important to users
+- Engage the community in working toward the best possible Manta
+- Enable a sustainable system for Manta's maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Every commit needs to be signed-off with your name, email and [gpg key](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits):
+    `git config --global user.name your_name`
+    `git config --global user.email you_email`
+    COMMAND : `git commit -s -S -m your_commit_message`
+    `-s` = `Signed-off-by`
+    `-S` = `Verify commit using gpg key`
+    If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
+    `git rebase --signoff HEAD~<number_of_commits>` Then, force push:
+    `git push -f origin <your_branch>`
+    
+2. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
+3. After you submit your pull request, verify that all CI checks are passing <details><summary>What if CI checks are failing?</summary>If a CI check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem.</details>
+4. If you have a significant design decision to make please document it as an ehancement request first, so we can review it and provide feedback before any code is written.
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+
+## Styleguides
+
+* We generally follow the [Rust styleguide](https://doc.rust-lang.org/1.0.0/style/).
+
+### Comments
+
+* Comments should focus more on the `why` instead of the `what` is the code.
+* Write comments on top of your code.
+
+### PR descriptions
+
+* Descriptions should link to issues with the keyword `closes #issue_number`
+* Descriptions should include a list of the new changes and why they were made.
+* Descriptions should include links to other relevant issues/pull requests.
+
+### Git Commit Messages
+
+* Write clear and concise commit messages.
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Don't forget to sign your commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Please follow these steps to have your contribution considered by the maintainer
         * `-S` = `Verify commit using gpg key`
 2. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
 3. After you submit your pull request, verify that all CI checks are passing <details><summary>What if CI checks are failing?</summary>If a CI check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem.</details>
-4. If you have a significant design decision to make please document it as an ehancement request first, so we can review it and provide feedback before any code is written.
+4. If you have a significant design decision to make please document it as an enhancement request first, so we can review it and provide feedback before any code is written.
 
 While the prerequisites above should be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The following is a set of guidelines for contributing to the Manta Network codeb
 
 Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
-* **Perform a cursory search in the Manta Network organization to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+Perform a cursory **search in the Manta Network organization** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Manta Network
 
-First off, thanks for taking the time to contribute!
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
 The following is a set of guidelines for contributing to the Manta Network codebase. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
@@ -75,15 +75,11 @@ The process described here has several goals:
 Please follow these steps to have your contribution considered by the maintainers:
 
 1. Every commit needs to be signed-off with your name, email and [gpg key](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits):
-    `git config --global user.name your_name`
-    `git config --global user.email you_email`
-    COMMAND : `git commit -s -S -m your_commit_message`
-    `-s` = `Signed-off-by`
-    `-S` = `Verify commit using gpg key`
-    If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
-    `git rebase --signoff HEAD~<number_of_commits>` Then, force push:
-    `git push -f origin <your_branch>`
-    
+    1.1. `git config --global user.name your_name`
+    1.2. `git config --global user.email you_email`
+    1.3. `git commit -s -S -m your_commit_message`
+        * `-s` = `Signed-off-by`
+        * `-S` = `Verify commit using gpg key`
 2. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
 3. After you submit your pull request, verify that all CI checks are passing <details><summary>What if CI checks are failing?</summary>If a CI check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem.</details>
 4. If you have a significant design decision to make please document it as an ehancement request first, so we can review it and provide feedback before any code is written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
 * **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact network configuraiton** include parachain node version, relay chain node version and any tooling you may be using, such as polkadot-launch and its configurations.
+* **Describe the exact network configuration** include parachain node version, relay chain node version and any tooling you may be using, such as polkadot-launch and its configurations.
 * **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started the Manta node, e.g. which command exactly you used in the terminal, how you started the relay chain, etc.
 * **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
@@ -38,8 +38,8 @@ Furthermore, provide more context by answering these questions:
 
 ### Always include details about your configuration and environment
 
-* **Are you working with the Manta/Calamari mainnets or have you depoloyed locally**
-* **Wich version of Manta/Calamari are you using?**
+* **Are you working with the Manta/Calamari mainnets or have you deployed locally**
+* **Which version of Manta/Calamari are you using?**
 * **What relay chain and version are you using?**
 * **What's the name and version of the OS you're using**?
 * **Are you running Manta/Calamari with Docker?** 
@@ -53,7 +53,7 @@ Before creating enhancement suggestions, please check the existing issues as you
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).Create an issue on that repository and provide the following information:
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information:
 
 * **Use a clear and descriptive title** for the issue to identify the suggestion.
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
@@ -84,7 +84,7 @@ Please follow these steps to have your contribution considered by the maintainer
 3. After you submit your pull request, verify that all CI checks are passing <details><summary>What if CI checks are failing?</summary>If a CI check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem.</details>
 4. If you have a significant design decision to make please document it as an ehancement request first, so we can review it and provide feedback before any code is written.
 
-While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+While the prerequisites above should be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 
 ## Styleguides
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Manta Network
 
-:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+First off, thanks for taking the time to contribute!
 
 The following is a set of guidelines for contributing to the Manta Network codebase. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to the Manta Network codeb
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for Manta Network. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
 * **Perform a cursory search in the Manta Network organization to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #362

* If DCO check fails the instructions are commented in the PR , not just in the CI output:

Please signoff on all commits with your name, email and gpg key for the Developer's Certificate of Origin.
    `git config --global user.name your_name`
    `git config --global user.email you_email`
COMMAND : `git commit -s -S -m your_commit_message`
    `-s` = `Signed-off-by`
    `-S` = `Verify commit using gpg key`
If there is more than one commit in your pull request and your git client is modern enough (2.13+), rebase the required number of commits with --signoff:
   `git rebase --signoff HEAD~<number_of_commits>` 
Then, force push:
   `git push -f origin <your_branch>`
For instructions on managing gpg signature verification please visit: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

---

* Check the comments in the PR for actual example

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (`manta` or `dolphin`) with right title (start with [Manta] or [Dolphin]),
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] If needed, notify the committer this is a draft-release and a tag is needed after merging the PR.
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If needed, bump `version` for every crate.
- [x] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If we're going to issue a new release, freeze the code one week early(it depends, but usually it's one week), ensure we have enough time for related testing.
- [x] Check if inheriting any upstream runtime storage migrations. If any, perform tests with `try-runtime`.
