### PR TITLE
Compile the runtime with stable Rust by adding RUSTC_BOOTSTRAP=1 flag

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -69,10 +69,9 @@ jobs:
         run: |
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
-          rustup toolchain install nightly
-          rustup target add wasm32-unknown-unknown --toolchain nightly
-          rustup default nightly
-          rustup update
+          rustup toolchain install nightly-2022-06-02-x86_64-unknown-linux-gnu
+          rustup +nightly-2022-06-02-x86_64-unknown-linux-gnu target add wasm32-unknown-unknown
+          rustup default nightly-2022-06-02-x86_64-unknown-linux-gnu
           cargo install taplo-cli
       - name: Run yamllint
         uses: actionshub/yamllint@main

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -66,12 +66,13 @@ jobs:
       - name: start sccache server
         run: sccache --start-server
       - name: init
+      # NOTE: We use nightly Rust only to get nightly fmt & clippy
         run: |
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
-          rustup toolchain install nightly-2022-06-02-x86_64-unknown-linux-gnu
-          rustup +nightly-2022-06-02-x86_64-unknown-linux-gnu target add wasm32-unknown-unknown
-          rustup default nightly-2022-06-02-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly
+          rustup +nightly target add wasm32-unknown-unknown
+          rustup default nightly
           cargo install taplo-cli
       - name: Run yamllint
         uses: actionshub/yamllint@main

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -70,10 +70,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: Run Unit Tests
         env:
           RUST_BACKTRACE: full
@@ -82,7 +81,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo test --release --features=runtime-benchmarks,try-runtime -- --test-threads=2
+          RUSTC_BOOTSTRAP=1 cargo test --release --features=runtime-benchmarks,try-runtime -- --test-threads=2
       - name: stop sccache server
         run: sccache --stop-server || true
   stop-unit-test-checks:

--- a/.github/workflows/generate_calamari_weights_files.yml
+++ b/.github/workflows/generate_calamari_weights_files.yml
@@ -49,10 +49,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: build
         env:
           RUST_BACKTRACE: full
@@ -62,7 +61,7 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           source ${HOME}/.cargo/env
-          cargo build --profile production --verbose --features=runtime-benchmarks
+          RUSTC_BOOTSTRAP=1 cargo build --profile production --verbose --features=runtime-benchmarks
       - name: stop sccache server
         run: sccache --stop-server || true
       - name: upload

--- a/.github/workflows/generate_dolphin_weights_files.yml
+++ b/.github/workflows/generate_dolphin_weights_files.yml
@@ -49,10 +49,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: build
         env:
           RUST_BACKTRACE: full
@@ -62,7 +61,7 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           source ${HOME}/.cargo/env
-          cargo build --profile production --verbose --features=runtime-benchmarks
+          RUSTC_BOOTSTRAP=1 cargo build --profile production --verbose --features=runtime-benchmarks
       - name: stop sccache server
         run: sccache --stop-server || true
       - name: upload

--- a/.github/workflows/generate_manta_weights_files.yml
+++ b/.github/workflows/generate_manta_weights_files.yml
@@ -49,10 +49,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: build
         env:
           RUST_BACKTRACE: full
@@ -62,7 +61,7 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           source ${HOME}/.cargo/env
-          cargo build --profile production --verbose --features=runtime-benchmarks
+          RUSTC_BOOTSTRAP=1 cargo build --profile production --verbose --features=runtime-benchmarks
       - name: stop sccache server
         run: sccache --stop-server || true
       - name: upload

--- a/.github/workflows/metadata_diff.yml
+++ b/.github/workflows/metadata_diff.yml
@@ -75,10 +75,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: Build Binary
         env:
           RUST_BACKTRACE: full
@@ -87,7 +86,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo build --release
+          RUSTC_BOOTSTRAP=1 cargo build --release
           chmod +x target/release/manta
       - name: stop sccache server
         run: sccache --stop-server || true

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -120,10 +120,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: build
         env:
           RUST_BACKTRACE: full
@@ -132,7 +131,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo build --profile production --verbose
+          RUSTC_BOOTSTRAP=1 cargo build --profile production --verbose
       - name: stop sccache server
         run: sccache --stop-server || true
       - name: upload
@@ -188,7 +187,7 @@ jobs:
       - if: ${{ needs.check-for-runtime-upgrade.outputs.do-versions-match == 'false' }}
         name: fetch and chmod polkadot
         run: |
-          curl -L -o $HOME/.local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.18/polkadot
+          curl -L -o $HOME/.local/bin/polkadot https://github.com/paritytech/polkadot/releases/download/v0.9.22/polkadot
           chmod +x $HOME/.local/bin/polkadot
           ls -ahl $HOME/.local/bin/
       - if: ${{ needs.check-for-runtime-upgrade.outputs.do-versions-match == 'false' }}

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -1,4 +1,4 @@
-name: Check Build
+name: Run Linters
 on:
   pull_request:
     branches: [manta]
@@ -87,7 +87,7 @@ jobs:
           cargo fmt --all -- --check
           $HOME/.cargo/bin/taplo fmt --check
           $HOME/.cargo/bin/taplo lint
-      - name: Check Build
+      - name: Cargo Check & Clippy
         env:
           RUST_BACKTRACE: full
           RUSTC_WRAPPER: sccache

--- a/.github/workflows/try-runtime-calamari-mainnet.yml
+++ b/.github/workflows/try-runtime-calamari-mainnet.yml
@@ -75,10 +75,9 @@ jobs:
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable
-          rustup toolchain install nightly
           rustup default stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
           rustup update
+          rustup target add wasm32-unknown-unknown
       - name: Build Binary
         env:
           RUST_BACKTRACE: full
@@ -87,7 +86,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          cargo build --release --features=try-runtime
+          RUSTC_BOOTSTRAP=1 cargo build --release --features=try-runtime
           chmod a+x target/release/manta
       - name: move bin
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [\#657](https://github.com/Manta-Network/Manta/pull/657) retire manta-pc-launch with polkadot-launch.
 
 ### Bug fixes
-- [\#677](https://github.com/Manta-Network/Manta/pull/677) Compile the runtime with stable Rust by adding RUSTC_BOOTSTRAP=1 flag
+- [\#677](https://github.com/Manta-Network/Manta/pull/677) Fix CI failure by building the runtime with stable Rust
 
 ## v3.2.0
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [\#657](https://github.com/Manta-Network/Manta/pull/657) retire manta-pc-launch with polkadot-launch.
 
 ### Bug fixes
+- [\#677](https://github.com/Manta-Network/Manta/pull/677) Compile the runtime with stable Rust by adding RUSTC_BOOTSTRAP=1 flag
 
 ## v3.2.0
 ### Breaking changes


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description
See https://github.com/paritytech/substrate/issues/11307

relates to: #599 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functonality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
