### PR TITLE
Remove v3.2.1 SessionKey migration code

### DIFF
--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -96,11 +96,6 @@ pub mod opaque {
 
     use nimbus_session_adapter::{AuthorInherentWithNoOpSession, VrfWithNoOpSession};
     impl_opaque_keys! {
-        pub struct OldSessionKeys {
-            pub aura: Aura,
-        }
-    }
-    impl_opaque_keys! {
         pub struct SessionKeys {
             pub aura: Aura,
             pub nimbus: AuthorInherentWithNoOpSession<Runtime>,
@@ -782,48 +777,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsReversedWithSystemFirst,
-    UpgradeSessionKeys,
 >;
-// When this is removed, should also remove `OldSessionKeys`.
-pub struct UpgradeSessionKeys;
-impl frame_support::traits::OnRuntimeUpgrade for UpgradeSessionKeys {
-    fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        use opaque::transform_session_keys;
-        // transform_session_keys runs translate() on NextKeys and on QueuedKeys which is (at worst or faster than) 1 read 1 write
-        let validator_set_len: u64 = Session::queued_keys().len().try_into().unwrap();
-
-        Session::upgrade_keys::<opaque::OldSessionKeys, _>(transform_session_keys);
-
-        core::cmp::max(
-            Perbill::from_percent(50) * BlockWeights::default().max_block as u64,
-            <Runtime as frame_system::Config>::DbWeight::get()
-                .reads_writes(2 * validator_set_len, validator_set_len * 2),
-        )
-    }
-    #[cfg(feature = "try_runtime")]
-    fn pre_runtime_upgrade() -> frame_support::weights::Weight {
-        // get aura keys
-        let owners_and_aura_keys = Session::queued_keys();
-        Self::set_temp_storage(owners_and_aura_keys, "aura_keys");
-        0
-    }
-    #[cfg(feature = "try_runtime")]
-    fn post_runtime_upgrade() -> frame_support::weights::Weight {
-        // ensure aura keys have not changed
-        let pre_migration_keys = Self::get_temp_storage(owners_and_aura_keys, "aura_keys");
-        let new_owners_and_aura_keys = Session::queued_keys();
-
-        for it in pre_migration_keys
-            .iter()
-            .zip(new_owners_and_aura_keys.iter())
-        {
-            let ((old_owner, old_key), (new_owner, new_key)) = iter;
-            ensure!(old_owner == new_owner, "owner changed");
-            ensure!(old_key.aura == new_key.aura, "key changed");
-        }
-        0
-    }
-}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -108,14 +108,6 @@ pub mod opaque {
             SessionKeys { aura, nimbus, vrf }
         }
     }
-
-    pub fn transform_session_keys(_v: AccountId, old: OldSessionKeys) -> SessionKeys {
-        SessionKeys {
-            aura: old.aura.clone(),
-            nimbus: session_key_primitives::nimbus::dummy_key_from(old.aura.clone()),
-            vrf: session_key_primitives::vrf::dummy_key_from(old.aura),
-        }
-    }
 }
 
 // Weights used in the runtime.

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -767,7 +767,6 @@ pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExt
 /// Types for runtime upgrading.
 /// Each type should implement trait `OnRuntimeUpgrade`.
 pub type OnRuntimeUpgradeHooks = (
-    UpgradeSessionKeys,
     MigratePalletPv2Sv<pallet_asset_manager::Pallet<Runtime>>,
     MigratePalletPv2Sv<pallet_tx_pause::Pallet<Runtime>>,
     MigratePalletPv2Sv<manta_collator_selection::Pallet<Runtime>>,
@@ -781,6 +780,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsReversedWithSystemFirst,
+    OnRuntimeUpgradeHooks,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -94,11 +94,6 @@ pub mod opaque {
 
     use nimbus_session_adapter::{AuthorInherentWithNoOpSession, VrfWithNoOpSession};
     impl_opaque_keys! {
-        pub struct OldSessionKeys {
-            pub aura: Aura,
-        }
-    }
-    impl_opaque_keys! {
         pub struct SessionKeys {
             pub aura: Aura,
             pub nimbus: AuthorInherentWithNoOpSession<Runtime>,
@@ -769,48 +764,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsReversedWithSystemFirst,
-    UpgradeSessionKeys,
 >;
-// When this is removed, should also remove `OldSessionKeys`.
-pub struct UpgradeSessionKeys;
-impl frame_support::traits::OnRuntimeUpgrade for UpgradeSessionKeys {
-    fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        use opaque::transform_session_keys;
-        // transform_session_keys runs translate() on NextKeys and on QueuedKeys which is (at worst or faster than) 1 read 1 write
-        let validator_set_len: u64 = Session::queued_keys().len().try_into().unwrap();
-
-        Session::upgrade_keys::<opaque::OldSessionKeys, _>(transform_session_keys);
-
-        core::cmp::max(
-            Perbill::from_percent(50) * BlockWeights::default().max_block as u64,
-            <Runtime as frame_system::Config>::DbWeight::get()
-                .reads_writes(2 * validator_set_len, validator_set_len * 2),
-        )
-    }
-    #[cfg(feature = "try_runtime")]
-    fn pre_runtime_upgrade() -> frame_support::weights::Weight {
-        // get aura keys
-        let owners_and_aura_keys = Session::queued_keys();
-        Self::set_temp_storage(owners_and_aura_keys, "aura_keys");
-        0
-    }
-    #[cfg(feature = "try_runtime")]
-    fn post_runtime_upgrade() -> frame_support::weights::Weight {
-        // ensure aura keys have not changed
-        let pre_migration_keys = Self::get_temp_storage(owners_and_aura_keys, "aura_keys");
-        let new_owners_and_aura_keys = Session::queued_keys();
-
-        for it in pre_migration_keys
-            .iter()
-            .zip(new_owners_and_aura_keys.iter())
-        {
-            let ((old_owner, old_key), (new_owner, new_key)) = iter;
-            ensure!(old_owner == new_owner, "owner changed");
-            ensure!(old_key.aura == new_key.aura, "key changed");
-        }
-        0
-    }
-}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -754,7 +754,6 @@ pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExt
 /// Types for runtime upgrading.
 /// Each type should implement trait `OnRuntimeUpgrade`.
 pub type OnRuntimeUpgradeHooks = (
-    UpgradeSessionKeys,
     MigratePalletPv2Sv<pallet_asset_manager::Pallet<Runtime>>,
     MigratePalletPv2Sv<pallet_tx_pause::Pallet<Runtime>>,
     MigratePalletPv2Sv<manta_collator_selection::Pallet<Runtime>>,
@@ -768,6 +767,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsReversedWithSystemFirst,
+    OnRuntimeUpgradeHooks,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -106,14 +106,6 @@ pub mod opaque {
             SessionKeys { aura, nimbus, vrf }
         }
     }
-
-    pub fn transform_session_keys(_v: AccountId, old: OldSessionKeys) -> SessionKeys {
-        SessionKeys {
-            aura: old.aura.clone(),
-            nimbus: session_key_primitives::nimbus::dummy_key_from(old.aura.clone()),
-            vrf: session_key_primitives::vrf::dummy_key_from(old.aura),
-        }
-    }
 }
 
 // Weights used in the runtime.


### PR DESCRIPTION
## Description

closes: #662 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels out of `A-` and `C-` groups to this PR
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
