### PR TITLE
Extend asset-manager for adapting to xtokens

### DIFF
--- a/pallets/asset-manager/src/benchmarking.rs
+++ b/pallets/asset-manager/src/benchmarking.rs
@@ -131,6 +131,30 @@ benchmarks! {
 	verify {
 		assert_last_event::<T>(Event::AssetMinted { asset_id: end, beneficiary, amount }.into());
 	}
+
+	set_min_xcm_fee {
+		let start = <T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get();
+		let end = start + 1000;
+		for i in start..end {
+
+			let location: MultiLocation = MultiLocation::new(0, X1(Parachain(i)));
+			let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(location.clone());
+			let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
+
+			Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+			Pallet::<T>::set_units_per_second(RawOrigin::Root.into(), i, 0)?;
+		}
+
+		// does not really matter what we register, as long as it is different than the previous
+		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
+		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
+		let min_xcm_fee = 10;
+		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+
+	}: _(RawOrigin::Root, end, min_xcm_fee)
+	verify {
+		assert_eq!(Pallet::<T>::get_min_xcm_fee(end), Some(min_xcm_fee));
+	}
 }
 
 impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -31,7 +31,7 @@ use manta_primitives::{
 	constants::{ASSET_MANAGER_PALLET_ID, ASSET_STRING_LIMIT},
 	types::{AccountId, AssetId, Balance},
 };
-use sp_core::H256;
+use sp_core::{H160, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -229,4 +229,24 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.assimilate_storage(&mut t)
 	.unwrap();
 	sp_io::TestExternalities::new(t)
+}
+
+pub(crate) fn create_asset_metadata(
+	name: &str,
+	symbol: &str,
+	decimals: u8,
+	min_balance: u128,
+	evm_address: Option<H160>,
+	is_frozen: bool,
+	is_sufficient: bool,
+) -> AssetRegistrarMetadata {
+	AssetRegistrarMetadata {
+		name: name.as_bytes().to_vec(),
+		symbol: symbol.as_bytes().to_vec(),
+		decimals,
+		min_balance,
+		evm_address,
+		is_frozen,
+		is_sufficient,
+	}
 }

--- a/pallets/asset-manager/src/weights.rs
+++ b/pallets/asset-manager/src/weights.rs
@@ -48,6 +48,7 @@ pub trait WeightInfo {
 	fn update_asset_location() -> Weight;
 	fn update_asset_metadata() -> Weight;
 	fn mint_asset() -> Weight;
+	fn set_min_xcm_fee() -> Weight;
 }
 
 /// Weights for pallet_asset_manager using the Substrate node and recommended hardware.
@@ -95,6 +96,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
+	// Storage: AssetManager AssetIdLocation (r:1 w:0)
+	// Storage: AssetManager MinXcmFee (r:0 w:1)
+	fn set_min_xcm_fee() -> Weight {
+		(31_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -141,5 +149,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
+	// Storage: AssetManager AssetIdLocation (r:1 w:0)
+	// Storage: AssetManager MinXcmFee (r:0 w:1)
+	fn set_min_xcm_fee() -> Weight {
+		(31_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
 }
-


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

There're two more types in `xtokens::Config`, so I need to implement them before merge #481 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [ ] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
