### PR TITLE
Concrete fungible ledger integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,6 +4931,7 @@ dependencies = [
  "frame-system",
  "log",
  "manta-accounting",
+ "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,7 +4931,6 @@ dependencies = [
  "frame-system",
  "log",
  "manta-accounting",
- "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "smallvec",

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -252,7 +252,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// Public Transfer Event
 		Transfer {
-			/// Asset Transfered
+			/// Asset Transferred
 			asset: Asset,
 
 			/// Source Account
@@ -302,7 +302,7 @@ pub mod pallet {
 
 		/// Balance Low
 		///
-		/// Attempted to withdraw from balance which was smaller than the withdrawl amount.
+		/// Attempted to withdraw from balance which was smaller than the withdrawal amount.
 		BalanceLow,
 
 		/// Invalid Serialized Form
@@ -450,7 +450,7 @@ pub mod pallet {
 				FungibleLedgerError::ReducedToZero(_) => Self::PublicUpdateReducedToZero,
 				FungibleLedgerError::NoFunds => Self::PublicUpdateNoFunds,
 				FungibleLedgerError::WouldDie => Self::PublicUpdateWouldDie,
-				FungibleLedgerError::InvalidTransfer => Self::PublicUpdateInvalidTransfer,
+				FungibleLedgerError::InvalidTransfer(_e) => Self::PublicUpdateInvalidTransfer,
 				_ => Self::InternalLedgerError,
 			}
 		}

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -684,6 +684,9 @@ parameter_types! {
 	pub const AssetManagerPalletId: PalletId = ASSET_MANAGER_PALLET_ID;
 }
 
+pub type CalamariConcreteFungibleLedger =
+	ConcreteFungibleLedger<Runtime, CalamariAssetConfig, Balances, Assets>;
+
 #[derive(Clone, Eq, PartialEq)]
 pub struct CalamariAssetConfig;
 
@@ -697,7 +700,7 @@ impl AssetConfig<Runtime> for CalamariAssetConfig {
 	type StorageMetadata = AssetStorageMetadata;
 	type AssetLocation = AssetLocation;
 	type AssetRegistrar = CalamariAssetRegistrar;
-	type FungibleLedger = ConcreteFungibleLedger<Runtime, CalamariAssetConfig, Balances, Assets>;
+	type FungibleLedger = CalamariConcreteFungibleLedger;
 }
 
 impl pallet_asset_manager::Config for Runtime {

--- a/runtime/calamari/tests/common/mock.rs
+++ b/runtime/calamari/tests/common/mock.rs
@@ -17,11 +17,12 @@
 use crate::common::*;
 
 pub use calamari_runtime::{
-	currency::KMA, Call, CollatorSelection, Democracy, Runtime, Scheduler, Session, System,
-	TransactionPayment,
+	currency::KMA, CalamariAssetConfig, Call, CollatorSelection, Democracy, Runtime, Scheduler,
+	Session, System, TransactionPayment,
 };
 use frame_support::traits::{GenesisBuild, OnFinalize, OnInitialize};
 use manta_primitives::{
+	assets::AssetConfig,
 	helpers::{get_account_id_from_seed, get_collator_keys_from_seed},
 	types::{AccountId, AuraId, Balance},
 };
@@ -33,6 +34,7 @@ pub struct ExtBuilder {
 	desired_candidates: u32,
 	safe_xcm_version: Option<u32>,
 }
+use sp_std::marker::PhantomData;
 
 impl Default for ExtBuilder {
 	fn default() -> ExtBuilder {
@@ -109,6 +111,13 @@ impl ExtBuilder {
 					)
 				})
 				.collect(),
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		pallet_asset_manager::GenesisConfig::<Runtime> {
+			start_id: <CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+			_marker: PhantomData::<Runtime>::default(),
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/runtime/calamari/tests/integration_tests.rs
+++ b/runtime/calamari/tests/integration_tests.rs
@@ -989,8 +989,14 @@ fn concrete_fungible_ledger_transfers_work() {
 					&charlie.clone(),
 					INITIAL_BALANCE + 1,
 				),
-				// Not enough funds
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Module {
+					index: <calamari_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+						Balances,
+					>()
+					.unwrap() as u8,
+					error: 2,
+					message: Some("InsufficientBalance")
+				})
 			);
 			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
 			assert_eq!(
@@ -1006,8 +1012,14 @@ fn concrete_fungible_ledger_transfers_work() {
 					&charlie.clone(),
 					INITIAL_BALANCE,
 				),
-				// Because keep_alive is set to true
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Module {
+					index: <calamari_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+						Balances,
+					>()
+					.unwrap() as u8,
+					error: 4,
+					message: Some("KeepAlive")
+				})
 			);
 			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
 			assert_eq!(
@@ -1044,8 +1056,14 @@ fn concrete_fungible_ledger_transfers_work() {
 					&new_account.clone(),
 					NativeTokenExistentialDeposit::get() - 1,
 				),
-				// Because the new balance will be below ED
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Module {
+					index: <calamari_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+						Balances,
+					>()
+					.unwrap() as u8,
+					error: 3,
+					message: Some("ExistentialDeposit")
+				})
 			);
 
 			// Should be able to create new account with enough balance
