### PR TITLE
fix: move deserialization of manta-pay types into the extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,28 +4840,16 @@ dependencies = [
 [[package]]
 name = "manta-accounting"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
+source = "git+https://github.com/manta-network/manta-rs.git#a91d908da79e7fee0a3215945a73c7bb28f94641"
 dependencies = [
  "derivative",
  "derive_more",
- "futures 0.3.21",
  "indexmap",
- "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-crypto",
+ "manta-util",
  "parking_lot 0.12.0",
  "rand 0.8.5",
  "statrs",
-]
-
-[[package]]
-name = "manta-accounting"
-version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
-dependencies = [
- "derivative",
- "derive_more",
- "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs)",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs)",
 ]
 
 [[package]]
@@ -4894,27 +4882,17 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
+source = "git+https://github.com/manta-network/manta-rs.git#a91d908da79e7fee0a3215945a73c7bb28f94641"
 dependencies = [
  "derivative",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "manta-crypto"
-version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
-dependencies = [
- "derivative",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs)",
+ "manta-util",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "manta-pay"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
+source = "git+https://github.com/manta-network/manta-rs.git#16e142f7917cc61e6066d6896f1a75aa45a0569d"
 dependencies = [
  "aes-gcm",
  "ark-bls12-381",
@@ -4929,9 +4907,9 @@ dependencies = [
  "ark-std",
  "blake2 0.10.4",
  "derivative",
- "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
- "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-accounting",
+ "manta-crypto",
+ "manta-util",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
@@ -4945,7 +4923,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs)",
+ "manta-accounting",
  "parity-scale-codec",
  "scale-info",
  "smallvec",
@@ -5037,12 +5015,7 @@ dependencies = [
 [[package]]
 name = "manta-util"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
-
-[[package]]
-name = "manta-util"
-version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
+source = "git+https://github.com/manta-network/manta-rs.git#a91d908da79e7fee0a3215945a73c7bb28f94641"
 
 [[package]]
 name = "maplit"
@@ -6184,12 +6157,12 @@ dependencies = [
  "frame-system",
  "indoc",
  "lazy_static",
- "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
- "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-accounting",
+ "manta-crypto",
  "manta-pay",
  "manta-primitives",
  "manta-sdk",
- "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-util",
  "pallet-asset-manager",
  "pallet-assets",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -500,9 +500,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,7 +1245,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.6",
+ "semver 1.0.7",
  "serde",
  "serde_json",
 ]
@@ -3155,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -3414,9 +3414,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -3565,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -4693,18 +4693,19 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
@@ -4839,16 +4840,28 @@ dependencies = [
 [[package]]
 name = "manta-accounting"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git#8689e771de49d28dd52eba7658ce78330f799244"
+source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
 dependencies = [
  "derivative",
  "derive_more",
+ "futures 0.3.21",
  "indexmap",
- "manta-crypto",
- "manta-util",
+ "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
  "parking_lot 0.12.0",
  "rand 0.8.5",
  "statrs",
+]
+
+[[package]]
+name = "manta-accounting"
+version = "0.4.0"
+source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
+dependencies = [
+ "derivative",
+ "derive_more",
+ "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs)",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs)",
 ]
 
 [[package]]
@@ -4881,17 +4894,27 @@ dependencies = [
 [[package]]
 name = "manta-crypto"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git#8689e771de49d28dd52eba7658ce78330f799244"
+source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
 dependencies = [
  "derivative",
- "manta-util",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "manta-crypto"
+version = "0.4.0"
+source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
+dependencies = [
+ "derivative",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs)",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "manta-pay"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git#8689e771de49d28dd52eba7658ce78330f799244"
+source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
 dependencies = [
  "aes-gcm",
  "ark-bls12-381",
@@ -4906,9 +4929,9 @@ dependencies = [
  "ark-std",
  "blake2 0.10.4",
  "derivative",
- "manta-accounting",
- "manta-crypto",
- "manta-util",
+ "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
@@ -4922,7 +4945,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "manta-accounting",
+ "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs)",
  "parity-scale-codec",
  "scale-info",
  "smallvec",
@@ -5014,7 +5037,12 @@ dependencies = [
 [[package]]
 name = "manta-util"
 version = "0.4.0"
-source = "git+https://github.com/manta-network/manta-rs.git#8689e771de49d28dd52eba7658ce78330f799244"
+source = "git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api#c61271af6c79ed00b1e60289fa110da6c0535b6b"
+
+[[package]]
+name = "manta-util"
+version = "0.4.0"
+source = "git+https://github.com/manta-network/manta-rs#a91d908da79e7fee0a3215945a73c7bb28f94641"
 
 [[package]]
 name = "maplit"
@@ -5373,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -6156,12 +6184,12 @@ dependencies = [
  "frame-system",
  "indoc",
  "lazy_static",
- "manta-accounting",
- "manta-crypto",
+ "manta-accounting 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
+ "manta-crypto 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
  "manta-pay",
  "manta-primitives",
  "manta-sdk",
- "manta-util",
+ "manta-util 0.4.0 (git+https://github.com/manta-network/manta-rs.git?branch=convert-to-async-api)",
  "pallet-asset-manager",
  "pallet-assets",
  "pallet-balances",
@@ -6826,7 +6854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.6",
+ "lock_api 0.4.7",
  "parking_lot_core 0.8.5",
 ]
 
@@ -6836,8 +6864,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "lock_api 0.4.6",
- "parking_lot_core 0.9.1",
+ "lock_api 0.4.7",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -6863,29 +6891,29 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "smallvec",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "smallvec",
  "windows-sys",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pbkdf2"
@@ -8382,9 +8410,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -8455,7 +8483,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -8525,21 +8553,21 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.5",
- "redox_syscall 0.2.11",
+ "getrandom 0.2.6",
+ "redox_syscall 0.2.13",
  "thiserror",
 ]
 
@@ -8868,7 +8896,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.6",
+ "semver 1.0.7",
 ]
 
 [[package]]
@@ -10021,9 +10049,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]
@@ -11233,9 +11261,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11275,7 +11303,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -12419,9 +12447,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -12432,33 +12460,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/pallets/manta-pay/Cargo.toml
+++ b/pallets/manta-pay/Cargo.toml
@@ -67,24 +67,24 @@ scale-codec = { package = "parity-scale-codec", version = "2.3.1", default-featu
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
 # manta dependencies
-manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
-manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
-manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "scale"] }
+manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
+manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
+manta-pay = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false, features = ["groth16", "scale"] }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", default-features = false }
-manta-util = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
+manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
 manta-primitives = { path = "../../primitives", default-features = false}
 
 [dev-dependencies]
 bencher = "0.1.5"
 criterion = "0.3.4"
 lazy_static = "1.4.0"
-manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", features = ["test"] }
+manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", features = ["test"] }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16"}
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16"}
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-assets = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-asset-manager = { path = "../asset-manager"}
-manta-util = { git = "https://github.com/manta-network/manta-rs.git"}
+manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api" }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", features = ["download"] }
 tempfile = "3.3.0"
 rand = "0.8.4"

--- a/pallets/manta-pay/Cargo.toml
+++ b/pallets/manta-pay/Cargo.toml
@@ -84,7 +84,7 @@ sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkado
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-assets = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-asset-manager = { path = "../asset-manager"}
-manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api" }
+manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", features = ["std"] }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", features = ["download"] }
 tempfile = "3.3.0"
 rand = "0.8.4"

