### PR TITLE
Add manual try-runtime test against Calamari mainnet

### DIFF
--- a/.github/workflows/try-runtime-calamari-mainnet.yml
+++ b/.github/workflows/try-runtime-calamari-mainnet.yml
@@ -1,0 +1,176 @@
+---
+
+# yamllint disable rule:line-length
+
+# The try-runtime tool expects your local chain's runtime version to match
+# the version of the chain that you're testing against. In this case Calamari mainnet.
+# That's why this CI workflow has a manual trigger.
+name: Execute try-runtime with latest Calamari mainnet state
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+env:
+  AWS_INSTANCE_SSH_PUBLIC_KEY: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPb24HEQ++aNFWaqVyMtIs6GotUB8R+q61XOoI2z6uMj
+  AWS_REGION: us-east-1
+  AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
+  AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
+  AWS_INSTANCE_TYPE: r5dn.2xlarge
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
+  AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
+  AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'  # canonical
+
+jobs:
+
+  build-node:
+    needs:
+      - start-node-builder
+    runs-on: ${{ needs.start-node-builder.outputs.runner-label }}
+    steps:
+      -
+        uses: actions/checkout@v2
+      -
+        name: install sccache
+
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      -
+        name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      -
+        name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      -
+        name: start sccache server
+        run: sccache --start-server
+      -
+        name: init
+        run: |
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup toolchain install stable
+          rustup toolchain install nightly
+          rustup default stable
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo +nightly install --git https://github.com/alexcrichton/wasm-gc --force
+          rustup update
+      -
+        name: build
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 2G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+          CARGO_TERM_COLOR: always
+        run: |
+          source ${HOME}/.cargo/env
+          cargo build --profile release --verbose --features=runtime-benchmarks
+      -
+        name: stop sccache server
+        run: sccache --stop-server || true
+      -
+        name: upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: manta
+          path: target/release/manta
+
+  run-try-runtime:
+    name: try-runtime
+    needs:
+      - start-node-builder
+      - build-node
+    runs-on: ${{ needs.start-node-builder.outputs.runner-label }}
+    strategy:
+      matrix:
+        runtime:
+          -
+            name: calamari
+    steps:
+      -
+        uses: actions/download-artifact@v2
+        with:
+          name: manta
+      -
+        run: |
+          mv manta $HOME/.local/bin/
+          chmod +x $HOME/.local/bin/manta
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      -
+        uses: actions/checkout@v2
+        with:
+          repository: Manta-Network/Dev-Tools
+          path: dev-tools-calamari
+      -
+        name: execute try-runtime
+        run: |
+          cd ${{ github.workspace }}/dev-tools-calamari/check-finalized-block
+          latest_hash=$(node get-latest-finalized-header-hash --address=wss://ws.calamari.systems:443)
+          $HOME/.local/bin/manta try-runtime --chain calamari-dev on-runtime-upgrade live --at $latest_hash --uri wss://ws.calamari.systems:443
+
+  start-node-builder:
+    runs-on: ubuntu-20.04
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      -
+        id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-instance-ssh-public-key: ${{ env.AWS_INSTANCE_SSH_PUBLIC_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-subnet-id: ${{ env.AWS_SUBNET_ID }}
+          aws-security-group-id: ${{ env.AWS_SECURITY_GROUP_ID }}
+          aws-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
+          aws-instance-root-volume-size: 32
+          aws-image-search-pattern: ${{ env.AWS_IMAGE_SEARCH_PATTERN }}
+          aws-image-search-owners: ${{ env.AWS_IMAGE_SEARCH_OWNERS }}  # canonical
+
+  stop-node-builder-current:
+    needs:
+      - start-node-builder
+      - build-node
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    steps:
+      -
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_SHR_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-node-builder.outputs.aws-region }}
+          runner-label: ${{ needs.start-node-builder.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-node-builder.outputs.aws-instance-id }}
+
+# yamllint enable rule:line-length


### PR DESCRIPTION
Signed-off-by: ghzlatarev <ghzlatarev@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #450 

* Created a manual CI workflow for `try-runtime` against Calamari mainnet `wss://ws.calamari.systems:443`
* It just calls the `try-runtime --chain calamari-dev on-runtime-upgrade live --at $latest_hash --uri wss://ws.calamari.systems:443` . Meaning it starts a local `calamari-dev` chain and populates it with scraped data from `wss://ws.calamari.systems:443`
* The reason it is manual is because the tool expects the local chain version to match the mainnets runtime version. So in order to not add a bunch of ifs to check if versions match, it can just be triggered manually from whatever branch the user decides.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
