### PR TITLE
fix: reduce pull rpc constant per shard

### DIFF
--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -465,7 +465,7 @@ pub mod pallet {
 		T: Config,
 	{
 		/// Maximum Number of Updates per Shard
-		const PULL_MAX_PER_SHARD_UPDATE_SIZE: usize = 128;
+		const PULL_MAX_PER_SHARD_UPDATE_SIZE: usize = 4;
 
 		/// Maximum Size of Sender Data Update
 		const PULL_MAX_SENDER_UPDATE_SIZE: usize = 1024;


### PR DESCRIPTION
Signed-off-by: Brandon H. Gomes <bhgomes@pm.me>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Reduces per-shard diff size constant to `4` from `128` for manta-pay pull RPC. Currently, the RPC is too slow when reading potentially `128 * 256` UTXOs from the storage. When downgrading to `4 * 256` we have a ~200ms read time. We will move to a more principled diff reading algorithm in the future, but we can at least use the current one when the maximum reads are reduced. Also, reducing it to `4 * 256 = 1024` makes it equal to the void number downloading rate.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests.
- [x] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [x] Verify benchmarks & weights have been updated for any modified runtime logics
- [x] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [x] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [x] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