--- a/pallets/manta-pay/Cargo.toml
+++ b/pallets/manta-pay/Cargo.toml
@@ -67,24 +67,24 @@ scale-codec = { package = "parity-scale-codec", version = "2.3.1", default-featu
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
 # manta dependencies
-manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
-manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
-manta-pay = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false, features = ["groth16", "scale"] }
+manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
+manta-crypto = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
+manta-pay = { git = "https://github.com/manta-network/manta-rs.git", default-features = false, features = ["groth16", "scale"] }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", default-features = false }
-manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", default-features = false }
+manta-util = { git = "https://github.com/manta-network/manta-rs.git", default-features = false }
 manta-primitives = { path = "../../primitives", default-features = false}
 
 [dev-dependencies]
 bencher = "0.1.5"
 criterion = "0.3.4"
 lazy_static = "1.4.0"
-manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", features = ["test"] }
+manta-accounting = { git = "https://github.com/manta-network/manta-rs.git", features = ["test"] }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16"}
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16"}
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-assets = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-asset-manager = { path = "../asset-manager"}
-manta-util = { git = "https://github.com/manta-network/manta-rs.git", branch = "convert-to-async-api", features = ["std"] }
+manta-util = { git = "https://github.com/manta-network/manta-rs.git", features = ["std"] }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", features = ["download"] }
 tempfile = "3.3.0"
 rand = "0.8.4"

--- a/pallets/manta-pay/src/benchmark/mod.rs
+++ b/pallets/manta-pay/src/benchmark/mod.rs
@@ -24,8 +24,8 @@ use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_call
 use frame_system::RawOrigin;
 use manta_primitives::{
 	assets::{AssetConfig, AssetRegistrar, FungibleLedger},
-	types::{AssetId, Balance},
 	constants::DEFAULT_ASSET_ED,
+	types::{AssetId, Balance},
 };
 use scale_codec::Decode;
 
