### PR TITLE
feat: export node CLI for library use

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,8 +45,8 @@ jobs:
         runtime:
           -
             name: calamari
-          # -
-          #   name: manta
+        # -
+        #   name: manta
     steps:
       -
         name: run docker image

--- a/.github/workflows/publish-draft-releases.yml
+++ b/.github/workflows/publish-draft-releases.yml
@@ -1089,8 +1089,8 @@ jobs:
         runtime:
           -
             name: calamari
-          # -
-          #   name: manta
+        # -
+        #   name: manta
     steps:
       -
         uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,10 +1384,51 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.15.0",
+ "unicase",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1569,7 +1610,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -4775,6 +4816,7 @@ dependencies = [
  "async-trait",
  "calamari-runtime",
  "cfg-if 1.0.0",
+ "clap 3.1.18",
  "cumulus-client-cli",
  "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
@@ -5703,6 +5745,12 @@ dependencies = [
  "xcm",
  "xcm-executor",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "owning_ref"
@@ -11139,12 +11187,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -11342,11 +11396,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
  "unicode-width",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,14 +14,15 @@ version = '3.1.5'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-log = "0.4.13"
-codec = { package = 'parity-scale-codec', version = '2.3.1' }
-cfg-if = "1.0.0"
-structopt = "0.3.8"
-serde = { version = "1.0.137", features = ["derive"] }
-hex-literal = "0.3.3"
 async-trait = "0.1.42"
+cfg-if = "1.0.0"
+clap = { version = "3.1.15", default-features = false, features = ["color", "derive", "std", "suggestions", "unicode", "wrap_help"] }
+codec = { package = 'parity-scale-codec', version = '2.3.1' }
 futures = "0.3.14"
+hex-literal = "0.3.3"
+log = "0.4.13"
+serde = { version = "1.0.137", features = ["derive"] }
+structopt = "0.3.8"
 
 # Substrate frames
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -29,8 +30,8 @@ frame-benchmarking-cli = { git = 'https://github.com/paritytech/substrate.git', 
 try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16", optional = true }
 
 # RPC related dependencies
-jsonrpc-core = "18.0.0"
 frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
+jsonrpc-core = "18.0.0"
 pallet-transaction-payment-rpc = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 
@@ -38,29 +39,29 @@ sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate.git",
 sc-basic-authorship = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sc-client-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-consensus = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-executor = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sc-client-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-keystore = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sc-rpc = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-rpc-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-service = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sc-transaction-pool = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sc-tracing = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sc-transaction-pool = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 
 # Substrate primitives
 sp-api = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-block-builder = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sp-blockchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-consensus = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-consensus-aura = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sp-blockchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-inherents = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-offchain = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
-sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.16" }
 sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-session = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
 sp-timestamp = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -69,13 +70,13 @@ substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate
 
 # Cumulus dependencies
 cumulus-client-cli = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
-cumulus-client-consensus-common = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-consensus-aura = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
+cumulus-client-consensus-common = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-consensus-relay-chain = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-client-network = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
+cumulus-client-service = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-primitives-parachain-inherent = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
-cumulus-client-service = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 cumulus-relay-chain-local = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.16" }
 
@@ -88,9 +89,9 @@ xcm = { git = "https://github.com/paritytech/polkadot.git", branch = "release-v0
 
 # Self dependencies
 calamari-runtime = { path = '../runtime/calamari' }
-manta-runtime = { path = '../runtime/manta' }
 dolphin-runtime = { path = '../runtime/dolphin' }
 manta-primitives = { path = '../primitives' }
+manta-runtime = { path = '../runtime/manta' }
 
 [build-dependencies]
 substrate-build-script-utils = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.16" }
@@ -98,8 +99,8 @@ substrate-build-script-utils = { git = 'https://github.com/paritytech/substrate.
 [features]
 runtime-benchmarks = [
 	'calamari-runtime/runtime-benchmarks',
-	'polkadot-service/runtime-benchmarks',
 	'manta-runtime/runtime-benchmarks',
+	'polkadot-service/runtime-benchmarks',
 ]
 try-runtime = [
 	'calamari-runtime/try-runtime',
@@ -107,6 +108,6 @@ try-runtime = [
 	'try-runtime-cli',
 ]
 fast-runtime = [
-	"manta-runtime/fast-runtime",
 	"calamari-runtime/fast-runtime",
+	"manta-runtime/fast-runtime",
 ]

--- a/node/build.rs
+++ b/node/build.rs
@@ -18,6 +18,5 @@ use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_change
 
 fn main() {
 	generate_cargo_keys();
-
 	rerun_if_git_head_changed();
 }

--- a/node/src/chain_specs/calamari.rs
+++ b/node/src/chain_specs/calamari.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Calamari Chain Spec
+
 use super::*;
 use crate::command::CALAMARI_PARACHAIN_ID;
 use calamari_runtime::{CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig};
@@ -22,8 +24,13 @@ use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type CalamariChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
-pub const CALAMARI_PROTOCOL_ID: &str = "calamari"; // for p2p network configuration
+/// Calamari Protocol ID for p2p Network Configuration
+pub const CALAMARI_PROTOCOL_ID: &str = "calamari";
+
+/// Kusama Relaychain Local Network
 pub const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
+
+/// Kusama Relaychain Development Network
 pub const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
 
 /// The default XCM version to set in genesis config.

--- a/node/src/chain_specs/calamari.rs
+++ b/node/src/chain_specs/calamari.rs
@@ -16,20 +16,18 @@
 
 use super::*;
 use crate::command::CALAMARI_PARACHAIN_ID;
-
 use calamari_runtime::{CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig};
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type CalamariChainSpec =
-	sc_service::GenericChainSpec<calamari_runtime::GenesisConfig, Extensions>;
+pub type CalamariChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
-const CALAMARI_PROTOCOL_ID: &str = "calamari"; // for p2p network configuration
-const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
-const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
+pub const CALAMARI_PROTOCOL_ID: &str = "calamari"; // for p2p network configuration
+pub const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
+pub const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
 
 /// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = 2;
+pub const SAFE_XCM_VERSION: u32 = 2;
 
 /// Generate the calamari session keys from individual elements.
 ///
@@ -38,7 +36,7 @@ pub fn calamari_session_keys(keys: AuraId) -> calamari_runtime::opaque::SessionK
 	calamari_runtime::opaque::SessionKeys { aura: keys }
 }
 
-// calamari chain specs
+/// Returns the Calamari chain properties.
 pub fn calamari_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::CALAMARI_SS58PREFIX.into());
@@ -50,9 +48,8 @@ pub fn calamari_properties() -> Properties {
 	p
 }
 
+/// Returns the Calamari development chain spec.
 pub fn calamari_development_config() -> CalamariChainSpec {
-	let properties = calamari_properties();
-
 	CalamariChainSpec::from_genesis(
 		// Name
 		"Calamari Parachain Development",
@@ -79,7 +76,7 @@ pub fn calamari_development_config() -> CalamariChainSpec {
 		None,
 		Some(CALAMARI_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(calamari_properties()),
 		Extensions {
 			relay_chain: KUSAMA_RELAYCHAIN_DEV_NET.into(),
 			para_id: CALAMARI_PARACHAIN_ID,
@@ -87,9 +84,8 @@ pub fn calamari_development_config() -> CalamariChainSpec {
 	)
 }
 
+/// Returns the Calamari local chain spec.
 pub fn calamari_local_config() -> CalamariChainSpec {
-	let properties = calamari_properties();
-
 	CalamariChainSpec::from_genesis(
 		// Name
 		"Calamari Parachain Local",
@@ -140,7 +136,7 @@ pub fn calamari_local_config() -> CalamariChainSpec {
 		None,
 		Some(CALAMARI_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(calamari_properties()),
 		Extensions {
 			relay_chain: KUSAMA_RELAYCHAIN_LOCAL_NET.into(),
 			para_id: CALAMARI_PARACHAIN_ID,
@@ -148,12 +144,13 @@ pub fn calamari_local_config() -> CalamariChainSpec {
 	)
 }
 
+/// Returns the Calamari development genesis.
 fn calamari_dev_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-) -> calamari_runtime::GenesisConfig {
-	calamari_runtime::GenesisConfig {
+) -> GenesisConfig {
+	GenesisConfig {
 		system: calamari_runtime::SystemConfig {
 			code: calamari_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
@@ -217,6 +214,7 @@ fn calamari_dev_genesis(
 	}
 }
 
+/// Returns the Calamari testnet configuration.
 pub fn calamari_testnet_config() -> Result<CalamariChainSpec, String> {
 	let mut spec = CalamariChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/calamari-testnet-genesis.json")[..],
@@ -225,14 +223,14 @@ pub fn calamari_testnet_config() -> Result<CalamariChainSpec, String> {
 	Ok(spec)
 }
 
-// Calamari testnet for ci jobs
+/// Returns the Calamari testnet configuration for CI jobs.
 pub fn calamari_testnet_ci_config() -> Result<CalamariChainSpec, String> {
 	CalamariChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/calamari-testnet-ci-genesis.json")[..],
 	)
 }
 
-// Calamari mainnet
+/// Returns the Calamari mainnet configuration.
 pub fn calamari_config() -> Result<CalamariChainSpec, String> {
 	CalamariChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/calamari-genesis.json")[..],

--- a/node/src/chain_specs/dolphin.rs
+++ b/node/src/chain_specs/dolphin.rs
@@ -14,22 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Dolphin Chain Spec
+
 use super::*;
 use crate::command::DOLPHIN_PARACHAIN_ID;
-use dolphin_runtime::{
-	AssetManagerConfig, CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig,
-};
+use dolphin_runtime::{CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig};
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type DolphinChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
-pub const DOLPHIN_PROTOCOL_ID: &str = "dolphin"; // for p2p network configuration
+/// Dolphin Protocol ID for p2p Network Configuration
+pub const DOLPHIN_PROTOCOL_ID: &str = "dolphin";
+
+/// Kusama Relaychain Local Network
 pub const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
+
+/// Kusama Relaychain Development Network
 pub const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
 
 /// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = 2;
+pub const SAFE_XCM_VERSION: u32 = 2;
 
 /// Generate the dolphin session keys from individual elements.
 ///

--- a/node/src/chain_specs/dolphin.rs
+++ b/node/src/chain_specs/dolphin.rs
@@ -16,19 +16,17 @@
 
 use super::*;
 use crate::command::DOLPHIN_PARACHAIN_ID;
-
 use dolphin_runtime::{
 	AssetManagerConfig, CouncilConfig, DemocracyConfig, GenesisConfig, TechnicalCommitteeConfig,
 };
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type DolphinChainSpec =
-	sc_service::GenericChainSpec<dolphin_runtime::GenesisConfig, Extensions>;
+pub type DolphinChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
-const DOLPHIN_PROTOCOL_ID: &str = "dolphin"; // for p2p network configuration
-const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
-const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
+pub const DOLPHIN_PROTOCOL_ID: &str = "dolphin"; // for p2p network configuration
+pub const KUSAMA_RELAYCHAIN_LOCAL_NET: &str = "kusama-local";
+pub const KUSAMA_RELAYCHAIN_DEV_NET: &str = "kusama-dev";
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = 2;
@@ -40,7 +38,7 @@ pub fn dolphin_session_keys(keys: AuraId) -> dolphin_runtime::opaque::SessionKey
 	dolphin_runtime::opaque::SessionKeys { aura: keys }
 }
 
-// dolphin chain specs
+/// Returns the Dolphin chain properties.
 pub fn dolphin_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::CALAMARI_SS58PREFIX.into());
@@ -49,9 +47,8 @@ pub fn dolphin_properties() -> Properties {
 	p
 }
 
+/// Returns the Dolphin development chain spec.
 pub fn dolphin_development_config() -> DolphinChainSpec {
-	let properties = dolphin_properties();
-
 	DolphinChainSpec::from_genesis(
 		// Name
 		"Dolphin Parachain Development",
@@ -78,7 +75,7 @@ pub fn dolphin_development_config() -> DolphinChainSpec {
 		None,
 		Some(DOLPHIN_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(dolphin_properties()),
 		Extensions {
 			relay_chain: "".into(),
 			para_id: DOLPHIN_PARACHAIN_ID,
@@ -86,9 +83,8 @@ pub fn dolphin_development_config() -> DolphinChainSpec {
 	)
 }
 
+/// Returns the Dolphin local chain spec.
 pub fn dolphin_local_config() -> DolphinChainSpec {
-	let properties = dolphin_properties();
-
 	DolphinChainSpec::from_genesis(
 		// Name
 		"Dolphin Parachain Local",
@@ -139,7 +135,7 @@ pub fn dolphin_local_config() -> DolphinChainSpec {
 		None,
 		Some(DOLPHIN_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(dolphin_properties()),
 		Extensions {
 			relay_chain: "".into(),
 			para_id: DOLPHIN_PARACHAIN_ID,
@@ -147,12 +143,13 @@ pub fn dolphin_local_config() -> DolphinChainSpec {
 	)
 }
 
+/// Returns the Dolphin development genesis.
 fn dolphin_dev_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-) -> dolphin_runtime::GenesisConfig {
-	dolphin_runtime::GenesisConfig {
+) -> GenesisConfig {
+	GenesisConfig {
 		system: dolphin_runtime::SystemConfig {
 			code: dolphin_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
@@ -216,6 +213,7 @@ fn dolphin_dev_genesis(
 	}
 }
 
+/// Returns the Dolphin testnet configuration.
 pub fn dolphin_testnet_config() -> Result<DolphinChainSpec, String> {
 	let mut spec = DolphinChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/dolphin-testnet-genesis.json")[..],

--- a/node/src/chain_specs/manta.rs
+++ b/node/src/chain_specs/manta.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Manta Chain Spec
+
 use super::*;
 use crate::command::MANTA_PARACHAIN_ID;
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
@@ -22,9 +24,16 @@ use manta_runtime::GenesisConfig;
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type MantaChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
-pub const MANTA_PROTOCOL_ID: &str = "manta"; // for p2p network configuration
+/// Manta Protocol ID for p2p Network Configuration
+pub const MANTA_PROTOCOL_ID: &str = "manta";
+
+/// Polkadot Relaychain Local Network
 pub const POLKADOT_RELAYCHAIN_LOCAL_NET: &str = "polkadot-local";
+
+/// Polkadot Relaychain Development Network
 pub const POLKADOT_RELAYCHAIN_DEV_NET: &str = "polkadot-dev";
+
+/// Polkadot Relaychain Main Network
 pub const POLKADOT_RELAYCHAIN_MAIN_NET: &str = "polkadot";
 
 /// The default XCM version to set in genesis config.

--- a/node/src/chain_specs/manta.rs
+++ b/node/src/chain_specs/manta.rs
@@ -16,18 +16,19 @@
 
 use super::*;
 use crate::command::MANTA_PARACHAIN_ID;
-
-pub type MantaChainSpec = sc_service::GenericChainSpec<manta_runtime::GenesisConfig, Extensions>;
 use manta_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
+use manta_runtime::GenesisConfig;
 
-const MANTA_PROTOCOL_ID: &str = "manta"; // for p2p network configuration
-const POLKADOT_RELAYCHAIN_LOCAL_NET: &str = "polkadot-local";
-const POLKADOT_RELAYCHAIN_DEV_NET: &str = "polkadot-dev";
-#[allow(dead_code)]
-const POLKADOT_RELAYCHAIN_MAIN_NET: &str = "polkadot";
+/// Specialized `ChainSpec` for the normal parachain runtime.
+pub type MantaChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
+
+pub const MANTA_PROTOCOL_ID: &str = "manta"; // for p2p network configuration
+pub const POLKADOT_RELAYCHAIN_LOCAL_NET: &str = "polkadot-local";
+pub const POLKADOT_RELAYCHAIN_DEV_NET: &str = "polkadot-dev";
+pub const POLKADOT_RELAYCHAIN_MAIN_NET: &str = "polkadot";
 
 /// The default XCM version to set in genesis config.
-const SAFE_XCM_VERSION: u32 = 2;
+pub const SAFE_XCM_VERSION: u32 = 2;
 
 /// Generate the manta session keys from individual elements.
 ///
@@ -36,7 +37,7 @@ pub fn manta_session_keys(keys: AuraId) -> manta_runtime::opaque::SessionKeys {
 	manta_runtime::opaque::SessionKeys { aura: keys }
 }
 
-/// Token
+/// Returns the Manta chain properties.
 pub fn manta_properties() -> Properties {
 	let mut p = Properties::new();
 	p.insert("ss58format".into(), constants::MANTA_SS58PREFIX.into());
@@ -45,10 +46,8 @@ pub fn manta_properties() -> Properties {
 	p
 }
 
-// manta chain spec
+/// Returns the Manta development chain spec.
 pub fn manta_development_config() -> MantaChainSpec {
-	let properties = manta_properties();
-
 	MantaChainSpec::from_genesis(
 		// Name
 		"Manta Parachain Development",
@@ -75,7 +74,7 @@ pub fn manta_development_config() -> MantaChainSpec {
 		None,
 		Some(MANTA_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(manta_properties()),
 		Extensions {
 			relay_chain: POLKADOT_RELAYCHAIN_DEV_NET.into(),
 			para_id: MANTA_PARACHAIN_ID,
@@ -83,9 +82,8 @@ pub fn manta_development_config() -> MantaChainSpec {
 	)
 }
 
+/// Returns the Calamari local chain spec.
 pub fn manta_local_config() -> MantaChainSpec {
-	let properties = manta_properties();
-
 	MantaChainSpec::from_genesis(
 		// Name
 		"Manta Parachain Local",
@@ -124,7 +122,7 @@ pub fn manta_local_config() -> MantaChainSpec {
 		None,
 		Some(MANTA_PROTOCOL_ID),
 		None,
-		Some(properties),
+		Some(manta_properties()),
 		Extensions {
 			relay_chain: POLKADOT_RELAYCHAIN_LOCAL_NET.into(),
 			para_id: MANTA_PARACHAIN_ID,
@@ -132,12 +130,13 @@ pub fn manta_local_config() -> MantaChainSpec {
 	)
 }
 
+/// Returns the Manta development genesis.
 fn manta_dev_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-) -> manta_runtime::GenesisConfig {
-	manta_runtime::GenesisConfig {
+) -> GenesisConfig {
+	GenesisConfig {
 		system: manta_runtime::SystemConfig {
 			code: manta_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
@@ -189,6 +188,7 @@ fn manta_dev_genesis(
 	}
 }
 
+/// Returns the Manta testnet configuration.
 pub fn manta_testnet_config() -> Result<MantaChainSpec, String> {
 	let mut spec = MantaChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/manta-testnet-genesis.json")[..],
@@ -197,14 +197,16 @@ pub fn manta_testnet_config() -> Result<MantaChainSpec, String> {
 	Ok(spec)
 }
 
-pub fn manta_config() -> Result<MantaChainSpec, String> {
-	MantaChainSpec::from_json_bytes(&include_bytes!("../../../genesis/manta-genesis.json")[..])
-}
-
+/// Returns the Manta testnet configuration for CI jobs.
 pub fn manta_testnet_ci_config() -> Result<MantaChainSpec, String> {
 	let mut spec = MantaChainSpec::from_json_bytes(
 		&include_bytes!("../../../genesis/manta-testnet-ci-genesis.json")[..],
 	)?;
 	spec.extensions_mut().para_id = MANTA_PARACHAIN_ID;
 	Ok(spec)
+}
+
+/// Returns the Manta mainnet configuration.
+pub fn manta_config() -> Result<MantaChainSpec, String> {
+	MantaChainSpec::from_json_bytes(&include_bytes!("../../../genesis/manta-genesis.json")[..])
 }

--- a/node/src/chain_specs/mod.rs
+++ b/node/src/chain_specs/mod.rs
@@ -14,43 +14,43 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_imports)]
-#![allow(dead_code)]
-use cumulus_primitives_core::ParaId;
-use hex_literal::hex;
+//! Chain Specifications
+
 use manta_primitives::{
 	constants,
-	types::{AccountId, AuraId, Balance, Signature},
+	types::{AccountId, AuraId, Balance},
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::{ChainType, Properties};
 use serde::{Deserialize, Serialize};
-use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_core::sr25519;
+
+pub use self::{calamari::*, dolphin::*, manta::*};
+pub use calamari_runtime::currency::KMA;
+pub use dolphin_runtime::currency::DOL;
+pub use manta_runtime::currency::MANTA;
 
 pub mod calamari;
-pub use self::calamari::*;
-pub use calamari_runtime::currency::KMA;
-pub mod manta;
-pub use self::manta::*;
-pub use manta_runtime::currency::MANTA;
 pub mod dolphin;
-pub use self::dolphin::*;
-pub use dolphin_runtime::currency::DOL;
+pub mod manta;
 
-const CALAMARI_ENDOWMENT: Balance = 1_000_000_000 * KMA; // 10 endowment so that total supply is 10B
+/// Calamari Endowment
+pub const CALAMARI_ENDOWMENT: Balance = 1_000_000_000 * KMA; // 10 endowment so that total supply is 10B
 
-const DOLPHIN_ENDOWMENT: Balance = 1_000_000_000 * DOL; // 10 endowment so that total supply is 10B
+/// Dolphin Endowment
+pub const DOLPHIN_ENDOWMENT: Balance = 1_000_000_000 * DOL; // 10 endowment so that total supply is 10B
 
-const MANTA_ENDOWMENT: Balance = 100_000_000 * MANTA; // 10 endowment so that total supply is 1B
+/// Manta Endowment
+pub const MANTA_ENDOWMENT: Balance = 100_000_000 * MANTA; // 10 endowment so that total supply is 1B
 
-const STAGING_TELEMETRY_URL: &str = "wss://api.telemetry.manta.systems/submit/";
+/// Staging Telemetry URL
+pub const STAGING_TELEMETRY_URL: &str = "wss://api.telemetry.manta.systems/submit/";
 
-// A generic chain spec
+/// Generic Manta Chain Spec
 pub type ChainSpec = sc_service::GenericChainSpec<manta_runtime::GenesisConfig, Extensions>;
 
 /// The extensions for the [`ChainSpec`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
+#[derive(ChainSpecExtension, ChainSpecGroup, Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Extensions {
 	/// The relay chain of the Parachain.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Node CLI
+
 use crate::chain_specs;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -102,6 +104,7 @@ pub struct ExportGenesisWasmCommand {
 	pub chain: Option<String>,
 }
 
+/// Node CLI
 #[derive(Debug, StructOpt)]
 #[structopt(settings = &[
 	structopt::clap::AppSettings::GlobalVersion,
@@ -109,9 +112,11 @@ pub struct ExportGenesisWasmCommand {
 	structopt::clap::AppSettings::SubcommandsNegateReqs,
 ])]
 pub struct Cli {
+	/// CLI Subcommand
 	#[structopt(subcommand)]
 	pub subcommand: Option<Subcommand>,
 
+	/// Cumulus Client Run CLI
 	#[structopt(flatten)]
 	pub run: cumulus_client_cli::RunCmd,
 
@@ -120,6 +125,7 @@ pub struct Cli {
 	pub relaychain_args: Vec<String>,
 }
 
+/// Relay Chain CLI
 #[derive(Debug)]
 pub struct RelayChainCli {
 	/// The actual relay chain cli object.

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -19,12 +19,10 @@ use crate::{
 	cli::{Cli, RelayChainCli, Subcommand},
 	service::{new_partial, CalamariRuntimeExecutor, DolphinRuntimeExecutor, MantaRuntimeExecutor},
 };
-
 use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
-
 use manta_primitives::types::{AuraId, Header};
 use polkadot_parachain::primitives::AccountIdConversion;
 use sc_cli::{

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -16,7 +16,14 @@
 
 //! Manta/Calamari Parachain CLI
 
-#[inline]
-fn main() -> sc_cli::Result<()> {
-	command::run()
-}
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![forbid(rustdoc::broken_intra_doc_links)]
+#![forbid(missing_docs)]
+
+extern crate alloc;
+
+pub mod chain_specs;
+pub mod cli;
+pub mod command;
+pub mod rpc;
+pub mod service;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -18,7 +18,6 @@
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![forbid(rustdoc::broken_intra_doc_links)]
-#![forbid(missing_docs)]
 
 extern crate alloc;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -18,5 +18,5 @@
 
 #[inline]
 fn main() -> sc_cli::Result<()> {
-	command::run()
+	manta::command::run()
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -16,16 +16,16 @@
 
 //! Parachain-specific RPCs implementation.
 
-use std::sync::Arc;
-
+use alloc::sync::Arc;
+use frame_rpc_system::{FullSystem, SystemApi};
+use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
+use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 use sc_client_api::AuxStore;
-pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
+use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
-
-use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
 
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
@@ -55,16 +55,12 @@ where
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
-	use frame_rpc_system::{FullSystem, SystemApi};
-	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
-
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps {
 		client,
 		pool,
 		deny_unsafe,
 	} = deps;
-
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(
 		client.clone(),
 		pool,
@@ -73,6 +69,5 @@ where
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
 		client,
 	)));
-
 	io
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -21,7 +21,7 @@ use frame_rpc_system::{FullSystem, SystemApi};
 use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
 use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 use sc_client_api::AuxStore;
-use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
+use sc_rpc::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -34,7 +34,7 @@ use cumulus_primitives_core::{
 use cumulus_relay_chain_interface::RelayChainInterface;
 use cumulus_relay_chain_local::build_relay_chain_interface;
 use futures::lock::Mutex;
-use manta_primitives::types::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
+use manta_primitives::types::{AccountId, Balance, Hash, Header, Index as Nonce};
 use polkadot_service::NativeExecutionDispatch;
 use sc_client_api::ExecutorProvider;
 use sc_consensus::{
@@ -56,6 +56,8 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Header as HeaderT},
 };
 use substrate_prometheus_endpoint::Registry;
+
+pub use manta_primitives::types::Block;
 
 /// Native Manta Parachain executor instance.
 pub struct MantaRuntimeExecutor;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -14,12 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::rpc;
+use alloc::sync::Arc;
 use codec::Codec;
 use core::marker::PhantomData;
 use cumulus_client_consensus_aura::{AuraConsensus, BuildAuraConsensusParams, SlotProportion};
 use cumulus_client_consensus_common::{
 	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
 };
+use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
 	prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
@@ -30,13 +33,9 @@ use cumulus_primitives_core::{
 };
 use cumulus_relay_chain_interface::RelayChainInterface;
 use cumulus_relay_chain_local::build_relay_chain_interface;
-use polkadot_service::NativeExecutionDispatch;
-
-use crate::rpc;
-pub use manta_primitives::types::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
-
-use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use futures::lock::Mutex;
+use manta_primitives::types::{AccountId, Balance, Block, Hash, Header, Index as Nonce};
+use polkadot_service::NativeExecutionDispatch;
 use sc_client_api::ExecutorProvider;
 use sc_consensus::{
 	import_queue::{BasicQueue, Verifier as VerifierT},
@@ -56,11 +55,11 @@ use sp_runtime::{
 	generic::BlockId,
 	traits::{BlakeTwo256, Header as HeaderT},
 };
-use std::sync::Arc;
 use substrate_prometheus_endpoint::Registry;
 
-// Native Manta Parachain executor instance.
+/// Native Manta Parachain executor instance.
 pub struct MantaRuntimeExecutor;
+
 impl sc_executor::NativeExecutionDispatch for MantaRuntimeExecutor {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 
@@ -73,8 +72,9 @@ impl sc_executor::NativeExecutionDispatch for MantaRuntimeExecutor {
 	}
 }
 
-// Native Calamari Parachain executor instance.
+/// Native Calamari Parachain executor instance.
 pub struct CalamariRuntimeExecutor;
+
 impl sc_executor::NativeExecutionDispatch for CalamariRuntimeExecutor {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 
@@ -87,8 +87,9 @@ impl sc_executor::NativeExecutionDispatch for CalamariRuntimeExecutor {
 	}
 }
 
-// Native Dolphin Parachain executor instance.
+/// Native Dolphin Parachain executor instance.
 pub struct DolphinRuntimeExecutor;
+
 impl sc_executor::NativeExecutionDispatch for DolphinRuntimeExecutor {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 

--- a/pallets/asset-manager/src/benchmarking.rs
+++ b/pallets/asset-manager/src/benchmarking.rs
@@ -38,7 +38,7 @@ benchmarks! {
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 
-	}: _(RawOrigin::Root, location.clone(), metadata.clone())
+	}: _(RawOrigin::Root, location.clone(), metadata)
 	verify {
 		assert_eq!(Pallet::<T>::asset_id_location(<T::AssetConfig as AssetConfig<T>>::StartNonNativeAssetId::get()), Some(location));
 	}
@@ -60,7 +60,7 @@ benchmarks! {
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
 		let amount = 10;
-		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+		Pallet::<T>::register_asset(RawOrigin::Root.into(), location, metadata)?;
 
 	}: _(RawOrigin::Root, end, amount)
 	verify {
@@ -82,7 +82,7 @@ benchmarks! {
 		// does not really matter what we register, as long as it is different than the previous
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
-		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+		Pallet::<T>::register_asset(RawOrigin::Root.into(), location, metadata)?;
 		let new_location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::from(MultiLocation::new(0, X1(Parachain(end))));
 	}: _(RawOrigin::Root, end, new_location.clone())
 	verify {
@@ -104,7 +104,7 @@ benchmarks! {
 		// does not really matter what we register, as long as it is different than the previous
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
-		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+		Pallet::<T>::register_asset(RawOrigin::Root.into(), location, metadata.clone())?;
 	}: _(RawOrigin::Root, end, metadata.clone())
 	verify {
 		assert_last_event::<T>(Event::AssetMetadataUpdated { asset_id: end, metadata }.into());
@@ -126,7 +126,7 @@ benchmarks! {
 		// does not really matter what we register, as long as it is different than the previous
 		let location = <T::AssetConfig as AssetConfig<T>>::AssetLocation::default();
 		let metadata = <T::AssetConfig as AssetConfig<T>>::AssetRegistrarMetadata::default();
-		Pallet::<T>::register_asset(RawOrigin::Root.into(), location.clone(), metadata.clone())?;
+		Pallet::<T>::register_asset(RawOrigin::Root.into(), location, metadata)?;
 	}: _(RawOrigin::Root, end, beneficiary.clone(), amount)
 	verify {
 		assert_last_event::<T>(Event::AssetMinted { asset_id: end, beneficiary, amount }.into());

--- a/pallets/collator-selection/src/benchmarking.rs
+++ b/pallets/collator-selection/src/benchmarking.rs
@@ -130,7 +130,7 @@ benchmarks! {
 		let origin = T::UpdateOrigin::successful_origin();
 	}: {
 		assert_ok!(
-			<CollatorSelection<T>>::set_desired_candidates(origin, max.clone())
+			<CollatorSelection<T>>::set_desired_candidates(origin, max)
 		);
 	}
 	verify {
@@ -142,7 +142,7 @@ benchmarks! {
 		let origin = T::UpdateOrigin::successful_origin();
 	}: {
 		assert_ok!(
-			<CollatorSelection<T>>::set_candidacy_bond(origin, bond.clone())
+			<CollatorSelection<T>>::set_candidacy_bond(origin, bond)
 		);
 	}
 	verify {
@@ -186,7 +186,7 @@ benchmarks! {
 
 		let caller: T::AccountId = whitelisted_caller();
 		let bond: BalanceOf<T> = T::Currency::minimum_balance() * 2u32.into();
-		T::Currency::make_free_balance_be(&caller, bond.clone());
+		T::Currency::make_free_balance_be(&caller, bond);
 
 		<session::Pallet<T>>::set_keys(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -249,7 +249,7 @@ benchmarks! {
 
 		let caller: T::AccountId = whitelisted_caller();
 		let bond: BalanceOf<T> = T::Currency::minimum_balance() * 2u32.into();
-		T::Currency::make_free_balance_be(&caller, bond.clone());
+		T::Currency::make_free_balance_be(&caller, bond);
 
 		<session::Pallet<T>>::set_keys(
 			RawOrigin::Signed(caller.clone()).into(),

--- a/pallets/collator-selection/src/lib.rs
+++ b/pallets/collator-selection/src/lib.rs
@@ -609,17 +609,17 @@ pub mod pallet {
 
 			// 5. Walk the percentile slice, call try_remove_candidate if a collator is under threshold
 			let kick_candidates = &collator_perf_this_session[..index_at_ordinal_rank]; // ordinal-rank exclusive, the collator at percentile is safe
-			let mut removed_account_ids: Vec<T::AccountId> = Vec::with_capacity(kick_candidates.len());
+			let mut removed_account_ids: Vec<T::AccountId> =
+				Vec::with_capacity(kick_candidates.len());
 			kick_candidates.iter().for_each(|(acc_id, my_blocks_this_session)| {
 				if *my_blocks_this_session < evict_below_blocks {
 					// If our validator is not also a candidate we're invulnerable or already kicked
-					if let Some(_) = candidates.iter().find(|&x|{ x.who == *acc_id })
+					if candidates.iter().any(|x| x.who == *acc_id)
 					{
 						Self::try_remove_candidate(acc_id)
-							.and_then(|_| {
+							.map(|_| {
 								removed_account_ids.push(acc_id.clone());
 								log::info!("Removed collator of account {:?} as it only produced {} blocks this session which is below acceptable threshold of {}", &acc_id, my_blocks_this_session,evict_below_blocks);
-								Ok(())
 							})
 							.unwrap_or_else(|why| {
 								log::warn!("Failed to remove candidate due to underperformance {:?}", why);

--- a/pallets/tx-pause/src/benchmarking.rs
+++ b/pallets/tx-pause/src/benchmarking.rs
@@ -36,7 +36,6 @@ pub fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 }
 
 benchmarks! {
-
 	// Benchmark `pause_transaction` extrinsic:
 	pause_transaction {
 		let pallet_name = b"Balances".to_vec();
@@ -44,7 +43,7 @@ benchmarks! {
 	}: pause_transaction(RawOrigin::Root, pallet_name.clone(), function_name.clone())
 	verify {
 		assert_last_event::<T>(
-			Event::TransactionPaused(pallet_name.clone(), function_name.clone()).into()
+			Event::TransactionPaused(pallet_name.clone(), function_name).into()
 		);
 	}
 
@@ -53,13 +52,11 @@ benchmarks! {
 		let origin: T::Origin = T::Origin::from(RawOrigin::Root);
 		let pallet_name = b"Balances".to_vec();
 		let function_name =  b"transfer".to_vec();
-
-		TransactionPause::<T>::pause_transaction(origin.clone(), pallet_name.clone(), function_name.clone())?;
-
+		TransactionPause::<T>::pause_transaction(origin, pallet_name.clone(), function_name.clone())?;
 	}: unpause_transaction(RawOrigin::Root, pallet_name.clone(), function_name.clone())
 	verify {
 		assert_last_event::<T>(
-			Event::TransactionUnpaused(pallet_name.clone(), function_name.clone()).into()
+			Event::TransactionUnpaused(pallet_name.clone(), function_name).into()
 		);
 	}
 }

--- a/pallets/vesting/src/benchmarking.rs
+++ b/pallets/vesting/src/benchmarking.rs
@@ -53,7 +53,7 @@ fn init_setup<
 	let existential_deposit = <T as pallet_balances::Config<I>>::ExistentialDeposit::get();
 	let amount = existential_deposit.saturating_mul(ED_MULTIPLIER.into());
 	let source_caller = T::Lookup::unlookup(caller.clone());
-	let _ = pallet_balances::Pallet::<T, I>::make_free_balance_be(&caller, amount);
+	let _ = pallet_balances::Pallet::<T, I>::make_free_balance_be(caller, amount);
 
 	assert_ok!(pallet_balances::Pallet::<T, I>::set_balance(
 		RawOrigin::Root.into(),
@@ -96,7 +96,7 @@ benchmarks! {
 		init_setup::<T, ()>(&caller);
 		let existential_deposit = <T as pallet_balances::Config<()>>::ExistentialDeposit::get();
 		let unvested = existential_deposit.saturating_mul(ED_MULTIPLIER.div(10u32).into()).saturated_into::<u128>().try_into().ok().unwrap();
-		assert_ok!(crate::Pallet::<T>::vested_transfer(RawOrigin::Signed(caller.clone()).into(), source_recipient, unvested));
+		assert_ok!(crate::Pallet::<T>::vested_transfer(RawOrigin::Signed(caller).into(), source_recipient, unvested));
 		assert!(crate::Pallet::<T>::vesting_balance(&recipient).is_some());
 
 		let now = Duration::from_secs(1660694400)

--- a/primitives/src/assets.rs
+++ b/primitives/src/assets.rs
@@ -439,7 +439,7 @@ where
 			<Native as Currency<C::AccountId>>::deposit_creating(beneficiary, amount);
 		} else {
 			<NonNative as Mutate<C::AccountId>>::mint_into(asset_id, beneficiary, amount)
-				.map_err(|e| FungibleLedgerError::InvalidMint(e))?;
+				.map_err(FungibleLedgerError::InvalidMint)?;
 		}
 		Ok(())
 	}
@@ -469,6 +469,6 @@ where
 			)
 			.map(|_| ())
 		}
-		.map_err(|e| FungibleLedgerError::InvalidTransfer(e))
+		.map_err(FungibleLedgerError::InvalidTransfer)
 	}
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -43,16 +43,18 @@ pub type Hash = sp_core::H256;
 
 /// Block header type as expected by this runtime.
 pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
+
+/// Block Type
 pub type Block = sp_runtime::generic::Block<Header, sp_runtime::OpaqueExtrinsic>;
 
 /// Digest item type.
 pub type DigestItem = sp_runtime::generic::DigestItem;
 
-// Aura consensus authority.
+/// Aura consensus authority
 pub type AuraId = sp_consensus_aura::sr25519::AuthorityId;
 
-// Moment
+/// Moment
 pub type Moment = u64;
 
-// AssetId
+/// AssetId
 pub type AssetId = AssetIdType;

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -18,26 +18,14 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
+#![allow(clippy::identity_op)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::{
-	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT},
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Perbill, Permill,
-};
-
-use sp_core::u32_trait::{_1, _2, _3, _4, _5};
-use sp_std::{cmp::Ordering, prelude::*};
-#[cfg(feature = "std")]
-use sp_version::NativeVersion;
-use sp_version::RuntimeVersion;
-
+use currency::*;
+use fee::WeightToFee;
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{ConstU16, ConstU32, ConstU8, Contains, Currency, EnsureOneOf, PrivilegeCmp},
@@ -51,29 +39,40 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
+use impls::DealWithFees;
 use manta_primitives::{
 	constants::{time::*, STAKING_PALLET_ID, TREASURY_PALLET_ID},
 	types::{AccountId, AuraId, Balance, BlockNumber, Hash, Header, Index, Signature},
 };
+use polkadot_runtime_common::{BlockHashCount, RocksDbWeight, SlowAdjustingFeeUpdate};
 use runtime_common::prod_or_fast;
+use sp_api::impl_runtime_apis;
+use sp_core::{
+	crypto::KeyTypeId,
+	u32_trait::{_1, _2, _3, _4, _5},
+	OpaqueMetadata,
+};
+use sp_runtime::{
+	create_runtime_str, generic, impl_opaque_keys,
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT},
+	transaction_validity::{TransactionSource, TransactionValidity},
+	ApplyExtrinsicResult, Perbill, Permill,
+};
+use sp_std::{cmp::Ordering, prelude::*};
+use sp_version::RuntimeVersion;
+use xcm::latest::prelude::*;
+
+#[cfg(feature = "std")]
+use sp_version::NativeVersion;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-
-// Polkadot imports
-
-use polkadot_runtime_common::{BlockHashCount, RocksDbWeight, SlowAdjustingFeeUpdate};
-use xcm::latest::prelude::*;
 
 pub mod assets_config;
 pub mod currency;
 pub mod fee;
 pub mod impls;
 pub mod xcm_config;
-
-use currency::*;
-use fee::WeightToFee;
-use impls::DealWithFees;
 
 pub type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 
@@ -162,99 +161,103 @@ impl pallet_tx_pause::Config for Runtime {
 	type WeightInfo = weights::pallet_tx_pause::SubstrateWeight<Runtime>;
 }
 
-// Don't allow permission-less asset creation.
+/// Don't allow permission-less asset creation.
 pub struct BaseFilter;
+
 impl Contains<Call> for BaseFilter {
 	fn contains(call: &Call) -> bool {
+		// Always allow core call but pallet-timestamp and parachainSystem could not be filtered
+		// because they are used in communication between releychain and parachain.
 		if matches!(
 			call,
-			Call::Timestamp(_) | Call::ParachainSystem(_) | Call::System(_)
+			Call::ParachainSystem(_) | Call::System(_) | Call::Timestamp(_)
 		) {
-			// always allow core call
-			// pallet-timestamp and parachainSystem could not be filtered because
-			// they are used in communication between relaychain and parachain.
 			return true;
 		}
 
+		// No paused call allowed.
 		if pallet_tx_pause::PausedTransactionFilter::<Runtime>::contains(call) {
-			// no paused call
 			return false;
 		}
 
-		match call {
+		// Filter out XCM pallets, we only allow transfer with XTokens. Filter Assets. Assets should
+		// only be accessed by AssetManager. AssetManager is also filtered because all of its
+		// extrinsics are callable only by Root, and Root calls skip this whole filter.
+		matches!(
+			call,
 			| Call::Authorship(_)
 			// Sudo also cannot be filtered because it is used in runtime upgrade.
 			| Call::Sudo(_)
 			| Call::Multisig(_)
-			// For now disallow public proposal workflows, treasury workflows,
-			// as well as external_propose and external_propose_majority.
-			// The following are filtered out:
-			// pallet_democracy::Call::propose(_)
-			// pallet_democracy::Call::second(_, _)
-			// pallet_democracy::Call::cancel_proposal(_)
-			// pallet_democracy::Call::clear_public_proposals()
-			// pallet_democracy::Call::external_propose(_)
-			// pallet_democracy::Call::external_propose_majority(_)
-			| Call::Democracy(pallet_democracy::Call::vote {..}
-								| pallet_democracy::Call::emergency_cancel {..}
-								| pallet_democracy::Call::external_propose_default {..}
-								| pallet_democracy::Call::fast_track  {..}
-								| pallet_democracy::Call::veto_external {..}
-								| pallet_democracy::Call::cancel_referendum {..}
-								| pallet_democracy::Call::cancel_queued {..}
-								| pallet_democracy::Call::delegate {..}
-								| pallet_democracy::Call::undelegate {..}
-								| pallet_democracy::Call::note_preimage {..}
-								| pallet_democracy::Call::note_preimage_operational {..}
-								| pallet_democracy::Call::note_imminent_preimage {..}
-								| pallet_democracy::Call::note_imminent_preimage_operational {..}
-								| pallet_democracy::Call::reap_preimage {..}
-								| pallet_democracy::Call::unlock {..}
-								| pallet_democracy::Call::remove_vote {..}
-								| pallet_democracy::Call::remove_other_vote {..}
-								| pallet_democracy::Call::enact_proposal {..}
-								| pallet_democracy::Call::blacklist {..})
+			// For now disallow public proposal workflows, treasury workflows, as well as
+			// `external_propose` and external_propose_majority. The following are filtered out:
+			| Call::Democracy(
+				| pallet_democracy::Call::blacklist {..}
+				// | pallet_democracy::Call::cancel_proposal(_)
+				| pallet_democracy::Call::cancel_queued {..}
+				| pallet_democracy::Call::cancel_referendum {..}
+				// | pallet_democracy::Call::clear_public_proposals()
+				| pallet_democracy::Call::delegate {..}
+				| pallet_democracy::Call::emergency_cancel {..}
+				| pallet_democracy::Call::enact_proposal {..}
+				// | pallet_democracy::Call::external_propose(_)
+				| pallet_democracy::Call::external_propose_default {..}
+				// | pallet_democracy::Call::external_propose_majority(_)
+				| pallet_democracy::Call::fast_track  {..}
+				| pallet_democracy::Call::note_imminent_preimage {..}
+				| pallet_democracy::Call::note_imminent_preimage_operational {..}
+				| pallet_democracy::Call::note_preimage {..}
+				| pallet_democracy::Call::note_preimage_operational {..}
+				// | pallet_democracy::Call::propose(_)
+				| pallet_democracy::Call::reap_preimage {..}
+				| pallet_democracy::Call::remove_other_vote {..}
+				| pallet_democracy::Call::remove_vote {..}
+				// | pallet_democracy::Call::second(_, _)
+				| pallet_democracy::Call::undelegate {..}
+				| pallet_democracy::Call::unlock {..}
+				| pallet_democracy::Call::veto_external {..}
+				| pallet_democracy::Call::vote {..}
+			)
 			| Call::Council(_)
 			| Call::TechnicalCommittee(_)
 			| Call::CouncilMembership(_)
 			| Call::TechnicalMembership(_)
 			// Treasury calls are filtered while it is accumulating funds.
-			//| Call::Treasury(_)
+			// | Call::Treasury(_)
 			| Call::Scheduler(_)
-			| Call::Session(_) // User must be able to set their session key when applying for a collator
+			// User must be able to set their session key when applying for a collator.
+			| Call::Session(_)
+			// Currently, we filter `register_as_candidate` as this call is not yet ready for
+			// community.
 			| Call::CollatorSelection(
-				manta_collator_selection::Call::set_invulnerables{..}
+				| manta_collator_selection::Call::set_invulnerables{..}
 				| manta_collator_selection::Call::set_desired_candidates{..}
 				| manta_collator_selection::Call::set_candidacy_bond{..}
 				| manta_collator_selection::Call::set_eviction_baseline{..}
 				| manta_collator_selection::Call::set_eviction_tolerance{..}
 				| manta_collator_selection::Call::register_candidate{..}
-				// Currently, we filter `register_as_candidate` as this call is not yet ready for community.
 				| manta_collator_selection::Call::remove_collator{..}
-				| manta_collator_selection::Call::leave_intent{..})
+				| manta_collator_selection::Call::leave_intent{..}
+			)
 			| Call::Balances(_)
-			// Everything except transfer() is filtered out until it is practically needed:
-			// orml_xtokens::Call::transfer_with_fee {..}
-			// orml_xtokens::Call::transfer_multiasset {..}
-			// orml_xtokens::Call::transfer_multiasset_with_fee {..}
-			// orml_xtokens::Call::transfer_multicurrencies  {..}
-			// orml_xtokens::Call::transfer_multiassets {..}
-			| Call::XTokens(orml_xtokens::Call::transfer {..})
+			// Everything except `transfer` is filtered out until it is practically needed.
+			| Call::XTokens(
+				// | orml_xtokens::Call::transfer_multiasset {..}
+				// | orml_xtokens::Call::transfer_multiasset_with_fee {..}
+				// | orml_xtokens::Call::transfer_multiassets {..}
+				// | orml_xtokens::Call::transfer_multicurrencies  {..}
+				| orml_xtokens::Call::transfer {..}
+				// | orml_xtokens::Call::transfer_with_fee {..}
+			)
 			| Call::MantaPay(_)
 			| Call::Preimage(_)
-			| Call::Utility(_) => true,
-			// Filter XCM pallets, we only allow transfer with XTokens.
-			// Filter Assets. Assets should only be accessed by AssetManager.
-			// AssetManager is also filtered because all of its extrinsics are callable only by Root,
-			// and Root calls skip this whole filter.
-			_ => false,
-		}
+			| Call::Utility(_),
+		)
 	}
 }
 
-// Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = BaseFilter; // Let filter activate.
+	type BaseCallFilter = BaseFilter;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type AccountId = AccountId;
@@ -885,19 +888,18 @@ impl_runtime_apis! {
 
 			let storage_info = AllPalletsReversedWithSystemFirst::storage_info();
 
-			return (list, storage_info)
+			(list, storage_info)
 		}
 
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
-
-			use frame_system_benchmarking::Pallet as SystemBench;
-			impl frame_system_benchmarking::Config for Runtime {}
-
 			use cumulus_pallet_session_benchmarking::Pallet as SessionBench;
+			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
+			use frame_system_benchmarking::Pallet as SystemBench;
+
 			impl cumulus_pallet_session_benchmarking::Config for Runtime {}
+			impl frame_system_benchmarking::Config for Runtime {}
 
 			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes [bhgomes@pm.me](mailto:bhgomes@pm.me)

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

**This PR requires at least `polkadot-v0.9.17`.**

To use the node CLI in https://github.com/Manta-Network/cli/pull/1 we need to export the CLI code as a library instead of just a binary.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.