### PR TITLE
`OnRuntimeUpgrade` hook for `AssetManager` to properly set `NativeAssetId` and `StartNonNativeAssetId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5724,6 +5724,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "manta-primitives",
  "pallet-assets",
  "pallet-balances",

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -19,6 +19,7 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkad
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16", default-features = false, optional = true }
 xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.16", optional = true }
 manta-primitives = { path = "../../primitives", default-features = false }
+log = { version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
@@ -37,6 +38,7 @@ std = [
 	"frame-system/std",
 	"sp-std/std",
 	"manta-primitives/std",
+	'log/std',
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -214,6 +214,20 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type UnitsPerSecond<T: Config> = StorageMap<_, Blake2_128Concat, AssetId, u128>;
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> Weight {
+			NextAssetId::<T>::set(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get());
+			let asset_id = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+			let metadata = <T::AssetConfig as AssetConfig<T>>::NativeAssetMetadata::get();
+			let location = <T::AssetConfig as AssetConfig<T>>::NativeAssetLocation::get();
+			AssetIdLocation::<T>::insert(&asset_id, &location);
+			AssetIdMetadata::<T>::insert(&asset_id, &metadata);
+			LocationAssetId::<T>::insert(&location, &asset_id);
+			T::DbWeight::get().reads_writes(1, 4)
+		}
+	}
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Register a new asset in the asset manager.

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -400,7 +400,6 @@ pub mod pallet {
 		pub fn set_genesis_configuration() -> Weight {
 			let mut weight: Weight = T::DbWeight::get().reads(1);
 			if have_storage_value(Self::name().as_bytes(), b"NextAssetId", &[]) {
-				weight = weight.saturating_add(T::DbWeight::get().reads(1));
 				log::warn!(" !!! Aborting, NextAssetId was already set.");
 				return weight;
 			}

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -216,82 +216,6 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type UnitsPerSecond<T: Config> = StorageMap<_, Blake2_128Concat, AssetId, u128>;
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			let mut weight: Weight = T::DbWeight::get().reads(1);
-			if have_storage_value(Self::name().as_bytes(), b"NextAssetId", &[]) {
-				weight = weight.saturating_add(T::DbWeight::get().reads(1));
-				log::warn!(" !!! Aborting, NextAssetId was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(4));
-			let asset_id = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
-			let metadata = <T::AssetConfig as AssetConfig<T>>::NativeAssetMetadata::get();
-			let location = <T::AssetConfig as AssetConfig<T>>::NativeAssetLocation::get();
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"AssetIdLocation",
-				&Blake2_128Concat::hash(&asset_id.encode()),
-			) {
-				log::warn!(" !!! Aborting, AssetIdLocation was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(1));
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"AssetIdMetadata",
-				&Blake2_128Concat::hash(&asset_id.encode()),
-			) {
-				log::warn!(" !!! Aborting, AssetIdMetadata was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(1));
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"LocationAssetId",
-				&Blake2_128Concat::hash(&location.encode()),
-			) {
-				log::warn!(" !!! Aborting, LocationAssetId was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
-			let start_non_native_asset_id =
-				<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get();
-			NextAssetId::<T>::set(start_non_native_asset_id);
-			log::info!(
-				" >>> NextAssetId set the value {}",
-				start_non_native_asset_id
-			);
-
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 3));
-			AssetIdLocation::<T>::insert(&asset_id, &location);
-			log::info!(
-				" >>> AssetIdLocation inserted the key:value pair {}:{:?}",
-				asset_id,
-				location
-			);
-			AssetIdMetadata::<T>::insert(&asset_id, &metadata);
-			log::info!(
-				" >>> AssetIdMetadata inserted the key:value pair {}:{:?}",
-				asset_id,
-				metadata
-			);
-			LocationAssetId::<T>::insert(&location, &asset_id);
-			log::info!(
-				" >>> LocationAssetId inserted the key:value pair {:?}:{}",
-				location,
-				asset_id
-			);
-
-			weight
-		}
-	}
-
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Register a new asset in the asset manager.
@@ -471,6 +395,79 @@ pub mod pallet {
 		/// The account ID of AssetManager
 		pub fn account_id() -> T::AccountId {
 			T::PalletId::get().into_account()
+		}
+
+		pub fn set_genesis_configuration() -> Weight {
+			let mut weight: Weight = T::DbWeight::get().reads(1);
+			if have_storage_value(Self::name().as_bytes(), b"NextAssetId", &[]) {
+				weight = weight.saturating_add(T::DbWeight::get().reads(1));
+				log::warn!(" !!! Aborting, NextAssetId was already set.");
+				return weight;
+			}
+
+			weight = weight.saturating_add(T::DbWeight::get().reads(4));
+			let asset_id = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
+			let metadata = <T::AssetConfig as AssetConfig<T>>::NativeAssetMetadata::get();
+			let location = <T::AssetConfig as AssetConfig<T>>::NativeAssetLocation::get();
+			if have_storage_value(
+				Self::name().as_bytes(),
+				b"AssetIdLocation",
+				&Blake2_128Concat::hash(&asset_id.encode()),
+			) {
+				log::warn!(" !!! Aborting, AssetIdLocation was already set.");
+				return weight;
+			}
+
+			weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			if have_storage_value(
+				Self::name().as_bytes(),
+				b"AssetIdMetadata",
+				&Blake2_128Concat::hash(&asset_id.encode()),
+			) {
+				log::warn!(" !!! Aborting, AssetIdMetadata was already set.");
+				return weight;
+			}
+
+			weight = weight.saturating_add(T::DbWeight::get().reads(1));
+			if have_storage_value(
+				Self::name().as_bytes(),
+				b"LocationAssetId",
+				&Blake2_128Concat::hash(&location.encode()),
+			) {
+				log::warn!(" !!! Aborting, LocationAssetId was already set.");
+				return weight;
+			}
+
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+			let start_non_native_asset_id =
+				<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get();
+			NextAssetId::<T>::set(start_non_native_asset_id);
+			log::info!(
+				" >>> NextAssetId set the value {}",
+				start_non_native_asset_id
+			);
+
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 3));
+			AssetIdLocation::<T>::insert(&asset_id, &location);
+			log::info!(
+				" >>> AssetIdLocation inserted the key:value pair {}:{:?}",
+				asset_id,
+				location
+			);
+			AssetIdMetadata::<T>::insert(&asset_id, &metadata);
+			log::info!(
+				" >>> AssetIdMetadata inserted the key:value pair {}:{:?}",
+				asset_id,
+				metadata
+			);
+			LocationAssetId::<T>::insert(&location, &asset_id);
+			log::info!(
+				" >>> LocationAssetId inserted the key:value pair {:?}:{}",
+				location,
+				asset_id
+			);
+
+			weight
 		}
 	}
 

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -224,7 +224,7 @@ pub mod pallet {
 			AssetIdLocation::<T>::insert(&asset_id, &location);
 			AssetIdMetadata::<T>::insert(&asset_id, &metadata);
 			LocationAssetId::<T>::insert(&location, &asset_id);
-			T::DbWeight::get().reads_writes(1, 4)
+			T::DbWeight::get().reads_writes(4, 4)
 		}
 	}
 

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1153,21 +1153,21 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsReversedWithSystemFirst,
-	CollatorSelectionMigrationV2,
+	SetAssetManagerGenesisConfiguration,
 >;
 
-pub struct CollatorSelectionMigrationV2;
-impl OnRuntimeUpgrade for CollatorSelectionMigrationV2 {
+pub struct SetAssetManagerGenesisConfiguration;
+impl OnRuntimeUpgrade for SetAssetManagerGenesisConfiguration {
 	fn on_runtime_upgrade() -> Weight {
-		CollatorSelection::migrate_v0_to_v1()
+		AssetManager::set_genesis_configuration()
 	}
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
-		CollatorSelection::pre_migrate_v0_to_v1()
+		Ok(())
 	}
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
-		CollatorSelection::post_migrate_v0_to_v1()
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: ghzlatarev <ghzlatarev@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #498

* Use the genesis configuration code of `AssetManager` in a `OnRuntimeUpgrade` hook, as this pallet manager was not in Calamari's genesis and the code wasn't invoked.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. If this number is updated, then the spec_version must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If import a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are offcially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inhreited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
