### PR TITLE
Apokalip/changelog test release v3.2.2

### DIFF
--- a/.github/workflows/changelog_verification.yml
+++ b/.github/workflows/changelog_verification.yml
@@ -1,6 +1,13 @@
 name: Changelog Verification
 on:
+  pull_request:
+    branches: 
+      - '**/release-**'
   push:
+    branches: 
+      - '**/release-**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   verify_changelog:
     runs-on: ubuntu-20.04
@@ -8,6 +15,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
+        fetch-depth: 0
         path: manta
     - name: Save Dev Local CHANGELOG for diff
       run: |
@@ -20,9 +28,22 @@ jobs:
         ref: Apokalip/changelog-generator-license
         path: dev-tools
     - name: Generate workflow Changelog
+      continue-on-error: true
       run: |
-        git -C ${{ github.workspace }}/manta branch --show-current
+        git -C ${{ github.workspace }}/manta fetch
         cd dev-tools/changelog-generator
         cargo b -r
-        cargo run -- -u ${{ github.actor }} ${{ github.token }} -r ${{ github.workspace }}/manta
+        cargo run -- -u ${GITHUB_ACTOR} ${{ secrets.GITHUB_TOKEN }} -r ${{ github.workspace }}/manta
+    - name: Diff changelogs
+      run: |
+        cd ${{ github.workspace }}/manta
+        res=$(diff CHANGELOG.md CHANGELOG_ORIGIN.md)
+        exit $res
+        
+        
+
+        
+        
+        
+
         

--- a/.github/workflows/changelog_veriication.yml
+++ b/.github/workflows/changelog_veriication.yml
@@ -17,9 +17,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Manta-Network/Dev-Tools
+        ref: Apokalip/changelog-generator-license
         path: dev-tools
     - name: Generate workflow Changelog
       run: |
+        git -C ${{ github.workspace }}/manta branch --show-current
         cd dev-tools/changelog-generator
         cargo b -r
         cargo run -- -u ${{ github.actor }} ${{ github.token }} -r ${{ github.workspace }}/manta

--- a/.github/workflows/changelog_veriication.yml
+++ b/.github/workflows/changelog_veriication.yml
@@ -1,0 +1,26 @@
+name: Changelog Verification
+on:
+  push:
+jobs:
+  verify_changelog:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: manta
+    - name: Save Dev Local CHANGELOG for diff
+      run: |
+        cd manta
+        sudo cp CHANGELOG.md CHANGELOG_ORIGIN.md
+    - name: get Changelog Generator
+      uses: actions/checkout@v2
+      with:
+        repository: Manta-Network/Dev-Tools
+        path: dev-tools
+    - name: Generate workflow Changelog
+      run: |
+        cd dev-tools/changelog-generator
+        cargo b -r
+        cargo run -- -u ${{ github.actor }} ${{ github.token }} -r ${{ github.workspace }}/manta
+        

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -815,46 +815,9 @@ jobs:
       - name: test - calamari alice peered successfully
         run: |
           grep '\[Parachain\] 💤 Idle (${{ matrix.chain-spec.expected.peer-count.para }} peers)' ${{ github.workspace }}/polkadot-launch/9921.log
-  build-changelog:
-    runs-on: ubuntu-20.04
-    needs: [get-rust-versions, build-runtimes]
-    strategy:
-      matrix:
-        runtime:
-          - name: calamari
-          - name: manta
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.runtime.name }}-srtool-json
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          path: Manta
-      - name: ruby setup
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - name: changelog gems
-        run: |
-          gem install changelogerator git toml
-      - name: generate changelog
-        env:
-          RUSTC_STABLE: ${{ needs.get-rust-versions.outputs.rustc-stable }}
-          RUSTC_NIGHTLY: ${{ needs.get-rust-versions.outputs.rustc-nightly }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          ruby $GITHUB_WORKSPACE/Manta/scripts/github/generate-changelog.rb |
-          tee changelog.md
-      - name: upload changelog
-        uses: actions/upload-artifact@v2
-        with:
-          name: changelog
-          path: changelog.md
   create-draft-release:
     runs-on: ubuntu-20.04
-    needs: [build-changelog, build-runtimes, calamari-integration-test, dolphin-integration-test, runtime-upgrade-test, docker-image-test]
+    needs: [build-runtimes, calamari-integration-test, dolphin-integration-test, runtime-upgrade-test, docker-image-test]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
-# CHANGELOG
+# CHANGELOG 
 
-## Unreleased
-### Breaking changes
+## v3.2.2
+### Changed
+-[\#681](https://github.com/Manta-Network/Manta/pull/681) CI Ledger RPC Tests 
+-[\#682](https://github.com/Manta-Network/Manta/pull/682) Use `LengthToFee` in the `congested_chain_simulation`'s fee calculation 
+-[\#695](https://github.com/Manta-Network/Manta/pull/695) Refactor fungible ledger mint/burn 
+-[\#715](https://github.com/Manta-Network/Manta/pull/715) Update xcm-onboarding and release templates 
+-[\#701](https://github.com/Manta-Network/Manta/pull/701) switch runtime to wasm only 
+-[\#720](https://github.com/Manta-Network/Manta/pull/720) Update deps from v0.9.22 to v0.9.26 
 
-### Features
-
-### Improvements
-- [\#681](https://github.com/Manta-Network/Manta/pull/681) CI Ledger RPC Tests.
-- [\#694](https://github.com/Manta-Network/Manta/pull/694) Switch to u128::MAX in fungible ledger transfer integration test.
-
-### Bug fixes
+### Fixed
+-[\#694](https://github.com/Manta-Network/Manta/pull/694) Use u128::MAX in fungible ledger transfer test 
+-[\#703](https://github.com/Manta-Network/Manta/pull/703) Fix double spend reclaim test 
 
 ## v3.2.1
 ### Breaking changes


### PR DESCRIPTION
DO NOT MERGE Need a branch with release-v3.2.2 to test workflow for changelog

relates to OR closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels out of `A-` and `C-` groups to this PR
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
