### PR TITLE
storage migration

### DIFF
--- a/tests/serialize_data.ts
+++ b/tests/serialize_data.ts
@@ -1,0 +1,44 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { manta_pay_types, rpc_api } from './types';
+import { readFile, writeFile } from 'fs/promises';
+import { StorageData } from '@polkadot/types/interfaces';
+
+const dolphin_config = {
+    ws_address: "wss://ws.rococo.dolphin.engineering"
+}
+
+async function getStorageValuesByBatch(api: ApiPromise, keys: Array<string>, batch_size: number = 4096) {
+    let storage_values: Array<StorageData> = [];
+    for(let remains = keys.length; remains > 0; ){
+        console.log("start a batched get, remains: %i", remains);
+        let true_size = remains > batch_size? batch_size : remains;
+        let key_batch = keys.slice(keys.length - remains, keys.length - (remains - true_size));
+        let data = await api.rpc.state.queryStorageAt(key_batch);
+        (data as Array<StorageData>).forEach((value)=>{
+            storage_values.push(value);
+        });
+        remains -= true_size;
+    }
+    return storage_values;
+}
+
+async function main(){
+    const wsProvider = new WsProvider(dolphin_config.ws_address);
+
+    const api = await ApiPromise.create({ 
+        provider: wsProvider,
+        types: manta_pay_types,
+        rpc: rpc_api});
+    
+    let manta_keys_raw = await readFile('./manta_pay_keys.json');
+    let manta_keys = JSON.parse(manta_keys_raw.toString());
+    let shards = await getStorageValuesByBatch(api, manta_keys.shards);
+    let shard_trees = await getStorageValuesByBatch(api, manta_keys.shard_trees);
+    let void_number_set_insertion_order = await getStorageValuesByBatch(api, manta_keys.void_number_set_insertion_order);
+    await writeFile('./shards.json', JSON.stringify(shards));
+    await writeFile('./shards_trees.json', JSON.stringify(shard_trees));
+    await writeFile('./void_number_set_insertion_order.json', JSON.stringify(void_number_set_insertion_order));
+    console.log("ledger data serialized.");
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/tests/serialize_keys.ts
+++ b/tests/serialize_keys.ts
@@ -1,0 +1,61 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { manta_pay_types, rpc_api } from './types';
+import { readFile, writeFile } from 'fs/promises';
+
+const dolphin_config = {
+    ws_address: "wss://ws.rococo.dolphin.engineering"
+}
+
+async function main(){
+    const wsProvider = new WsProvider(dolphin_config.ws_address);
+
+    const api = await ApiPromise.create({ 
+        provider: wsProvider,
+        types: manta_pay_types,
+        rpc: rpc_api});
+    
+    // get storage keys 
+    let shards = await api.query.mantaPay.shards.keys();
+    console.log("Fetched %i keys from Shards", shards.length);
+    let shard_trees = await api.query.mantaPay.shardTrees.keys();
+    console.log("Fetched %i keys from ShardTrees", shard_trees.length);
+    let utxo_acc_outputs = await api.query.mantaPay.utxoAccumulatorOutputs.keys();
+    console.log("Fetched %i keys from UtxoAccumulatorOutputs", utxo_acc_outputs.length);
+    let utxo_set = await api.query.mantaPay.utxoSet.keys();
+    console.log("Fetched %i keys from UtxoSet", utxo_set.length);
+    let void_number_set = await api.query.mantaPay.voidNumberSet.keys();
+    console.log("Fetched %i keys from VoidNumberSet", void_number_set.length);
+    let void_number_set_insertion_order = await api.query.mantaPay.voidNumberSetInsertionOrder.keys();
+    console.log("Fetched %i keys from VNSIO", void_number_set_insertion_order.length);
+    
+    const manta_pay_keys = {
+        shards: shards,
+        shard_trees: shard_trees,
+        utxo_acc_outputs: utxo_acc_outputs,
+        utxo_set: utxo_set,
+        void_number_set: void_number_set,
+        void_number_set_insertion_order: void_number_set_insertion_order,
+    };
+
+    var manta_keys_raw = JSON.stringify(manta_pay_keys);
+    console.log(manta_keys_raw.length);
+
+    await writeFile('./manta_pay_keys.json', manta_keys_raw);
+    console.log("write keys to manta_pay_keys.json");
+    const manta_keys_read_raw = await readFile('./manta_pay_keys.json');
+    const manta_keys_read = JSON.parse(manta_keys_read_raw.toString());
+    console.log(manta_keys_read.shards.length);
+    console.log(manta_keys_read.shards[0]);
+    console.log(manta_keys_read.shard_trees.length);
+    console.log(manta_keys_read.shard_trees[0]);
+    console.log(manta_keys_read.utxo_acc_outputs.length);
+    console.log(manta_keys_read.utxo_acc_outputs[0]);
+    console.log(manta_keys_read.utxo_set.length);
+    console.log(manta_keys_read.utxo_set[0]);
+    console.log(manta_keys_read.void_number_set.length);
+    console.log(manta_keys_read.void_number_set[0]);
+    console.log(manta_keys_read.void_number_set_insertion_order.length);
+    console.log(manta_keys_read.void_number_set_insertion_order[0]);
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/tests/storage_migration.ts
+++ b/tests/storage_migration.ts
@@ -1,0 +1,260 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { Keyring } from '@polkadot/keyring';
+import { manta_pay_types, rpc_api } from './types';
+import { xxhashAsU8a } from '@polkadot/util-crypto';
+import { readFile, writeFile } from 'fs/promises';
+import { u8aToHex, hexToU8a } from '@polkadot/util';
+import { ExecutionContext, emojis, delay } from './test-util';
+
+const dolphin_config = {
+    ws_address: "wss://ws.rococo.dolphin.engineering"
+}
+// "ws://127.0.0.1:9800"
+
+function convert_shard_utxo_keys(data: Uint8Array): Uint8Array{
+    let shard_idx_data = data.slice(0, 1);
+    let utxo_idx_data = data.slice(1,);
+    return new Uint8Array([
+        ...xxhashAsU8a(shard_idx_data, 64),
+        ...shard_idx_data,
+        ...xxhashAsU8a(utxo_idx_data, 64),
+        ...utxo_idx_data
+    ]);
+}
+
+function convert_single_map_keys(data: Uint8Array): Uint8Array{
+    return new Uint8Array([
+        ...xxhashAsU8a(data, 64),
+        ...data
+    ])
+}
+
+async function insert_value_batches(
+    context: ExecutionContext,    
+    kvs: Array<String[]>, 
+    batch_size: number,
+    timeout: number,
+){
+    let success_batch = 0;
+    let expected_batch = Math.ceil(kvs.length/batch_size);
+    for(let check_point = 0;  check_point < kvs.length; ){
+        let finish_point = check_point + batch_size > kvs.length ? kvs.length : check_point + batch_size;
+        let data = kvs.slice(check_point, finish_point);
+        let call_data = context.api.tx.system.setStorage(data);
+        const unsub = await context.api.tx.sudo.sudo(call_data).signAndSend(context.keyring, {nonce: -1}, ({ events = [], status }) => {
+            if (status.isFinalized) {
+                success_batch ++;
+                console.log("%s %i batchs insertion finalized.", emojis.write, success_batch);
+                unsub();
+            }
+        });
+        check_point = finish_point;
+    }
+
+    // wait all txs finalized
+    for(let i =0; i < timeout; i ++){
+        await delay(1000);
+        if (success_batch === expected_batch) {
+            console.log("total wait: %i sec.", i + 1);
+            return success_batch;
+        }
+    }
+    throw "timeout";
+}
+
+async function insert_values(
+    context: ExecutionContext,
+    kvs: Array<String[]>, 
+    batch_size: number = 4096,
+    batch_count_before_gap: number = 4,
+    timeout_for_big_batch: number = 1000, 
+){
+    const big_batch_size = batch_size * batch_count_before_gap;
+    for(let check_point = 0; check_point < kvs.length; ){
+        let finish_point = check_point + big_batch_size > kvs.length ? kvs.length : check_point + big_batch_size;
+        console.log(">>>>>> writng big batch from %i", check_point);
+        await insert_value_batches(context, kvs.slice(check_point, finish_point), batch_size, timeout_for_big_batch);
+        check_point = finish_point;
+    }
+}
+
+async function drop_keys_in_batches(
+    context: ExecutionContext,    
+    keys: Array<String>, 
+    batch_size: number,
+    timeout: number,
+){
+    let success_batch = 0;
+    let expected_batch = Math.ceil(keys.length/batch_size);
+    for(let check_point = 0;  check_point < keys.length; ){
+        let finish_point = check_point + batch_size > keys.length ? keys.length : check_point + batch_size;
+        let data = keys.slice(check_point, finish_point);
+        let call_data = context.api.tx.system.killStorage(data);
+        const unsub = await context.api.tx.sudo.sudo(call_data).signAndSend(context.keyring, {nonce: -1}, ({ events = [], status }) => {
+            if (status.isFinalized) {
+                success_batch ++;
+                console.log("%s %i batchs insertion finalized.", emojis.write, success_batch);
+                unsub();
+            }
+        });
+        check_point = finish_point;
+    }
+
+    // wait all txs finalized
+    for(let i =0; i < timeout; i ++){
+        await delay(1000);
+        if (success_batch === expected_batch) {
+            console.log("total wait: %i sec.", i + 1);
+            return success_batch;
+        }
+    }
+    throw "timeout";
+}
+
+async function drop_keys(
+    context: ExecutionContext,
+    keys: Array<String>, 
+    batch_size: number = 4096,
+    batch_count_before_gap: number = 4,
+    timeout_for_big_batch: number = 1000, 
+){
+    const big_batch_size = batch_size * batch_count_before_gap;
+    for(let check_point = 0; check_point < keys.length; ){
+        let finish_point = check_point + big_batch_size > keys.length ? keys.length : check_point + big_batch_size;
+        console.log(">>>>>> writng big batch from %i", check_point);
+        await drop_keys_in_batches(context, keys.slice(check_point, finish_point), batch_size, timeout_for_big_batch);
+        check_point = finish_point;
+    }
+}
+
+
+function convert_single_map_keys_hex(key: string, changed_bytes: number): string {
+    let bytes = hexToU8a(key);
+    let transformed_last_bytes = convert_single_map_keys(bytes.slice(-changed_bytes));
+    let result = new Uint8Array([
+        ...bytes.slice(0, -changed_bytes),
+        ...transformed_last_bytes
+    ]);
+    return u8aToHex(result);
+}
+
+async function main(){
+    const wsProvider = new WsProvider(dolphin_config.ws_address);
+
+    const api = await ApiPromise.create({ 
+        provider: wsProvider,
+        types: manta_pay_types,
+        rpc: rpc_api});
+    
+    const keyring = new Keyring({ type: 'sr25519' });
+    const sudo_key_pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice');
+    const context: ExecutionContext = {
+        api: api,
+        keyring: sudo_key_pair,
+    }
+    const manta_keys_read_raw = await readFile('./manta_pay_keys.json');
+    const manta_keys_read = JSON.parse(manta_keys_read_raw.toString());
+    // shards key: take last 9 bytes
+    // shard_tree key: take last 1 bytes
+    // utxo_acc_outputs: take last 32 bytes
+    // utxo_set: take last 32 bytes
+    // void_number_set: take last 32 bytes
+    // void_number_set_insertion_order: take last 8 bytes
+
+    // drop keys
+    await drop_keys(context, manta_keys_read.shards);
+    let shards_keys = await api.query.mantaPay.shards.keys();
+    console.log("shards key count: %i", shards_keys.length);
+    await drop_keys(context, manta_keys_read.shard_trees);
+    let shard_trees_keys = await api.query.mantaPay.shardTrees.keys();
+    console.log("shard trees key count: %i", shard_trees_keys.length);
+    await drop_keys(context, manta_keys_read.utxo_acc_outputs);
+    let utxo_acc_outputs = await api.query.mantaPay.utxoAccumulatorOutputs.keys();
+    console.log("key count: %i", utxo_acc_outputs.length);
+    await drop_keys(context, manta_keys_read.utxo_set);
+    let utxo_set = await api.query.mantaPay.utxoSet.keys();
+    console.log("drop %i keys from UtxoSet", utxo_set.length);
+
+    await drop_keys(context, manta_keys_read.void_number_set);
+    let void_number_set = await api.query.mantaPay.voidNumberSet.keys();
+    console.log("drop %i keys from VoidNumberSet", void_number_set.length);
+
+    await drop_keys(context, manta_keys_read.void_number_set_insertion_order);
+    let vnsio = await api.query.mantaPay.voidNumberSetInsertionOrder.keys();
+    console.log("Fetched %i keys from VNSIO", vnsio.length);
+    const shards_raw = await readFile('./shards.json');
+    const shards = JSON.parse(shards_raw.toString());
+    const shard_trees_raw = await readFile('./shards_trees.json');
+    const shard_trees = JSON.parse(shard_trees_raw.toString());
+    const void_number_set_insertion_order_raw = await readFile('./void_number_set_insertion_order.json');
+    const void_number_set_insertion_order = JSON.parse(void_number_set_insertion_order_raw.toString());
+
+    // inserting new shards
+    const new_shards_keys = (manta_keys_read.shards as Array<string>).map((entry)=>{
+        let bytes = hexToU8a(entry);
+        let transformed_last_bytes = convert_shard_utxo_keys(bytes.slice(-9));
+        let result = new Uint8Array([
+            ...bytes.slice(0, -9),
+            ...transformed_last_bytes
+        ]);
+        return u8aToHex(result);
+    });
+
+    if(new_shards_keys.length !== (shards as Array<string>).length) 
+        throw "shards keys and values are not the same len.";
+    const new_shards_kvs = new_shards_keys.map((e, i)=>{
+        return [e, shards[i]];
+    });
+    await insert_values(context, new_shards_kvs);
+
+    // inserting new shard trees
+    const new_shard_tree_keys = (manta_keys_read.shard_trees as Array<string>).map((e)=>{
+        return convert_single_map_keys_hex(e, 1);
+    });
+    if(new_shard_tree_keys.length !== (shard_trees as Array<string>).length)
+        throw "shard tree keys and value are not the same len";
+    const new_shard_tree_kvs = new_shard_tree_keys.map((e, i)=>{
+        return [e, shard_trees[i]]
+    });
+    await insert_values(context, new_shard_tree_kvs);
+
+    // inserting new utxo_acc_outputs
+    const new_utxo_acc_output_keys = (manta_keys_read.utxo_acc_outputs as Array<string>).map((e)=>{
+        return convert_single_map_keys_hex(e, 32);
+    });
+    const new_utxo_acc_output_kvs = new_utxo_acc_output_keys.map((e)=>{
+        return [e, '0x'];
+    });
+    await insert_values(context, new_utxo_acc_output_kvs);
+   
+    // inserting new utxo_set
+    const new_utxo_set_keys = (manta_keys_read.utxo_set as Array<string>).map((e)=>{
+        return convert_single_map_keys_hex(e, 32);
+    });
+    const new_utxo_set_kvs = new_utxo_set_keys.map((e)=>{
+        return [e, '0x'];
+    })
+    await insert_values(context, new_utxo_set_kvs);
+
+    // inserting void number set
+    const new_void_number_set_keys = (manta_keys_read.void_number_set as Array<string>).map((e)=>{
+        return convert_single_map_keys_hex(e, 32);
+    });
+    const new_void_number_set_kvs = new_void_number_set_keys.map((e)=>{
+        return [e, '0x'];
+    });
+    await insert_values(context, new_void_number_set_kvs);
+
+    // insert void_number_set_insertion_order
+    const new_void_number_set_insertion_order_keys = (manta_keys_read.void_number_set_insertion_order as Array<string>).map((e)=>{
+        return convert_single_map_keys_hex(e, 8);
+    });
+    if (new_void_number_set_insertion_order_keys.length !== (void_number_set_insertion_order as Array<string>).length)
+        throw "void number set insertion order size unmatch";
+    const new_void_number_set_insertion_order_kvs = new_void_number_set_insertion_order_keys.map((e, i)=>{
+        return [e, void_number_set_insertion_order[i]];
+    });
+    await insert_values(context, new_void_number_set_insertion_order_kvs);
+}   
+
+main().catch(console.error).finally(() => process.exit());

--- a/tests/test-util.ts
+++ b/tests/test-util.ts
@@ -1,10 +1,17 @@
 import { xxhashAsU8a } from '@polkadot/util-crypto';
 import type { HexString } from '@polkadot/util/types';
 import { u8aToHex, u8aToBigInt, numberToU8a, nToU8a} from '@polkadot/util';
+import { ApiPromise } from '@polkadot/api';
+import { KeyringPair } from '@polkadot/keyring/types';
 
 export enum HashType {
     Identity,
     TwoxConcat
+}
+
+export interface ExecutionContext {
+    api: ApiPromise,
+    keyring: KeyringPair
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Shumo Chu <shumo.chu@pm.me>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review.
Please commit refactors and minor intermediate (doc) changes on your PR with the `[no ci]` keyword to skip meaningless runs of the full CI pipeline.
-->

closes: #XXXX

---

Reopen storage migration

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated relevant documentation in the code.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated 
- [ ] Verify benchmarks & weights have been updated for any modified runtime logics
- [ ] If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- [ ] If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- [ ] If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