@@ -1135,7 +1153,14 @@ fn concrete_fungible_ledger_transfers_work() {
 					&bob.clone(),
 					amount,
 				),
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Module {
+					index: <calamari_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+						Assets,
+					>()
+					.unwrap() as u8,
+					error: 0,
+					message: Some("BalanceLow")
+				})
 			);
 			assert_eq!(
 				Assets::balance(
@@ -1145,16 +1170,16 @@ fn concrete_fungible_ledger_transfers_work() {
 				amount
 			);
 
-			// Transferring to empty account without reaching ED of the asset should not work.
 			assert_err!(
 				CalamariConcreteFungibleLedger::transfer(
 					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
 					&alice.clone(),
 					&bob.clone(),
-					// Fail because of ED
 					min_balance - 1,
 				),
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Token(
+					sp_runtime::TokenError::BelowMinimum
+				))
 			);
 			assert_eq!(
 				Assets::balance(
@@ -1215,7 +1240,14 @@ fn concrete_fungible_ledger_transfers_work() {
 					&charlie.clone(),
 					transfer_amount,
 				),
-				FungibleLedgerError::InvalidTransfer
+				FungibleLedgerError::InvalidTransfer(DispatchError::Module {
+					index: <calamari_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+						Assets,
+					>()
+					.unwrap() as u8,
+					error: 3,
+					message: Some("Unknown")
+				})
 			);
 		});
 }

--- a/runtime/calamari/tests/integration_tests.rs
+++ b/runtime/calamari/tests/integration_tests.rs
@@ -1107,7 +1107,7 @@ fn concrete_fungible_ledger_transfers_work() {
 			),);
 
 			// Register and mint for testing.