@@ -50,11 +50,18 @@ where
 {
 	let metadata = <T::AssetConfig as AssetConfig>::AssetRegistrarMetadata::default();
 	let storage_metadata: <T::AssetConfig as AssetConfig>::StorageMetadata = metadata.into();
-	<T::AssetConfig as AssetConfig>::AssetRegistrar::create_asset(id, DEFAULT_ASSET_ED, storage_metadata, true)
-		.unwrap();
+	<T::AssetConfig as AssetConfig>::AssetRegistrar::create_asset(
+		id,
+		DEFAULT_ASSET_ED,
+		storage_metadata,
+		true,
+	)
+	.expect("Unable to create asset.");
 	let pallet_account: T::AccountId = Pallet::<T>::account_id();
-	T::FungibleLedger::mint(id, &owner, value + DEFAULT_ASSET_ED).unwrap();
-	T::FungibleLedger::mint(id, &pallet_account, DEFAULT_ASSET_ED).unwrap();
+	T::FungibleLedger::mint(id, owner, value + DEFAULT_ASSET_ED)
+		.expect("Unable to mint asset to its new owner.");
+	T::FungibleLedger::mint(id, &pallet_account, DEFAULT_ASSET_ED)
+		.expect("Unable to mint existential deposit to pallet account.");
 }
 
 benchmarks! {
@@ -68,7 +75,7 @@ benchmarks! {
 		RawOrigin::Signed(caller.clone()),
 		mint_post
 	) verify {
-		assert_last_event::<T, _>(Event::ToPrivate { asset, source: caller.clone() });
+		assert_last_event::<T, _>(Event::ToPrivate { asset, source: caller });
 		// FIXME: add balance checking
 		// assert_eq!(Balances::<T>::get(caller, asset.id), 1_000_000 - asset.value);
 	}

--- a/pallets/manta-pay/src/mock.rs
+++ b/pallets/manta-pay/src/mock.rs
@@ -193,7 +193,7 @@ impl FungibleLedger<Test> for MantaFungibleLedger {
 			<Assets as AssetTransfer<<Test as frame_system::Config>::AccountId>>::transfer(
 				asset_id, source, dest, amount, true,
 			)
-			.and_then(|_| Ok(()))
+			.map(|_| ())
 			.map_err(|_| FungibleLedgerConsequence::InternalError)
 		}
 	}
@@ -218,7 +218,7 @@ impl FungibleLedger<Test> for MantaFungibleLedger {
 				beneficiary.clone(),
 				amount,
 			)
-			.and_then(|_| Ok(()))
+			.map(|_| ())
 			.map_err(|_| FungibleLedgerConsequence::InternalError)
 		}
 	}

--- a/pallets/manta-pay/src/test/payment.rs
+++ b/pallets/manta-pay/src/test/payment.rs
@@ -35,7 +35,8 @@ use manta_pay::config::{
 };
 use manta_primitives::{
 	assets::{AssetRegistrar, AssetRegistrarMetadata, FungibleLedger},
-	constants::DEFAULT_ASSET_ED};
+	constants::DEFAULT_ASSET_ED,
+};
 use manta_util::codec::{Decode, IoReader};
 use rand::thread_rng;
 use std::fs::File;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -35,9 +35,9 @@ pub mod helpers;
 /// Usage:
 /// ```Rust
 /// parameter_types! {
-///     //Note that the env variable version parameter cannot be const.
-/// 	pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1, "KSM_LAUNCH_PERIOD");
-/// 	pub const VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES);
+///     // Note that the env variable version parameter cannot be const.
+///     pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1, "KSM_LAUNCH_PERIOD");
+///     pub const VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES);
 /// }
 #[macro_export]
 macro_rules! prod_or_fast {

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -1191,7 +1191,7 @@ construct_runtime!(
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>} = 42,
 
 		// Asset and Private Payment
-		Assets: pallet_assets::{Pallet, Storage, Event<T>} = 45,
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 45,
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>} = 46,
 		MantaPay: pallet_manta_pay::{Pallet, Call, Storage, Event<T>} = 47,
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Unfortunately, there is an error during SCALE deserialization of the custom arkworks types for the manta-pay pallet. For now, the workaround is to move the deserialization into the extrinsic calls instead of having the RPC code perform the deserialization ahead of time. **NB: This is a temporary fix and will need to be resolved at some point.**

DEPENDS ON: https://github.com/Manta-Network/manta-rs/pull/42

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.