### PR TITLE
dolphin v2 bootnodes

### DIFF
--- a/genesis/dolphin-testnet-genesis.json
+++ b/genesis/dolphin-testnet-genesis.json
@@ -2,7 +2,13 @@
   "name": "Dolphin Parachain Testnet",
   "id": "dolphin_testnet",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/dns/eddie.rococo.dolphin.engineering/tcp/30333/p2p/12D3KooWRPiKv8nJyNYYF4BXX318auddRVo9aUnBP7B1EPWNhEqF",
+    "/dns/kwaltz.rococo.dolphin.engineering/tcp/30333/p2p/12D3KooWApki85vevuLRLYGpcvVwbFibDDhZMD6VbDnxFN2F96Ga",
+    "/dns/prosser.rococo.dolphin.engineering/tcp/30333/p2p/12D3KooWMSS1M7C2x39gqbHQzag3mh5KkALcmyWFUfNnK1sZDMjF",
+    "/dns/roosta.rococo.dolphin.engineering/tcp/30333/p2p/12D3KooWFJwu9ZHXJn9ZiHWQ6Np2rGyobZtM6RhAsJ3eQjG6hU5i",
+    "/dns/zaphod.rococo.dolphin.engineering/tcp/30333/p2p/12D3KooWKgL2gERgp5749cWcdiAJaYZ1eHgYsMFq9663ixxjy6up"
+  ],
   "telemetryEndpoints": [
     [
       "/dns/api.telemetry.manta.systems/tcp/443/x-parity-wss/%2Fsubmit%2F",


### PR DESCRIPTION
## Description

adds dolphin (on rococo relay) bootnodes to allow for starting nodes on the default para/relay network without specifying `--bootnodes ...` in client binary start arguments.

for others working on this chainspec, below is the node and aura keys in use by the invulnerable collators which also double as the bootnodes.

```yaml
---
-
  cname: eddie.rococo.dolphin.engineering
  key:
    node:
      public: 12D3KooWRPiKv8nJyNYYF4BXX318auddRVo9aUnBP7B1EPWNhEqF
    aura:
      public:
        hex: 0xa262d065bbf88d4503babdc7a4f1069dee5d34480c2f61508f113d68ceb48626
        ss58: dmxc9USs4z5R1A8d1bCJAzBqVyt1fCng8n36LLK5RpYyUfzQg
-
  cname: kwaltz.rococo.dolphin.engineering
  key:
    node:
      public: 12D3KooWApki85vevuLRLYGpcvVwbFibDDhZMD6VbDnxFN2F96Ga
    aura:
      public:
        hex: 0x6e20fac2211beca05d11b10642399047694b46931dbe17c26405531fa3a5a25c
        ss58: dmwRdRiwfJ9sxa98AoK4sUudgjopPbHQyzmgf22vrMxQs1WW5
-
  cname: prosser.rococo.dolphin.engineering
  key:
    node:
      public: 12D3KooWMSS1M7C2x39gqbHQzag3mh5KkALcmyWFUfNnK1sZDMjF
    aura:
      public:
        hex: 0x127b12cf5884cb3a0dcd4f020d8e53d9e0364b2aa55f6f9514e216b4213ab46a
        ss58: dmuMTnVbVBS522eWjUeU7tMTBzx7omXX3YfVGxXwTqyUBR3aC
-
  cname: roosta.rococo.dolphin.engineering
  key:
    node:
      public: 12D3KooWFJwu9ZHXJn9ZiHWQ6Np2rGyobZtM6RhAsJ3eQjG6hU5i
    aura:
      public:
        hex: 0xf0ce48080ca5bd76883a050cca9a995b2427b1505b65e4899abb764c76aa7361
        ss58: dmzNy8hKUMgmei4Ui11nTCS3ZQd39ka2ierCWNWyabfZmKcgn
-
  cname: zaphod.rococo.dolphin.engineering
  key:
    node:
      public: 12D3KooWKgL2gERgp5749cWcdiAJaYZ1eHgYsMFq9663ixxjy6up
    aura:
      public:
        hex: 0x0ced09e42384df7e811273b0245c1123b640315789a90ceab3a11531a36cc359
        ss58: dmuEBMQPB8EmiWwbUq59GhqNHXSawwGn3prGZNu8hQpNyDVsD
```