-			// Switch to u128::MAX when we start using https://github.com/paritytech/substrate/pull/11241
+			// TODO:: Switch to u128::MAX when we start using https://github.com/paritytech/substrate/pull/11241
 			let amount = INITIAL_BALANCE;
 			assert_ok!(ConcreteFungibleLedger::<
 				Runtime,
@@ -1228,6 +1228,8 @@ fn concrete_fungible_ledger_can_deposit_and_mint_works() {
 		.with_balances(vec![(alice.clone(), INITIAL_BALANCE)])
 		.build()
 		.execute_with(|| {
+			// Native asset tests:
+
 			let new_account = get_account_id_from_seed::<sr25519::Public>("NewAccount");
 			assert_err!(
 				CalamariConcreteFungibleLedger::can_deposit(
@@ -1262,8 +1264,9 @@ fn concrete_fungible_ledger_can_deposit_and_mint_works() {
 				FungibleLedgerError::Overflow
 			);
 
+			// Non-native asset tests:
+
 			let min_balance = 10u128;
-			// non-native asset id
 			let asset_metadata = AssetRegistrarMetadata {
 				name: b"Kusama".to_vec(),
 				symbol: b"KSM".to_vec(),
@@ -1362,6 +1365,8 @@ fn concrete_fungible_ledger_can_withdraw_works() {
 		.with_balances(vec![(alice.clone(), INITIAL_BALANCE)])
 		.build()
 		.execute_with(|| {
+			// Native asset tests:
+
 			assert_err!(
 				CalamariConcreteFungibleLedger::can_withdraw(
 					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
@@ -1389,7 +1394,8 @@ fn concrete_fungible_ledger_can_withdraw_works() {
 				FungibleLedgerError::NoFunds
 			);
 
-			// Underflow -> NoFunds -> ReducedToZero -> WouldDie -> Frozen
+			// Non-native asset tests:
+
 			let min_balance = 10u128;
 			let asset_metadata = AssetRegistrarMetadata {
 				name: b"Kusama".to_vec(),

--- a/runtime/calamari/tests/integration_tests.rs
+++ b/runtime/calamari/tests/integration_tests.rs
@@ -25,9 +25,10 @@ pub use calamari_runtime::{
 		FEES_PERCENTAGE_TO_AUTHOR, FEES_PERCENTAGE_TO_TREASURY, TIPS_PERCENTAGE_TO_AUTHOR,
 		TIPS_PERCENTAGE_TO_TREASURY,
 	},
-	Authorship, Balances, CalamariVesting, Council, Democracy, EnactmentPeriod, LaunchPeriod,
-	NativeTokenExistentialDeposit, Origin, Period, PolkadotXcm, Runtime, Sudo, TechnicalCommittee,
-	Timestamp, Treasury, Utility, VotingPeriod,
+	AssetManager, Assets, Authorship, Balances, CalamariAssetConfig,
+	CalamariConcreteFungibleLedger, CalamariVesting, Council, Democracy, EnactmentPeriod,
+	LaunchPeriod, NativeTokenExistentialDeposit, Origin, Period, PolkadotXcm, Runtime, Sudo,
+	TechnicalCommittee, Timestamp, Treasury, Utility, VotingPeriod, XcmFeesAccount,
 };
 
 use frame_support::{
@@ -38,11 +39,22 @@ use frame_support::{
 	weights::constants::*,
 	StorageHasher, Twox128,
 };
-
 use manta_primitives::{
+	assets::{
+		AssetConfig, AssetLocation, AssetRegistrarMetadata, ConcreteFungibleLedger, FungibleLedger,
+		FungibleLedgerError,
+	},
 	constants::time::{DAYS, HOURS},
 	helpers::{get_account_id_from_seed, get_collator_keys_from_seed},
 	types::{AccountId, Header},
+};
+use xcm::{
+	opaque::latest::{
+		Junction::{PalletInstance, Parachain},
+		Junctions::X2,
+		MultiLocation,
+	},
+	VersionedMultiLocation,
 };
 
 use pallet_transaction_payment::ChargeTransactionPayment;
@@ -366,7 +378,7 @@ fn balances_operations_should_work() {
 			assert_eq!(Balances::free_balance(alice.clone()), INITIAL_BALANCE);
 			assert_eq!(Balances::free_balance(charlie.clone()), INITIAL_BALANCE);
 
-			// Should not be able to trnasfer all with this call
+			// Should not be able to transfer all with this call
 			assert_err!(
 				Balances::transfer_keep_alive(
 					Origin::signed(alice.clone()),
@@ -740,7 +752,7 @@ fn batched_registration_of_collator_candidates_works() {
 #[test]
 fn sanity_check_weight_per_time_constants_are_as_expected() {
 	// These values comes from Substrate, we want to make sure that if it
-	// ever changes we don't accidently break Polkadot
+	// ever changes we don't accidentally break Polkadot
 	assert_eq!(WEIGHT_PER_SECOND, 1_000_000_000_000);
 	assert_eq!(WEIGHT_PER_MILLIS, WEIGHT_PER_SECOND / 1000);
 	assert_eq!(WEIGHT_PER_MICROS, WEIGHT_PER_MILLIS / 1000);
@@ -947,4 +959,505 @@ fn verify_pallet_indices() {
 	is_pallet_index::<calamari_runtime::Multisig>(41);
 	is_pallet_index::<calamari_runtime::Sudo>(42);
 	is_pallet_index::<calamari_runtime::CalamariVesting>(50);
+}
+
+#[test]
+fn concrete_fungible_ledger_transfers_work() {
+	let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
+	let bob = get_account_id_from_seed::<sr25519::Public>("Bob");
+	let charlie = get_account_id_from_seed::<sr25519::Public>("Charlie");
+
+	ExtBuilder::default()
+		.with_balances(vec![
+			(alice.clone(), INITIAL_BALANCE),
+			(bob.clone(), INITIAL_BALANCE),
+			(charlie.clone(), INITIAL_BALANCE),
+		])
+		.build()
+		.execute_with(|| {
+			let transfer_amount = 10 * KMA;
+			let mut current_balance_alice = INITIAL_BALANCE;
+			let mut current_balance_charlie = INITIAL_BALANCE;
+
+			// Switch transfer amount
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&alice.clone(),
+					&charlie.clone(),
+					INITIAL_BALANCE + 1,
+				),
+				// Not enough funds
+				FungibleLedgerError::InvalidTransfer
+			);
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(charlie.clone()),
+				current_balance_charlie
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&alice.clone(),
+					&charlie.clone(),
+					INITIAL_BALANCE,
+				),
+				// Because keep_alive is set to true
+				FungibleLedgerError::InvalidTransfer
+			);
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(charlie.clone()),
+				current_balance_charlie
+			);
+
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::transfer(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+				&alice.clone(),
+				&charlie.clone(),
+				transfer_amount,
+			));
+			current_balance_alice -= transfer_amount;
+			current_balance_charlie += transfer_amount;
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(charlie.clone()),
+				current_balance_charlie
+			);
+
+			let new_account = get_account_id_from_seed::<sr25519::Public>("NewAccount");
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&alice.clone(),
+					&new_account.clone(),
+					NativeTokenExistentialDeposit::get() - 1,
+				),
+				// Because the new balance will be below ED
+				FungibleLedgerError::InvalidTransfer
+			);
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::transfer(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+				&alice.clone(),
+				&new_account.clone(),
+				NativeTokenExistentialDeposit::get(),
+			));
+			current_balance_alice -= NativeTokenExistentialDeposit::get();
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(new_account.clone()),
+				NativeTokenExistentialDeposit::get()
+			);
+
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::transfer(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+				&bob.clone(),
+				&alice.clone(),
+				// Transfer a large amount
+				INITIAL_BALANCE - NativeTokenExistentialDeposit::get(),
+			));
+			current_balance_alice += INITIAL_BALANCE - NativeTokenExistentialDeposit::get();
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(bob.clone()),
+				NativeTokenExistentialDeposit::get()
+			);
+
+			let min_balance = 10u128;
+			// non-native asset id
+			let asset_metadata = AssetRegistrarMetadata {
+				name: b"Kusama".to_vec(),
+				symbol: b"KSM".to_vec(),
+				decimals: 12,
+				min_balance: min_balance,
+				evm_address: None,
+				is_frozen: false,
+				is_sufficient: true,
+			};
+			let source_location =
+				AssetLocation(VersionedMultiLocation::V1(MultiLocation::parent()));
+			assert_ok!(AssetManager::register_asset(
+				root_origin(),
+				source_location.clone(),
+				asset_metadata.clone()
+			),);
+			// TODO: change u128::MAX when we start using https://github.com/paritytech/substrate/pull/11241
+			let amount = INITIAL_BALANCE;
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::mint(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				&alice.clone(),
+				amount,
+			),);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				amount
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					&bob.clone(),
+					// Fail because of ED
+					amount,
+				),
+				FungibleLedgerError::InvalidTransfer
+			);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				amount
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					&bob.clone(),
+					// Fail because of ED
+					min_balance - 1,
+				),
+				FungibleLedgerError::InvalidTransfer
+			);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				amount
+			);
+
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::transfer(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				&alice.clone(),
+				&bob.clone(),
+				transfer_amount,
+			),);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				INITIAL_BALANCE - transfer_amount
+			);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					bob.clone()
+				),
+				transfer_amount
+			);
+
+			// Switch asset-id
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::DummyAssetId::get(),
+					&alice.clone(),
+					&charlie.clone(),
+					transfer_amount,
+				),
+				FungibleLedgerError::InvalidAssetId
+			);
+			assert_eq!(Balances::free_balance(alice.clone()), current_balance_alice);
+			assert_eq!(
+				Balances::free_balance(charlie.clone()),
+				current_balance_charlie
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::transfer(
+					u32::MAX,
+					&alice.clone(),
+					&charlie.clone(),
+					transfer_amount,
+				),
+				FungibleLedgerError::InvalidTransfer
+			);
+		});
+}
+
+#[test]
+fn concrete_fungible_ledger_can_deposit_and_mint_works() {
+	let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
+
+	ExtBuilder::default()
+		.with_balances(vec![(alice.clone(), INITIAL_BALANCE)])
+		.build()
+		.execute_with(|| {
+			let new_account = get_account_id_from_seed::<sr25519::Public>("NewAccount");
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&new_account.clone(),
+					NativeTokenExistentialDeposit::get() - 1,
+				),
+				FungibleLedgerError::BelowMinimum
+			);
+
+			let remaining_to_max = u128::MAX - Balances::total_issuance();
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::mint(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+				&new_account.clone(),
+				remaining_to_max,
+			),);
+			assert_eq!(
+				Balances::free_balance(new_account.clone()),
+				remaining_to_max
+			);
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&new_account.clone(),
+					1,
+				),
+				FungibleLedgerError::Overflow
+			);
+
+			let min_balance = 10u128;
+			// non-native asset id
+			let asset_metadata = AssetRegistrarMetadata {
+				name: b"Kusama".to_vec(),
+				symbol: b"KSM".to_vec(),
+				decimals: 12,
+				min_balance: min_balance,
+				evm_address: None,
+				is_frozen: false,
+				is_sufficient: true,
+			};
+			let source_location =
+				AssetLocation(VersionedMultiLocation::V1(MultiLocation::parent()));
+			assert_ok!(AssetManager::register_asset(
+				root_origin(),
+				source_location.clone(),
+				asset_metadata.clone()
+			),);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					0,
+				),
+				FungibleLedgerError::BelowMinimum
+			);
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get() + 1,
+					&alice.clone(),
+					11,
+				),
+				FungibleLedgerError::UnknownAsset
+			);
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::mint(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				&alice.clone(),
+				u128::MAX,
+			),);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				u128::MAX
+			);
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					1,
+				),
+				FungibleLedgerError::Overflow
+			);
+
+			let asset_metadata = AssetRegistrarMetadata {
+				name: b"Rococo".to_vec(),
+				symbol: b"Roc".to_vec(),
+				decimals: 12,
+				min_balance: min_balance,
+				evm_address: None,
+				is_frozen: false,
+				is_sufficient: false,
+			};
+
+			let source_location = AssetLocation(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X2(Parachain(1), PalletInstance(1)),
+			)));
+			assert_ok!(AssetManager::register_asset(
+				root_origin(),
+				source_location.clone(),
+				asset_metadata.clone()
+			),);
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_deposit(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get() + 1,
+					&XcmFeesAccount::get(),
+					11,
+				),
+				FungibleLedgerError::CannotCreate
+			);
+		});
+}
+
+#[test]
+fn concrete_fungible_ledger_can_withdraw_works() {
+	let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
+	let bob = get_account_id_from_seed::<sr25519::Public>("Bob");
+
+	ExtBuilder::default()
+		.with_balances(vec![(alice.clone(), INITIAL_BALANCE)])
+		.build()
+		.execute_with(|| {
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&alice.clone(),
+					INITIAL_BALANCE + 1,
+				),
+				FungibleLedgerError::Underflow
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&alice.clone(),
+					INITIAL_BALANCE,
+				),
+				FungibleLedgerError::WouldDie
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::NativeAssetId::get(),
+					&bob.clone(),
+					INITIAL_BALANCE,
+				),
+				FungibleLedgerError::NoFunds
+			);
+
+			// Underflow -> NoFunds -> ReducedToZero -> WouldDie -> Frozen
+			let min_balance = 10u128;
+			let asset_metadata = AssetRegistrarMetadata {
+				name: b"Kusama".to_vec(),
+				symbol: b"KSM".to_vec(),
+				decimals: 12,
+				min_balance: min_balance,
+				evm_address: None,
+				is_frozen: false,
+				is_sufficient: true,
+			};
+			let source_location =
+				AssetLocation(VersionedMultiLocation::V1(MultiLocation::parent()));
+			assert_ok!(AssetManager::register_asset(
+				root_origin(),
+				source_location.clone(),
+				asset_metadata.clone()
+			),);
+
+			assert_ok!(ConcreteFungibleLedger::<
+				Runtime,
+				CalamariAssetConfig,
+				Balances,
+				Assets,
+			>::mint(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				&alice.clone(),
+				INITIAL_BALANCE,
+			),);
+			assert_eq!(
+				Assets::balance(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					alice.clone()
+				),
+				INITIAL_BALANCE
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					INITIAL_BALANCE + 1,
+				),
+				FungibleLedgerError::Underflow
+			);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					INITIAL_BALANCE,
+				),
+				FungibleLedgerError::ReducedToZero(0)
+			);
+
+			assert_ok!(CalamariConcreteFungibleLedger::can_withdraw(
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				&alice.clone(),
+				INITIAL_BALANCE - min_balance,
+			),);
+
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&bob.clone(),
+					10,
+				),
+				FungibleLedgerError::NoFunds
+			);
+
+			assert_ok!(Assets::freeze(
+				Origin::signed(AssetManager::account_id()),
+				<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+				sp_runtime::MultiAddress::Id(alice.clone()),
+			));
+			assert_err!(
+				CalamariConcreteFungibleLedger::can_withdraw(
+					<CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
+					&alice.clone(),
+					10,
+				),
+				FungibleLedgerError::Frozen
+			);
+		});
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #494 
closes: #496 (part 1)

* Some integration tests for Calamari's implementation of `ConcreteFungibleLedger` trait.
* Propagate DispatchError when `InvalidMint` or `InvalidTransfer` errors are hit, for better fornt-end user experience.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
