### PR TITLE
Let CI support cargo audit and dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -119,9 +119,10 @@ release-time. To initialize a benchmark run for each production runtime
 
 ### Security Audit
 
-Before each release, we should do `Security Audit`
+Before release, run a `Security Audit`
 
 * Go to [Security Audit](https://github.com/Manta-Network/Manta/actions/workflows/audit.yml).
 * Open `Run workflow` drop-down menu.
 * Choose your branch and run the workflow.
-* Finnaly, an audit report will be generated.
+* An audit report will be generated.
+* Address any reported findings before release. If it cannot be fixed, please file an issue.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -116,3 +116,12 @@ release-time. To initialize a benchmark run for each production runtime
 * Commit the changes to your branch and push to the remote branch for review.
 * The weights should be (Currently manually) checked to make sure there are no
     big outliers (i.e., twice or half the weight).
+
+### Security Audit
+
+Before each release, we should do `Security Audit`
+
+* Go to [Security Audit](https://github.com/Manta-Network/Manta/actions/workflows/audit.yml).
+* Open `Run workflow` drop-down menu.
+* Choose your branch and run the workflow.
+* Finnaly, an audit report will be generated.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels: ["Priority: Medium"]
+    # We update upstream manually.
+    ignore:
+      - dependency-name: "substrate-*"
+      - dependency-name: "sc-*"
+      - dependency-name: "sp-*"
+      - dependency-name: "frame-*"
+      - dependency-name: "pallet-*"
+      - dependency-name: "cumulus-*"
+      - dependency-name: "parachain-*"
+      - dependency-name: "manta-*"
+      - dependency-name: "orml-*"
+      - dependency-name: "xcm*"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,4 @@ updates:
       - dependency-name: "orml-*"
       - dependency-name: "xcm*"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2
 updates:
   - package-ecosystem: "cargo"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+
+name: Security Audit
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+# yamllint enable rule:line-length

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,3 +1,5 @@
+---
+
 # yamllint disable rule:line-length
 
 name: Security Audit


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

1. The audit workflow will be triggered manually, like we benchmark pallets.
2. `dependabot` will be triggered ~~daily~~weekly. But it doesn't check upstream upgrade, like substrate/polkadot/cumulus/orml.