### PR TITLE
feat: export node CLIs for library use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,10 +1384,51 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.15.0",
+ "unicase",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1569,7 +1610,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -4775,6 +4816,7 @@ dependencies = [
  "async-trait",
  "calamari-runtime",
  "cfg-if 1.0.0",
+ "clap 3.1.15",
  "cumulus-client-cli",
  "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
@@ -4830,7 +4872,6 @@ dependencies = [
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
- "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
@@ -5703,6 +5744,12 @@ dependencies = [
  "xcm",
  "xcm-executor",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "owning_ref"
@@ -11139,12 +11186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -11342,11 +11395,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
  "unicode-width",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,14 +14,14 @@ version = '3.1.5'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-log = "0.4.13"
-codec = { package = 'parity-scale-codec', version = '2.3.1' }
-cfg-if = "1.0.0"
-structopt = "0.3.8"
-serde = { version = "1.0.119", features = ["derive"] }
-hex-literal = "0.3.3"
 async-trait = "0.1.42"
+cfg-if = "1.0.0"
+clap = { version = "3.1.15", default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
+codec = { package = 'parity-scale-codec', version = '2.3.1' }
 futures = "0.3.14"
+hex-literal = "0.3.3"
+log = "0.4.13"
+serde = { version = "1.0.119", features = ["derive"] }
 
 # Substrate frames
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -29,8 +29,8 @@ frame-benchmarking-cli = { git = 'https://github.com/paritytech/substrate.git', 
 try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16", optional = true }
 
 # RPC related dependencies
-jsonrpc-core = "18.0.0"
 frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
+jsonrpc-core = "18.0.0"
 pallet-transaction-payment-rpc = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 
@@ -38,29 +38,29 @@ sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git",
 sc-basic-authorship = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sc-client-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-consensus = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-executor = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sc-client-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-keystore = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sc-rpc = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-rpc-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-service = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sc-transaction-pool = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-tracing = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sc-transaction-pool = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 
 # Substrate primitives
 sp-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-block-builder = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-consensus = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-consensus-aura = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-inherents = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-offchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-session = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-timestamp = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -69,13 +69,13 @@ substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate
 
 # Cumulus dependencies
 cumulus-client-cli = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
-cumulus-client-consensus-common = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-consensus-aura = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
+cumulus-client-consensus-common = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-consensus-relay-chain = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-network = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
+cumulus-client-service = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-primitives-parachain-inherent = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
-cumulus-client-service = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-relay-chain-local = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 
@@ -88,9 +88,9 @@ xcm = { git = "https://github.com/paritytech/polkadot.git", branch = "release-v0
 
 # Self dependencies
 calamari-runtime = { path = '../runtime/calamari' }
-manta-runtime = { path = '../runtime/manta' }
 dolphin-runtime = { path = '../runtime/dolphin' }
 manta-primitives = { path = '../primitives' }
+manta-runtime = { path = '../runtime/manta' }
 
 [build-dependencies]
 substrate-build-script-utils = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -98,8 +98,8 @@ substrate-build-script-utils = { git = 'https://github.com/paritytech/substrate.
 [features]
 runtime-benchmarks = [
 	'calamari-runtime/runtime-benchmarks',
-	'polkadot-service/runtime-benchmarks',
 	'manta-runtime/runtime-benchmarks',
+	'polkadot-service/runtime-benchmarks',
 ]
 try-runtime = [
 	'calamari-runtime/try-runtime',
@@ -107,6 +107,6 @@ try-runtime = [
 	'try-runtime-cli',
 ]
 fast-runtime = [
-	"manta-runtime/fast-runtime",
 	"calamari-runtime/fast-runtime",
+	"manta-runtime/fast-runtime",
 ]

--- a/node/build.rs
+++ b/node/build.rs
@@ -18,6 +18,5 @@ use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_change
 
 fn main() {
 	generate_cargo_keys();
-
 	rerun_if_git_head_changed();
 }

--- a/node/src/chain_specs/calamari.rs
+++ b/node/src/chain_specs/calamari.rs
@@ -16,7 +16,6 @@
 
 use super::*;
 use crate::command::CALAMARI_PARACHAIN_ID;
-
 use calamari_runtime::{CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig};
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 
@@ -38,7 +37,7 @@ pub fn calamari_session_keys(keys: AuraId) -> calamari_runtime::opaque::SessionK
 	calamari_runtime::opaque::SessionKeys { aura: keys }
 }
 
-// calamari chain specs
+/// Calamari chain specs
 pub fn calamari_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::CALAMARI_SS58PREFIX.into());

--- a/node/src/chain_specs/dolphin.rs
+++ b/node/src/chain_specs/dolphin.rs
@@ -16,7 +16,6 @@
 
 use super::*;
 use crate::command::DOLPHIN_PARACHAIN_ID;
-
 use dolphin_runtime::{
 	AssetManagerConfig, CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig,
 };
@@ -40,7 +39,7 @@ pub fn dolphin_session_keys(keys: AuraId) -> dolphin_runtime::opaque::SessionKey
 	dolphin_runtime::opaque::SessionKeys { aura: keys }
 }
 
-// dolphin chain specs
+/// Dolphin chain specs.
 pub fn dolphin_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::CALAMARI_SS58PREFIX.into());

--- a/node/src/chain_specs/manta.rs
+++ b/node/src/chain_specs/manta.rs
@@ -16,18 +16,18 @@
 
 use super::*;
 use crate::command::MANTA_PARACHAIN_ID;
-
-pub type MantaChainSpec = sc_service::GenericChainSpec<manta_runtime::GenesisConfig, Extensions>;
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 
 const MANTA_PROTOCOL_ID: &str = "manta"; // for p2p network configuration
 const POLKADOT_RELAYCHAIN_LOCAL_NET: &str = "polkadot-local";
 const POLKADOT_RELAYCHAIN_DEV_NET: &str = "polkadot-dev";
-#[allow(dead_code)]
 const POLKADOT_RELAYCHAIN_MAIN_NET: &str = "polkadot";
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = 2;
+
+/// Manta Chain Specification Type
+pub type MantaChainSpec = sc_service::GenericChainSpec<manta_runtime::GenesisConfig, Extensions>;
 
 /// Generate the manta session keys from individual elements.
 ///
@@ -36,7 +36,7 @@ pub fn manta_session_keys(keys: AuraId) -> manta_runtime::opaque::SessionKeys {
 	manta_runtime::opaque::SessionKeys { aura: keys }
 }
 
-/// Token
+/// Manta chain spec.
 pub fn manta_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::MANTA_SS58PREFIX.into());
@@ -45,7 +45,7 @@ pub fn manta_properties() -> Properties {
 	p
 }
 
-// manta chain spec
+/// Manta chain spec.
 pub fn manta_development_config() -> MantaChainSpec {
 	let properties = manta_properties();
 

--- a/node/src/chain_specs/mod.rs
+++ b/node/src/chain_specs/mod.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_imports)]
-#![allow(dead_code)]
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
 use manta_primitives::{
@@ -29,14 +27,12 @@ use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 pub mod calamari;
-pub use self::calamari::*;
-pub use calamari_runtime::currency::KMA;
-pub mod manta;
-pub use self::manta::*;
-pub use manta_runtime::currency::MANTA;
 pub mod dolphin;
-pub use self::dolphin::*;
+pub mod manta;
+
+pub use calamari_runtime::currency::KMA;
 pub use dolphin_runtime::currency::DOL;
+pub use manta_runtime::currency::MANTA;
 
 const CALAMARI_ENDOWMENT: Balance = 1_000_000_000 * KMA; // 10 endowment so that total supply is 10B
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -15,18 +15,18 @@
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::chain_specs;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 /// Sub-commands supported by the collator.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum Subcommand {
 	/// Export the genesis state of the parachain.
-	#[structopt(name = "export-genesis-state")]
+	#[clap(name = "export-genesis-state")]
 	ExportGenesisState(ExportGenesisStateCommand),
 
 	/// Export the genesis wasm of the parachain.
-	#[structopt(name = "export-genesis-wasm")]
+	#[clap(name = "export-genesis-wasm")]
 	ExportGenesisWasm(ExportGenesisWasmCommand),
 
 	/// Build a chain specification.
@@ -51,7 +51,7 @@ pub enum Subcommand {
 	Revert(sc_cli::RevertCmd),
 
 	/// The custom benchmark subcommmand benchmarking runtime pallets.
-	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
+	#[clap(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
 	/// Try some command against runtime state.
@@ -65,58 +65,59 @@ pub enum Subcommand {
 }
 
 /// Command for exporting the genesis state of the parachain
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct ExportGenesisStateCommand {
 	/// Output file name or stdout if unspecified.
-	#[structopt(parse(from_os_str))]
+	#[clap(parse(from_os_str))]
 	pub output: Option<PathBuf>,
 
 	/// Id of the parachain this state is for.
 	///
 	/// Default: 2084
-	#[structopt(long)]
+	#[clap(long)]
 	pub parachain_id: Option<u32>,
 
 	/// Write output in binary. Default is to write in hex.
-	#[structopt(short, long)]
+	#[clap(short, long)]
 	pub raw: bool,
 
 	/// The name of the chain for that the genesis state should be exported.
-	#[structopt(long)]
+	#[clap(long)]
 	pub chain: Option<String>,
 }
 
 /// Command for exporting the genesis wasm file.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct ExportGenesisWasmCommand {
 	/// Output file name or stdout if unspecified.
-	#[structopt(parse(from_os_str))]
+	#[clap(parse(from_os_str))]
 	pub output: Option<PathBuf>,
 
 	/// Write output in binary. Default is to write in hex.
-	#[structopt(short, long)]
+	#[clap(short, long)]
 	pub raw: bool,
 
 	/// The name of the chain for that the genesis wasm file should be exported.
-	#[structopt(long)]
+	#[clap(long)]
 	pub chain: Option<String>,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(settings = &[
-	structopt::clap::AppSettings::GlobalVersion,
-	structopt::clap::AppSettings::ArgsNegateSubcommands,
-	structopt::clap::AppSettings::SubcommandsNegateReqs,
+/// Manta Node CLI
+#[derive(Debug, Parser)]
+#[clap(settings = &[
+	clap::AppSettings::GlobalVersion,
+	clap::AppSettings::ArgsNegateSubcommands,
+	clap::AppSettings::SubcommandsNegateReqs,
 ])]
 pub struct Cli {
-	#[structopt(subcommand)]
+	#[clap(subcommand)]
 	pub subcommand: Option<Subcommand>,
 
-	#[structopt(flatten)]
+	#[clap(flatten)]
 	pub run: cumulus_client_cli::RunCmd,
 
 	/// Relaychain arguments
-	#[structopt(raw = true)]
+	#[clap(raw = true)]
 	pub relaychain_args: Vec<String>,
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -16,6 +16,20 @@
 
 use crate::{
 	chain_specs,
+	chain_specs::{
+		calamari::{
+			calamari_config, calamari_development_config, calamari_local_config,
+			calamari_testnet_ci_config, calamari_testnet_config, CalamariChainSpec,
+		},
+		dolphin::{
+			dolphin_development_config, dolphin_local_config, dolphin_testnet_config,
+			DolphinChainSpec,
+		},
+		manta::{
+			manta_config, manta_development_config, manta_local_config, manta_testnet_ci_config,
+			manta_testnet_config, MantaChainSpec,
+		},
+	},
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, CalamariRuntimeExecutor, DolphinRuntimeExecutor, MantaRuntimeExecutor},
 };

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -19,12 +19,10 @@ use crate::{
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, CalamariRuntimeExecutor, DolphinRuntimeExecutor, MantaRuntimeExecutor},
 };
-
 use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
-
 use manta_primitives::types::{AuraId, Header};
 use polkadot_parachain::primitives::AccountIdConversion;
 use sc_cli::{

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -16,7 +16,12 @@
 
 //! Manta/Calamari Parachain CLI
 
-#[inline]
-fn main() -> sc_cli::Result<()> {
-	command::run()
-}
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![forbid(rustdoc::broken_intra_doc_links)]
+#![forbid(missing_docs)]
+
+pub mod chain_specs;
+pub mod cli;
+pub mod command;
+pub mod rpc;
+pub mod service;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -20,6 +20,8 @@
 #![forbid(rustdoc::broken_intra_doc_links)]
 #![forbid(missing_docs)]
 
+extern crate alloc;
+
 pub mod chain_specs;
 pub mod cli;
 pub mod command;

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -16,16 +16,17 @@
 
 //! Parachain-specific RPCs implementation.
 
-use std::sync::Arc;
-
+use alloc::sync::Arc;
+use frame_rpc_system::{FullSystem, SystemApi};
+use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
+use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 use sc_client_api::AuxStore;
-pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 
-use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
+pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
 
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
@@ -55,16 +56,12 @@ where
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
-	use frame_rpc_system::{FullSystem, SystemApi};
-	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
-
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps {
 		client,
 		pool,
 		deny_unsafe,
 	} = deps;
-
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(
 		client.clone(),
 		pool,
@@ -73,6 +70,5 @@ where
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
 		client,
 	)));
-
 	io
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -14,12 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::rpc;
+use alloc::sync::Arc;
 use codec::Codec;
 use core::marker::PhantomData;
 use cumulus_client_consensus_aura::{AuraConsensus, BuildAuraConsensusParams, SlotProportion};
 use cumulus_client_consensus_common::{
 	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
 };
+use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
 	prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
@@ -30,13 +33,8 @@ use cumulus_primitives_core::{
 };
 use cumulus_relay_chain_interface::RelayChainInterface;
 use cumulus_relay_chain_local::build_relay_chain_interface;
-use polkadot_service::NativeExecutionDispatch;
-
-use crate::rpc;
-pub use manta_primitives::types::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
-
-use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use futures::lock::Mutex;
+use polkadot_service::NativeExecutionDispatch;
 use sc_client_api::ExecutorProvider;
 use sc_consensus::{
 	import_queue::{BasicQueue, Verifier as VerifierT},
@@ -56,8 +54,9 @@ use sp_runtime::{
 	generic::BlockId,
 	traits::{BlakeTwo256, Header as HeaderT},
 };
-use std::sync::Arc;
 use substrate_prometheus_endpoint::Registry;
+
+pub use manta_primitives::types::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
 
 // Native Manta Parachain executor instance.
 pub struct MantaRuntimeExecutor;


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

To use the node CLI in https://github.com/Manta-Network/cli/pull/1 we need to export the CLI code as a library instead of just a binary.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
