### PR TITLE
Clean up `AssetManager` migration code

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -44,9 +44,7 @@ mod tests;
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
-	use frame_support::{
-		migration::have_storage_value, pallet_prelude::*, transactional, PalletId, StorageHasher,
-	};
+	use frame_support::{pallet_prelude::*, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
 	use manta_primitives::{
 		assets::{
@@ -395,78 +393,6 @@ pub mod pallet {
 		/// The account ID of AssetManager
 		pub fn account_id() -> T::AccountId {
 			T::PalletId::get().into_account()
-		}
-
-		pub fn set_genesis_configuration() -> Weight {
-			let mut weight: Weight = T::DbWeight::get().reads(1);
-			if have_storage_value(Self::name().as_bytes(), b"NextAssetId", &[]) {
-				log::warn!(" !!! Aborting, NextAssetId was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(4));
-			let asset_id = <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get();
-			let metadata = <T::AssetConfig as AssetConfig<T>>::NativeAssetMetadata::get();
-			let location = <T::AssetConfig as AssetConfig<T>>::NativeAssetLocation::get();
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"AssetIdLocation",
-				&Blake2_128Concat::hash(&asset_id.encode()),
-			) {
-				log::warn!(" !!! Aborting, AssetIdLocation was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(1));
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"AssetIdMetadata",
-				&Blake2_128Concat::hash(&asset_id.encode()),
-			) {
-				log::warn!(" !!! Aborting, AssetIdMetadata was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads(1));
-			if have_storage_value(
-				Self::name().as_bytes(),
-				b"LocationAssetId",
-				&Blake2_128Concat::hash(&location.encode()),
-			) {
-				log::warn!(" !!! Aborting, LocationAssetId was already set.");
-				return weight;
-			}
-
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
-			let start_non_native_asset_id =
-				<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get();
-			NextAssetId::<T>::set(start_non_native_asset_id);
-			log::info!(
-				" >>> NextAssetId set the value {}",
-				start_non_native_asset_id
-			);
-
-			weight = weight.saturating_add(T::DbWeight::get().reads_writes(0, 3));
-			AssetIdLocation::<T>::insert(&asset_id, &location);
-			log::info!(
-				" >>> AssetIdLocation inserted the key:value pair {}:{:?}",
-				asset_id,
-				location
-			);
-			AssetIdMetadata::<T>::insert(&asset_id, &metadata);
-			log::info!(
-				" >>> AssetIdMetadata inserted the key:value pair {}:{:?}",
-				asset_id,
-				metadata
-			);
-			LocationAssetId::<T>::insert(&location, &asset_id);
-			log::info!(
-				" >>> LocationAssetId inserted the key:value pair {:?}:{}",
-				location,
-				asset_id
-			);
-
-			weight
 		}
 	}
 

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -40,10 +40,7 @@ use sp_version::RuntimeVersion;
 
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{
-		ConstU16, ConstU32, ConstU8, Contains, Currency, EnsureOneOf, OnRuntimeUpgrade,
-		PrivilegeCmp,
-	},
+	traits::{ConstU16, ConstU32, ConstU8, Contains, Currency, EnsureOneOf, PrivilegeCmp},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, Weight,
@@ -748,23 +745,8 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsReversedWithSystemFirst,
-	SetAssetManagerGenesisConfiguration,
+	(),
 >;
-
-pub struct SetAssetManagerGenesisConfiguration;
-impl OnRuntimeUpgrade for SetAssetManagerGenesisConfiguration {
-	fn on_runtime_upgrade() -> Weight {
-		AssetManager::set_genesis_configuration()
-	}
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<(), &'static str> {
-		Ok(())
-	}
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade() -> Result<(), &'static str> {
-		Ok(())
-	}
-}
 
 impl_runtime_apis! {
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {


### PR DESCRIPTION
Signed-off-by: ghzlatarev <ghzlatarev@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #517 

* The `AssetManager` migration code is no longer needed, so removing it before next runtime upgrade.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
