### PR TITLE
Mention SDK in release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -30,8 +30,8 @@ The following checks can be performed after we have frozen our release candidate
 - [ ] Complete the following [manual QA workflow](https://hackmd.io/TbFmorG2RnOPmLuFcg9JOQ?view).
 - [ ] Verify Polkadot JS API are up to date with the latest
     runtime changes.
-- [ ] Execute runtime upgrade to Como and verify network stability.
 - [ ] Execute runtime upgrade to Baikal and verify network stability.
+- [ ] Execute runtime upgrade to Rococo and verify network stability.
 - [ ] Prepare a governance post and submit to our forum with description and motivation for changes.
 
 ### Client Releases

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -45,9 +45,10 @@ The following checks can be performed after we have frozen our release candidate
     https://github.com/Manta-Network/Manta/releases with relevant [release
     notes](#release-notes)
 - [ ] Check that build artifacts have been added to the
-    draft-release
+    draft-release 
 - [ ] Coordinate with marketing team for documentation updates and other relevant tasks.
 - [ ] Update changelog.
+- [ ] If the release contains any changes that break/change functionality used in https://github.com/Manta-Network/sdk (e.g. RPC changes, see also [extrinsic ordering](#extrinsic-ordering)), raise a PR there and **block this release** until your PR has been merged and incorporated in a new SDK release.
 
 Note: Do not publish draft releases from PR branches, because those branches will be deleted when the PR is merged.
 
@@ -63,16 +64,16 @@ for at least 12 hours prior to publishing the release.
 
 ### Release notes
 
-The release notes should list:
+The release notes **MUST** contain:
 
 - The priority of the release (i.e., how quickly users should upgrade) - this is
     based on the max priority of any *client* changes.
+- The version of [Manta SDK](https://github.com/Manta-Network/sdk) that is compatible with this release
 - Which native runtimes and their versions are included
-- The proposal hashes of the runtimes as built with
-    [srtool](https://gitlab.com/chevdor/srtool)
-- Any changes in this release that are still awaiting audit
+- The proposal hashes of the runtimes as built with [srtool](https://gitlab.com/chevdor/srtool)
+- (After auditing starts:) Any changes in this release that are still awaiting audit
 
-The release notes may also list:
+The release notes **MAY** also list:
 
 - Free text at the beginning of the notes mentioning anything important
     regarding this release

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -45,7 +45,7 @@ The following checks can be performed after we have frozen our release candidate
     https://github.com/Manta-Network/Manta/releases with relevant [release
     notes](#release-notes)
 - [ ] Check that build artifacts have been added to the
-    draft-release 
+    draft-release
 - [ ] Coordinate with marketing team for documentation updates and other relevant tasks.
 - [ ] Update changelog.
 - [ ] If the release contains any changes that break/change functionality used in https://github.com/Manta-Network/sdk (e.g. RPC changes, see also [extrinsic ordering](#extrinsic-ordering)), raise a PR there and **block this release** until your PR has been merged and incorporated in a new SDK release.


### PR DESCRIPTION
See discussion in notion: https://www.notion.so/Codebase-Architecture-ceeed8b194394c39a54b5eb5fe4c83a6#e2f52134c50f4434afb80f48048c0cdc

Signed-off-by: Adam Reif <garandor@manta.network>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review.
Please commit refactors and minor intermediate (doc) changes on your PR with the `[no ci]` keyword to skip meaningless runs of the full CI pipeline.
-->

fix #600 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [ ] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
