### PR TITLE
Set the version of feature resolver as `2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 
 [workspace]
+resolver = "2"
 members = [
 	'node',
 	'pallets/*',

--- a/pallets/manta-pay/Cargo.toml
+++ b/pallets/manta-pay/Cargo.toml
@@ -44,6 +44,7 @@ std = [
 precompute-coins = [
 	"anyhow",
 	"indoc",
+	"manta-accounting/test",
 	"manta-sdk/download",
 	"manta-util/std",
 	"rand",
@@ -84,7 +85,6 @@ sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkado
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-assets = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 pallet-asset-manager = { path = "../asset-manager"}
-manta-util = { git = "https://github.com/manta-network/manta-rs.git", features = ["std"] }
 manta-sdk = { git = "https://github.com/manta-network/sdk.git", features = ["download"] }
 tempfile = "3.3.0"
 rand = "0.8.4"


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

In rust 2021, it's enabled by default if the top level of `Cargo.toml` contains the field `edition    = "2021"`.
But our project is organized by `workspace`, it's `1`.
So we have to explicitly configure it.

How many crates will be compiled?
Before -> After
```
M1 Mac: 1193 -> 1182
Linux amd64: 1193 -> 1172
```

I think it will save some time on compilation.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
