### PR TITLE
Fix benchmarking

### DIFF
--- a/pallets/asset-manager/src/benchmarking.rs
+++ b/pallets/asset-manager/src/benchmarking.rs
@@ -40,12 +40,13 @@ benchmarks! {
 
 	}: _(RawOrigin::Root, location.clone(), metadata.clone())
 	verify {
-		assert_eq!(Pallet::<T>::asset_id_location(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()), Some(location));
+		assert_eq!(Pallet::<T>::asset_id_location(<T::AssetConfig as AssetConfig<T>>::NativeAssetId::get()), Some(location));
 	}
 
 	set_units_per_second {
-		let x in (<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get())..(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get() + 50);
-		for i in <T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()..x {
+		let start = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+		let end = start + 1000;
+		for i in start..end {
 
 			let location: MultiLocation = MultiLocation::new(0, X1(Parachain(i)));
 			let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(location.clone());
@@ -58,16 +59,18 @@ benchmarks! {
 		// does not really matter what we register, as long as it is different than the previous
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
+		let amount = 10;
 		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
 
-	}: _(RawOrigin::Root, x, 10)
+	}: _(RawOrigin::Root, end, amount)
 	verify {
-		assert_eq!(Pallet::<T>::get_units_per_second(x), Some(10));
+		assert_eq!(Pallet::<T>::get_units_per_second(end), Some(amount));
 	}
 
 	update_asset_location {
-		let x in (<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get())..(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get() + 50);
-		for i in <T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()..x {
+		let start = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+		let end = start + 1000;
+		for i in start..end {
 
 			let location: MultiLocation = MultiLocation::new(0, X1(Parachain(i)));
 			let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(location.clone());
@@ -80,15 +83,16 @@ benchmarks! {
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
-		let new_location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(MultiLocation::new(0, X1(Parachain(x))));
-	}: _(RawOrigin::Root, x, new_location.clone())
+		let new_location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(MultiLocation::new(0, X1(Parachain(end))));
+	}: _(RawOrigin::Root, end, new_location.clone())
 	verify {
-		assert_eq!(Pallet::<T>::asset_id_location(x), Some(new_location));
+		assert_eq!(Pallet::<T>::asset_id_location(end), Some(new_location));
 	}
 
 	update_asset_metadata {
-		let x in (<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get())..(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get() + 50);
-		for i in <T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()..x {
+		let start = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+		let end = start + 1000;
+		for i in start..end {
 
 			let location: MultiLocation = MultiLocation::new(0, X1(Parachain(i)));
 			let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(location.clone());
@@ -101,34 +105,32 @@ benchmarks! {
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
-	}: _(RawOrigin::Root, x, metadata.clone())
+	}: _(RawOrigin::Root, end, metadata.clone())
 	verify {
-		assert_last_event::<T>(Event::AssetMetadataUpdated { asset_id: x, metadata }.into());
+		assert_last_event::<T>(Event::AssetMetadataUpdated { asset_id: end, metadata }.into());
 	}
 
 	mint_asset {
-		let x in (<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get())..(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get() + 50);
-		for i in <T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()..x {
+		let start = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+		let end = start + 1000;
+		for i in start..end {
 
 			let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(MultiLocation::new(0, X1(Parachain(i))));
 			let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 
 			Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
 		}
+
 		let beneficiary: T::AccountId = whitelisted_caller();
 		let amount = 100;
 		// does not really matter what we register, as long as it is different than the previous
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
-	}: _(RawOrigin::Root, x, beneficiary.clone(), amount)
+	}: _(RawOrigin::Root, end, beneficiary.clone(), amount)
 	verify {
-		assert_last_event::<T>(Event::AssetMinted { asset_id: x, beneficiary, amount }.into());
+		assert_last_event::<T>(Event::AssetMinted { asset_id: end, beneficiary, amount }.into());
 	}
 }
 
-impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(),
-	crate::mock::Runtime
-);
+impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -43,6 +43,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
 
+	use crate::weights::WeightInfo;
 	use frame_support::{pallet_prelude::*, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
 	use manta_primitives::{
@@ -53,7 +54,6 @@ pub mod pallet {
 		types::{AssetId, Balance},
 	};
 	use sp_runtime::{traits::AccountIdConversion, ArithmeticError};
-	use crate::weights::WeightInfo;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -258,7 +258,7 @@ pub mod pallet {
 		/// * `origin`: Caller of this extrinsic, the access control is specfied by `ForceOrigin`.
 		/// * `asset_id`: AssetId to be updated.
 		/// * `location`: `location` to update the asset location.
-		#[pallet::weight(T::WeightInfo::update_asset_location(1u32))]
+		#[pallet::weight(T::WeightInfo::update_asset_location())]
 		#[transactional]
 		pub fn update_asset_location(
 			origin: OriginFor<T>,
@@ -291,7 +291,7 @@ pub mod pallet {
 		/// * `origin`: Caller of this extrinsic, the access control is specfied by `ForceOrigin`.
 		/// * `asset_id`: AssetId to be updated.
 		/// * `metadata`: new `metadata` to be associated with `asset_id`.
-		#[pallet::weight(T::WeightInfo::update_asset_metadata(1u32))]
+		#[pallet::weight(T::WeightInfo::update_asset_metadata())]
 		#[transactional]
 		pub fn update_asset_metadata(
 			origin: OriginFor<T>,
@@ -313,7 +313,7 @@ pub mod pallet {
 		/// * `origin`: Caller of this extrinsic, the access control is specfied by `ForceOrigin`.
 		/// * `asset_id`: AssetId to be updated.
 		/// * `units_per_second`: units per second for `asset_id`
-		#[pallet::weight(T::WeightInfo::set_units_per_second(1u32))]
+		#[pallet::weight(T::WeightInfo::set_units_per_second())]
 		#[transactional]
 		pub fn set_units_per_second(
 			origin: OriginFor<T>,
@@ -339,7 +339,7 @@ pub mod pallet {
 		/// * `asset_id`: AssetId to be updated.
 		/// * `beneficiary`: Account to mint the asset.
 		/// * `amount`: Amount of asset being minted.
-		#[pallet::weight(T::WeightInfo::mint_asset(1u32))]
+		#[pallet::weight(T::WeightInfo::mint_asset())]
 		#[transactional]
 		pub fn mint_asset(
 			origin: OriginFor<T>,

--- a/pallets/asset-manager/src/weights.rs
+++ b/pallets/asset-manager/src/weights.rs
@@ -45,10 +45,10 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for pallet_tx_pause.
 pub trait WeightInfo {
 	fn register_asset() -> Weight;
-	fn set_units_per_second(x: u32,) -> Weight;
-	fn update_asset_location(x: u32,) -> Weight;
-	fn update_asset_metadata(x: u32,) -> Weight;
-	fn mint_asset(x: u32,) -> Weight;
+	fn set_units_per_second() -> Weight;
+	fn update_asset_location() -> Weight;
+	fn update_asset_metadata() -> Weight;
+	fn mint_asset() -> Weight;
 }
 
 /// Weight functions for `pallet_asset_manager`.
@@ -67,38 +67,30 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: AssetManager AssetIdLocation (r:1 w:0)
 	// Storage: AssetManager UnitsPerSecond (r:0 w:1)
-	fn set_units_per_second(x: u32, ) -> Weight {
+	fn set_units_per_second() -> Weight {
 		(21_203_000 as Weight)
-			// Standard Error: 14_000
-			.saturating_add((227_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: AssetManager AssetIdLocation (r:1 w:1)
 	// Storage: AssetManager LocationAssetId (r:1 w:2)
-	fn update_asset_location(x: u32, ) -> Weight {
+	fn update_asset_location() -> Weight {
 		(20_737_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((241_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AssetManager AssetIdLocation (r:1 w:0)
 	// Storage: AssetManager AssetIdMetadata (r:0 w:1)
-	fn update_asset_metadata(x: u32, ) -> Weight {
+	fn update_asset_metadata() -> Weight {
 		(15_663_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((149_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: AssetManager AssetIdLocation (r:1 w:0)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:1 w:1)
-	fn mint_asset(x: u32, ) -> Weight {
+	fn mint_asset() -> Weight {
 		(39_949_000 as Weight)
-			// Standard Error: 14_000
-			.saturating_add((139_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -113,28 +105,29 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 
-	fn set_units_per_second(_x: u32, ) -> Weight {
+	fn set_units_per_second() -> Weight {
 		(42_450_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 
-	fn update_asset_location(_x: u32, ) -> Weight {
+	fn update_asset_location() -> Weight {
 		(42_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 
-	fn update_asset_metadata(_x: u32, ) -> Weight {
+	fn update_asset_metadata() -> Weight {
 		(42_450_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	
-	fn mint_asset(_x: u32, ) -> Weight {
+	fn mint_asset() -> Weight {
 		(42_450_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
+
 


### PR DESCRIPTION
Signed-off-by: ghzlatarev <ghzlatarev@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
