### PR TITLE
Changelog generation workflow verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+### Breaking changes
+
+### Features
+
+### Improvements
+- [\#694](https://github.com/Manta-Network/Manta/pull/694) Switch to u128::MAX in fungible ledger transfer integration test.
+
+### Bug fixes
+
 ## v3.2.1
 ### Breaking changes
 - [Dolphin] [\#628](https://github.com/Manta-Network/Manta/pull/628) Improve RPC performance, add `max_receivers` and `max_senders` fields in the RPC request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,30 @@
 # CHANGELOG
 
-## Unreleased
-### Breaking changes
+## Fake V3.3.0
 
-### Features
+### Added
+- [\#646](https://github.com/Manta-Network/Manta/pull/646) Add collator session keys for future nimbus consensus and a vrf placeholder.
+- [\#475](https://github.com/Manta-Network/Manta/pull/475) New workflow for comparing runtime metadata before and after runtime upgrade.
 
-### Improvements
-- [\#694](https://github.com/Manta-Network/Manta/pull/694) Switch to u128::MAX in fungible ledger transfer integration test.
+### Changed
+- [\#523](https://github.com/Manta-Network/Manta/pull/523) Move xcm and assets related runtime configurations to own files.
+- [\#531](https://github.com/Manta-Network/Manta/pull/531) Clean up AssetManager migration code.
+- [\#541](https://github.com/Manta-Network/Manta/pull/541) Skip build on too tiny change.
+- [\#542](https://github.com/Manta-Network/Manta/pull/542) Update xcm integrations template issue.
+- [Calamari] [\#550](https://github.com/Manta-Network/Manta/pull/550) Remove sudo pallet from calamari runtime.
 
-### Bug fixes
+### Depricated
+
+### Removed
+- [\#449](https://github.com/Manta-Network/Manta/pull/449) Remove strip from CI, and add strip profile to production.
+- [\#614](https://github.com/Manta-Network/Manta/pull/614) Remove `OnRuntimeUpgrade` from calamari-runtime.
+
+### Fixed
+- [\#671](https://github.com/Manta-Network/Manta/pull/671) polkadot-v0.9.22 syn breakage workaround.
+- [\#677](https://github.com/Manta-Network/Manta/pull/677) Fix CI failure by building the runtime with stable Rust.
+
+### Security
+
 
 ## v3.2.1
 ### Breaking changes

--- a/pallets/manta-pay/src/test/payment.rs
+++ b/pallets/manta-pay/src/test/payment.rs
@@ -160,9 +160,7 @@ where
         Some(id) => id,
         None => rng.gen(),
     };
-    // FIXME: get rid of the division after parity fixes the pallet-asset bug
-    let double_balance: u128 = rng.gen();
-    let total_free_balance = AssetValue(double_balance / 2);
+    let total_free_balance = AssetValue(rng.gen());
     let balances = value_distribution(count, total_free_balance, rng);
     initialize_test(asset_id, total_free_balance + DEFAULT_ASSET_ED);
     let mut utxo_accumulator = UtxoAccumulator::new(UTXO_ACCUMULATOR_MODEL.clone());
@@ -232,9 +230,7 @@ where
         Some(id) => id,
         None => rng.gen(),
     };
-    // FIXME: This is a workaround due to the substrate asset bug
-    let double_balance: u128 = rng.gen();
-    let total_free_balance = AssetValue(double_balance / 2);
+    let total_free_balance = AssetValue(rng.gen());
     let balances = value_distribution(count, total_free_balance, rng);
     initialize_test(asset_id, total_free_balance + DEFAULT_ASSET_ED);
     let mut utxo_accumulator = UtxoAccumulator::new(UTXO_ACCUMULATOR_MODEL.clone());
@@ -314,10 +310,7 @@ fn to_private_should_work() {
     let mut rng = OsRng;
     new_test_ext().execute_with(|| {
         let asset_id = rng.gen();
-        // FIXME: get rid of divide by two after parity fix pallet-asset
-        // This is to work around the substrate bug
-        let double_supply: u128 = rng.gen();
-        let total_free_supply = AssetValue(double_supply / 2);
+        let total_free_supply = AssetValue(rng.gen());
         initialize_test(asset_id, total_free_supply + DEFAULT_ASSET_ED);
         mint_tokens(
             asset_id,
@@ -331,10 +324,7 @@ fn to_private_should_work() {
 fn native_asset_to_private_should_work() {
     let mut rng = OsRng;
     new_test_ext().execute_with(|| {
-        // FIXME: get rid of divide by two after parity fix pallet-asset
-        // This is to work around the substrate bug
-        let double_supply: u128 = rng.gen();
-        let total_free_supply = AssetValue(double_supply / 2);
+        let total_free_supply = AssetValue(rng.gen());
         initialize_test(NATIVE_ASSET_ID, total_free_supply + DEFAULT_ASSET_ED);
         mint_tokens(
             NATIVE_ASSET_ID,
@@ -350,9 +340,7 @@ fn overdrawn_mint_should_not_work() {
     let mut rng = OsRng;
     new_test_ext().execute_with(|| {
         let asset_id = rng.gen();
-        // FIXME: remove the division after parity fix the pallet-asset bug
-        let double_supply: u128 = rng.gen();
-        let total_supply = AssetValue(double_supply / 2);
+        let total_supply = AssetValue(rng.gen());
         initialize_test(asset_id, total_supply + DEFAULT_ASSET_ED);
         assert_noop!(
             MantaPayPallet::to_private(

--- a/runtime/calamari/tests/integration_tests.rs
+++ b/runtime/calamari/tests/integration_tests.rs
@@ -50,7 +50,7 @@ use manta_primitives::{
         AssetConfig, AssetLocation, AssetRegistrarMetadata, FungibleLedger, FungibleLedgerError,
     },
     constants::time::{DAYS, HOURS},
-    types::{AccountId, Header},
+    types::{AccountId, Balance, Header},
 };
 use session_key_primitives::helpers::{get_account_id_from_seed, get_collator_keys_from_seed};
 use xcm::{
@@ -1108,8 +1108,7 @@ fn concrete_fungible_ledger_transfers_work() {
             ),);
 
             // Register and mint for testing.
-            // TODO:: Switch to u128::MAX when we start using https://github.com/paritytech/substrate/pull/11241
-            let amount = INITIAL_BALANCE;
+            let amount = Balance::MAX;
             assert_ok!(CalamariConcreteFungibleLedger::mint(
                 <CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
                 &alice.clone(),
@@ -1182,7 +1181,7 @@ fn concrete_fungible_ledger_transfers_work() {
                     <CalamariAssetConfig as AssetConfig<Runtime>>::StartNonNativeAssetId::get(),
                     alice.clone()
                 ),
-                INITIAL_BALANCE - transfer_amount
+                u128::MAX - transfer_amount
             );
             assert_eq!(
                 Assets::balance(


### PR DESCRIPTION
## Description
Only used for Changelog automation testing

relates to OR closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functonality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
