### PR TITLE
[WIP - requesting feedback] Debugger setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 /target/
 Cargo.lock
 runtime/**/target
-.vscode
 .idea
 /tests/node_modules/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Build & Launch Manta Node (Linux)",
+            "preLaunchTask": "Build Manta (debug symbols)",
+            "program": "${workspaceFolder}/target/release/manta",
+            "args": [
+              "--execution=Native",
+              "--no-telemetry",
+              "--no-prometheus",
+              "--chain=${dbgconfig:para_chain}",
+              "-linfo",
+              "--port=${dbgconfig:port_p2p}",
+              "--rpc-port=${dbgconfig:port_rpc}",
+              "--ws-port=${dbgconfig:port_ws}",
+              "--tmp",
+              "--",
+              "--execution=Native",
+              "--chain=${dbgconfig:relay_chain}"
+            ],
+            "cwd": "${workspaceFolder}",
+            "sourceLanguages": ["rust"],
+            "sourceMap": {
+              "/rustc/*": "${dbgconfig:rustc_path}"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "lldb.dbgconfig": {
+      "rustc_path": "${env:HOME}/.rustup/toolchains/nightly-2022-07-10-x86_64-unknown-linux-gnu/",
+      "para_chain": "calamari-dev",
+      // "relay_chain": "dev",
+      "relay_chain": "/home/georgi/Desktop/workspace/Parity/polkadot-launch/rococo-local-raw.json",
+      "port_p2p": 19931,
+      "port_rpc": 19932,
+      "port_ws": 19933
+    }
+}
+  

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Build Manta (debug symbols)",
+        "type": "shell",
+        "command": "RUSTFLAGS=-g cargo build --release",
+        "presentation": {
+          "reveal": "always",
+          "panel": "new"
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

## Description

relates to OR closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels out of `A-` and `C-` groups to this PR
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
