### PR TITLE
Multiply tx len and base fee component by max number of remarks per block, in the fees calculation of `congested_chain_simulation` test

### DIFF
--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -56,8 +56,12 @@ impl WeightToFeePolynomial for WeightToFee {
 
 #[cfg(test)]
 mod multiplier_tests {
-	use crate::{Runtime, RuntimeBlockWeights as BlockWeights, System, TransactionPayment, KMA};
+	use crate::{
+		Call, Runtime, RuntimeBlockWeights as BlockWeights, System, TransactionPayment, KMA,
+	};
+	use codec::Encode;
 	use frame_support::weights::{DispatchClass, Weight, WeightToFeePolynomial};
+	use frame_system::WeightInfo;
 	use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 	use polkadot_runtime_common::{AdjustmentVariable, MinimumMultiplier, TargetBlockFullness};
 	use sp_runtime::{
@@ -106,7 +110,7 @@ mod multiplier_tests {
 	// Consider the daily cost to fully congest our network to be defined as:
 	// `target_daily_congestion_cost_usd = inclusion_fee * blocks_per_day * kma_price`
 	// Where:
-	// `inclusion_fee = fee_adjustment * (weight_to_fee_coeff * (block_weight ^ degree)) + base_fee + length_fee`
+	// `inclusion_fee = fee_adjustment * (weight_to_fee_coeff * (block_weight ^ degree)) + base_fee + (weight_to_fee_coeff * length_fee)`
 	// Where:
 	// `fee_adjustment` and `weight_to_fee_coeff` are configurable in a runtime via `FeeMultiplierUpdate` and `WeightToFee`
 	// `fee_adjustment` is also variable depending on previous block's fullness
@@ -128,9 +132,21 @@ mod multiplier_tests {
 			.max_total
 			.unwrap() - 10;
 
-		let base_fee = <Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(
-			&frame_support::weights::constants::ExtrinsicBaseWeight::get(),
-		);
+		let remark = Call::System(frame_system::Call::<Runtime>::remark_with_event {
+			remark: vec![1, 2, 3],
+		});
+		let len: u32 = remark.clone().encode().len() as u32;
+		let remark_weight: Weight =
+			<Runtime as frame_system::Config>::SystemWeightInfo::remark(len);
+		let max_number_of_remarks_per_block = (block_weight / remark_weight) as u128;
+		let per_byte = <Runtime as pallet_transaction_payment::Config>::TransactionByteFee::get();
+		// length fee. this is not adjusted.
+		let len_fee = max_number_of_remarks_per_block * per_byte.saturating_mul(len as u128);
+
+		let base_fee = max_number_of_remarks_per_block
+			* <Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(
+				&frame_support::weights::constants::ExtrinsicBaseWeight::get(),
+			);
 
 		run_with_system_weight(block_weight, || {
 			// initial value configured on module
@@ -150,11 +166,12 @@ mod multiplier_tests {
 				let fee = <Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(
 					&block_weight,
 				);
-				// base_fee is not adjusted
-				let adjusted_fee = fee_adjustment.saturating_mul_acc_int(fee) + base_fee;
+
+				// base_fee and len_fee are not adjusted
+				let adjusted_fee = fee_adjustment.saturating_mul_acc_int(fee) + base_fee + len_fee;
 				accumulated_fee += adjusted_fee;
 				println!(
-					"Iteration {}, New fee_adjustment = {:?}. Adjusted Fee: {} KMA, Total Fee: {} KMA, Dollar Vlaue: {}",
+					"Iteration {}, New fee_adjustment = {:?}. Adjusted Fee: {} KMA, Total Fee: {} KMA, Dollar Value: {}",
 					iteration,
 					fee_adjustment,
 					adjusted_fee / KMA,

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -142,7 +142,8 @@ mod multiplier_tests {
 		let max_number_of_remarks_per_block = (block_weight / remark_weight) as u128;
 		let per_byte = <Runtime as pallet_transaction_payment::Config>::TransactionByteFee::get();
 		// length fee. this is not adjusted.
-		let len_fee = max_number_of_remarks_per_block * per_byte.saturating_mul(len as u128);
+		let len_fee =
+			max_number_of_remarks_per_block.saturating_mul(per_byte.saturating_mul(len as u128));
 
 		let base_fee = max_number_of_remarks_per_block
 			* <Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -132,6 +132,7 @@ mod multiplier_tests {
 			.max_total
 			.unwrap() - 10;
 
+		// remark extrinsic is chosen arbitrarily for benchmark as a small, constant size TX.
 		let remark = Call::System(frame_system::Call::<Runtime>::remark_with_event {
 			remark: vec![1, 2, 3],
 		});


### PR DESCRIPTION
Signed-off-by: ghzlatarev <ghzlatarev@gmail.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #530 

* Ad the tx len component to the fees calculation of `congested_chain_simulation`  because when https://github.com/paritytech/substrate/pull/10785 lands in 0.9.18 it might not be so negligible to ignore. It adds $500 to the result cost.
* Calculate a rough amount for maximum `remarks` in a TX and multiply the `len` and `base_weight` components by that amount. 
* The base component being multiplied by the number of extrinsics makes about 10x difference to the result cost, so we're still over our target cost of $250k. Currently costs ~$550k to congest the network on day 1

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
