### PR TITLE
Implement indexer ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4998,6 +4998,7 @@ dependencies = [
  "dolphin-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "frame-support",
  "futures 0.3.21",
  "jsonrpsee",
  "log",
@@ -5027,6 +5028,7 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde",
+ "serde_json",
  "session-key-primitives",
  "sp-api",
  "sp-block-builder",
@@ -10609,9 +10611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,10 +22,12 @@ codec = { package = 'parity-scale-codec', version = '3.1.2' }
 futures = "0.3.21"
 log = "0.4.16"
 serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.82"
 
 # Substrate frames
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.22" }
 frame-benchmarking-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.22" }
+frame-support = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.22" }
 try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22", optional = true }
 
 # RPC related dependencies

--- a/node/src/rpc/dolphin.rs
+++ b/node/src/rpc/dolphin.rs
@@ -17,26 +17,59 @@
 //! Dolphin RPC Extensions
 
 use super::*;
+use crate::service::{Client, StateBackend};
+use codec::Encode;
+use frame_support::{storage::storage_prefix, StorageHasher, Twox64Concat};
+use manta_primitives::types::Block;
 use pallet_manta_pay::{
-    rpc::{Pull, PullApiServer},
-    runtime::PullLedgerDiffApi,
+    types::{ReceiverChunk, SenderChunk},
+    Checkpoint, PullResponse, RawCheckpoint,
+};
+use polkadot_service::NativeExecutionDispatch;
+use sc_client_api::{HeaderBackend, StorageProvider};
+use sp_api::{ApiExt, ConstructRuntimeApi};
+use sp_core::storage::StorageKey;
+use sp_offchain::OffchainWorkerApi;
+use sp_runtime::{generic::BlockId, traits::BlakeTwo256};
+use sp_session::SessionKeys;
+use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
+use std::sync::Arc;
+
+use jsonrpsee::{
+    core::{async_trait, RpcResult},
+    proc_macros::rpc,
 };
 
+/// The storage name: MantaPay
+const MANTA_PAY_KEY_PREFIX: [u8; 8] = *b"MantaPay";
+/// The storage name: Shards
+const MANTA_PAY_STORAGE_SHARDS_NAME: [u8; 6] = *b"Shards";
+/// The storage name: VoidNumberSetInsertionOrder
+const MANTA_PAY_STORAGE_VOID_NAME: [u8; 27] = *b"VoidNumberSetInsertionOrder";
+
+const PULL_MAX_SENDER_UPDATE_SIZE: u64 = 32768;
+const PULL_MAX_RECEIVER_UPDATE_SIZE: u64 = 32768;
+
 /// Instantiate all RPC extensions for dolphin.
-pub fn create_dolphin_full<C, P>(deps: FullDeps<C, P>) -> Result<RpcExtension, sc_service::Error>
+pub fn create_dolphin_full<RuntimeApi, Executor>(
+    deps: FullDeps<
+        Client<RuntimeApi, Executor>,
+        crate::service::TransactionPool<RuntimeApi, Executor>,
+    >,
+) -> Result<RpcExtension, sc_service::Error>
 where
-    C: ProvideRuntimeApi<Block>
-        + HeaderBackend<Block>
-        + AuxStore
-        + HeaderMetadata<Block, Error = BlockChainError>
-        + Send
-        + Sync
-        + 'static,
-    C::Api: frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-    C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-    C::Api: BlockBuilder<Block>,
-    C::Api: PullLedgerDiffApi<Block>,
-    P: TransactionPool + Sync + Send + 'static,
+    RuntimeApi: ConstructRuntimeApi<Block, Client<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: TaggedTransactionQueue<Block>
+        + sp_api::Metadata<Block>
+        + SessionKeys<Block>
+        + ApiExt<Block, StateBackend = StateBackend>
+        + OffchainWorkerApi<Block>
+        + sp_block_builder::BlockBuilder<Block>
+        + cumulus_primitives_core::CollectCollationInfo<Block>
+        + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
+        + frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
+    StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    Executor: NativeExecutionDispatch + 'static,
 {
     use frame_rpc_system::{SystemApiServer, SystemRpc};
     use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPaymentRpc};
@@ -55,10 +88,210 @@ where
         .merge(TransactionPaymentRpc::new(client.clone()).into_rpc())
         .map_err(|e| sc_service::Error::Other(e.to_string()))?;
 
-    let manta_pay_rpc: jsonrpsee::RpcModule<Pull<Block, C>> = Pull::new(client).into_rpc();
+    let manta_pay_rpc = Pull::new(client).into_rpc();
     module
         .merge(manta_pay_rpc)
         .map_err(|e| sc_service::Error::Other(e.to_string()))?;
 
     Ok(module)
+}
+
+/// Pull API
+#[rpc(server)]
+pub trait PullApi {
+    /// Returns the update required to be synchronized with the ledger starting from
+    /// `checkpoint`.
+    #[method(name = "mantaPay_pullLedgerDiff", blocking)]
+    fn pull_ledger_diff(
+        &self,
+        checkpoint: Checkpoint,
+        max_receivers: u64,
+        max_senders: u64,
+    ) -> RpcResult<PullResponse>;
+}
+
+pub struct Pull<R, E: NativeExecutionDispatch> {
+    pub client: Arc<Client<R, E>>,
+}
+
+impl<R, E: NativeExecutionDispatch> Pull<R, E> {
+    /// Builds a new [`Pull`] RPC API implementation.
+    pub fn new(client: Arc<Client<R, E>>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl<R, E> PullApiServer for Pull<R, E>
+where
+    R: ConstructRuntimeApi<Block, Client<R, E>> + Send + Sync + 'static,
+    R::RuntimeApi: ApiExt<Block, StateBackend = StateBackend>,
+    StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    E: NativeExecutionDispatch + 'static,
+{
+    fn pull_ledger_diff(
+        &self,
+        checkpoint: Checkpoint,
+        max_receivers: u64,
+        max_senders: u64,
+    ) -> RpcResult<PullResponse> {
+        let client = &self.client;
+        let best_hash = client.info().best_hash;
+        let block_id = BlockId::<Block>::hash(best_hash);
+
+        let (more_receivers, receivers) = pull_receivers(
+            client.clone(),
+            &block_id,
+            *checkpoint.receiver_index,
+            max_receivers,
+        );
+        let (more_senders, senders) = pull_senders(
+            client.clone(),
+            &block_id,
+            checkpoint.sender_index,
+            max_senders,
+        );
+        let pr = PullResponse {
+            should_continue: more_receivers || more_senders,
+            receivers,
+            senders,
+        };
+
+        Ok(pr)
+    }
+}
+
+fn create_full_map_key(storage_name: &[u8], key: impl Encode) -> StorageKey {
+    let prefix = storage_prefix(&MANTA_PAY_KEY_PREFIX, storage_name);
+    let key = Twox64Concat::hash(&key.encode());
+
+    let full_key = prefix.into_iter().chain(key).collect();
+    StorageKey(full_key)
+}
+
+fn create_full_doublemap_key(
+    storage_name: &[u8],
+    key1: impl Encode,
+    key2: impl Encode,
+) -> StorageKey {
+    let prefix = storage_prefix(&MANTA_PAY_KEY_PREFIX, storage_name);
+    let key1 = Twox64Concat::hash(&key1.encode());
+    let key2 = Twox64Concat::hash(&key2.encode());
+    let key = key1.into_iter().chain(key2.into_iter());
+
+    let full_key = prefix.into_iter().chain(key).collect();
+    StorageKey(full_key)
+}
+
+fn pull_senders<RuntimeApi, Executor>(
+    client: Arc<Client<RuntimeApi, Executor>>,
+    block_id: &BlockId<Block>,
+    sender_index: usize,
+    max_update_request: u64,
+) -> (bool, SenderChunk)
+where
+    RuntimeApi: ConstructRuntimeApi<Block, Client<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: ApiExt<Block, StateBackend = StateBackend>,
+    StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    Executor: NativeExecutionDispatch + 'static,
+{
+    let mut senders = Vec::new();
+    let max_sender_index = if max_update_request > PULL_MAX_SENDER_UPDATE_SIZE {
+        (sender_index as u64) + PULL_MAX_SENDER_UPDATE_SIZE
+    } else {
+        (sender_index as u64) + max_update_request
+    };
+
+    for idx in (sender_index as u64)..max_sender_index {
+        let key = create_full_map_key(&MANTA_PAY_STORAGE_VOID_NAME, idx);
+        match client.storage(block_id, &key) {
+            Ok(Some(next)) => {
+                let next = serde_json::from_slice(&next.0).unwrap();
+                senders.push(next);
+            }
+            _ => return (false, senders),
+        }
+    }
+    let key = create_full_map_key(&MANTA_PAY_STORAGE_VOID_NAME, max_sender_index as u64);
+    let should_continue = matches!(client.storage(block_id, &key), Ok(Some(_)));
+
+    (should_continue, senders)
+}
+
+fn pull_receivers<RuntimeApi, Executor>(
+    client: Arc<Client<RuntimeApi, Executor>>,
+    block_id: &BlockId<Block>,
+    receiver_indices: [usize; 256],
+    max_update_request: u64,
+) -> (bool, ReceiverChunk)
+where
+    RuntimeApi: ConstructRuntimeApi<Block, Client<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: ApiExt<Block, StateBackend = StateBackend>,
+    StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    Executor: NativeExecutionDispatch + 'static,
+{
+    let mut more_receivers = false;
+    let mut receivers = Vec::new();
+    let mut receivers_pulled: u64 = 0;
+    let max_update = if max_update_request > PULL_MAX_RECEIVER_UPDATE_SIZE {
+        PULL_MAX_RECEIVER_UPDATE_SIZE
+    } else {
+        max_update_request
+    };
+
+    for (shard_index, utxo_index) in receiver_indices.into_iter().enumerate() {
+        more_receivers |= pull_receivers_for_shard(
+            client.clone(),
+            block_id,
+            shard_index as u8,
+            utxo_index,
+            max_update,
+            &mut receivers,
+            &mut receivers_pulled,
+        );
+        // if max capacity is reached and there is more to pull, then we return
+        if receivers_pulled == max_update && more_receivers {
+            break;
+        }
+    }
+    (more_receivers, receivers)
+}
+
+fn pull_receivers_for_shard<RuntimeApi, Executor>(
+    client: Arc<Client<RuntimeApi, Executor>>,
+    block_id: &BlockId<Block>,
+    shard_index: u8,
+    receiver_index: usize,
+    max_update: u64,
+    receivers: &mut ReceiverChunk,
+    receivers_pulled: &mut u64,
+) -> bool
+where
+    RuntimeApi: ConstructRuntimeApi<Block, Client<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: ApiExt<Block, StateBackend = StateBackend>,
+    StateBackend: sp_api::StateBackend<BlakeTwo256>,
+    Executor: NativeExecutionDispatch + 'static,
+{
+    let max_receiver_index = (receiver_index as u64) + max_update;
+    for idx in (receiver_index as u64)..max_receiver_index {
+        let key = create_full_doublemap_key(&MANTA_PAY_STORAGE_SHARDS_NAME, shard_index, idx);
+        if *receivers_pulled == max_update {
+            let should_continue = matches!(client.storage(block_id, &key), Ok(Some(_)));
+            return should_continue;
+        }
+        match client.storage(block_id, &key) {
+            Ok(Some(next)) => {
+                let next = serde_json::from_slice(&next.0).unwrap();
+                *receivers_pulled += 1;
+                receivers.push(next);
+            }
+            _ => return false,
+        }
+    }
+    let key = create_full_doublemap_key(
+        &MANTA_PAY_STORAGE_SHARDS_NAME,
+        shard_index,
+        max_receiver_index,
+    );
+    matches!(client.storage(block_id, &key), Ok(Some(_)))
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -34,6 +34,25 @@ export const rpc_api = {
 
             ],
             type: 'PullResponse'
+        },
+        pullLedgerDiff: {
+            description: 'pull from mantaPay',
+            params: [
+                {
+                    name: 'checkpoint',
+                    type: 'Checkpoint'
+                },
+                {
+                    name: 'max_receiver',
+                    type: 'u64'
+                },
+                {
+                    name: 'max_sender',
+                    type: 'u64'
+                }
+
+            ],
+            type: 'PullResponse'
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

## Description

relates to OR closes: #686

Implementation:
Move `pull_ledger_diff` out of mantaPay, to client, all storages query will happen from client side.
1. Storage prefix. I'm using [`storage_prefix`](https://github.com/paritytech/substrate/blob/polkadot-v0.9.22/frame/support/src/storage/mod.rs#L1362) to get storage prefix.
2. About how to hash keys. Because `Shards` and `VoidNumberSetInsertionOrder` are using `Twox64Concat` to hash keys, so this is the way to hash keys:
```rust
let key_hash = Twox64Concat::hash(&key.encode());
```

### Todo:
- [ ] Performance tests.
- [ ] If the performance doesn't meet out expectation, switch to another design.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** line describing your change in `<branch>/CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
