### PR TITLE
Release v3.3.0

### DIFF
--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -554,11 +554,11 @@ jobs:
         with:
           name: block-time-rococo-relay-for-${{ matrix.chain-spec.id }}.json
           path: ${{ github.workspace }}/block-time-rococo.json
-      - name: parse calamari block times
-        run: |
-          grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
-          if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
-          jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
+# - name: parse calamari block times
+#   run: |
+#     grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
+#     if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
+#     jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
       - uses: actions/upload-artifact@v2
         with:
           name: block-time-${{ matrix.chain-spec.id }}.json
@@ -797,11 +797,11 @@ jobs:
         with:
           name: block-time-rococo-relay-for-${{ matrix.chain-spec.id }}.json
           path: ${{ github.workspace }}/block-time-rococo.json
-      - name: parse calamari block times
-        run: |
-          grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
-          if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
-          jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
+# - name: parse calamari block times
+#   run: |
+#     grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
+#     if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
+#     jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
       - uses: actions/upload-artifact@v2
         with:
           name: block-time-${{ matrix.chain-spec.id }}.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
 -[\#726](https://github.com/Manta-Network/Manta/pull/726) support STORAGE_VERSION for our pallets 
 -[\#738](https://github.com/Manta-Network/Manta/pull/738) Add changelog verification. Remove old changelog workflow 
 -[\#582](https://github.com/Manta-Network/Manta/pull/582) Consensus migration stage 1: Enable Nimbus-Aura [CADO]
+-[\#752](https://github.com/Manta-Network/Manta/pull/752) v3.3.0 bump versions and weights 
 
 ### Fixed
 -[\#694](https://github.com/Manta-Network/Manta/pull/694) Use u128::MAX in fungible ledger transfer test 
 -[\#703](https://github.com/Manta-Network/Manta/pull/703) Fix double spend reclaim test 
+-[\#723](https://github.com/Manta-Network/Manta/pull/723) fix: upgrade to `manta-rs` v0.5.4 
 
 ### Removed
 -[\#737](https://github.com/Manta-Network/Manta/pull/737) Remove v3.2.1 SessionKey migration code [CADO]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,28 @@
-# CHANGELOG
+# CHANGELOG 
 
-## Unreleased
-### Breaking changes
+## v3.3.0
+### Added
+-[\#717](https://github.com/Manta-Network/Manta/pull/717) Dolphin-2085 on Baikal genesis [DO]
+-[\#712](https://github.com/Manta-Network/Manta/pull/712) Add RPC for latest checkpoint 
+-[\#763](https://github.com/Manta-Network/Manta/pull/763) Support verification of historic Aura blocks 
 
-### Features
+### Changed
+-[\#681](https://github.com/Manta-Network/Manta/pull/681) CI Ledger RPC Tests 
+-[\#682](https://github.com/Manta-Network/Manta/pull/682) Use `LengthToFee` in the `congested_chain_simulation`'s fee calculation 
+-[\#695](https://github.com/Manta-Network/Manta/pull/695) Refactor fungible ledger mint/burn 
+-[\#715](https://github.com/Manta-Network/Manta/pull/715) Update xcm-onboarding and release templates 
+-[\#701](https://github.com/Manta-Network/Manta/pull/701) switch runtime to wasm only 
+-[\#720](https://github.com/Manta-Network/Manta/pull/720) Update deps from v0.9.22 to v0.9.26 
+-[\#726](https://github.com/Manta-Network/Manta/pull/726) support STORAGE_VERSION for our pallets 
+-[\#738](https://github.com/Manta-Network/Manta/pull/738) Add changelog verification. Remove old changelog workflow 
+-[\#582](https://github.com/Manta-Network/Manta/pull/582) Consensus migration stage 1: Enable Nimbus-Aura [CADO]
 
-### Improvements
-- [\#681](https://github.com/Manta-Network/Manta/pull/681) CI Ledger RPC Tests.
-- [\#694](https://github.com/Manta-Network/Manta/pull/694) Switch to u128::MAX in fungible ledger transfer integration test.
+### Fixed
+-[\#694](https://github.com/Manta-Network/Manta/pull/694) Use u128::MAX in fungible ledger transfer test 
+-[\#703](https://github.com/Manta-Network/Manta/pull/703) Fix double spend reclaim test 
 
-### Bug fixes
+### Removed
+-[\#737](https://github.com/Manta-Network/Manta/pull/737) Remove v3.2.1 SessionKey migration code [CADO]
 
 ## v3.2.1
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#40bf50de7257f2e9a6708a3a1f3c89b9a5fc94a5"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#40bf50de7257f2e9a6708a3a1f3c89b9a5fc94a5"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#40bf50de7257f2e9a6708a3a1f3c89b9a5fc94a5"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5953,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#40bf50de7257f2e9a6708a3a1f3c89b9a5fc94a5"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -846,7 +846,9 @@ impl_runtime_apis! {
         }
 
         fn authorities() -> Vec<AuraId> {
-            Aura::authorities().into_inner()
+            // NOTE: AuraAPI must exist for node/src/aura_or_nimbus_consensus.rs
+            // But is intentionally DISABLED starting with manta v3.3.0
+            vec![]
         }
     }
 

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -833,7 +833,9 @@ impl_runtime_apis! {
         }
 
         fn authorities() -> Vec<AuraId> {
-            Aura::authorities().into_inner()
+            // NOTE: AuraAPI must exist for node/src/aura_or_nimbus_consensus.rs
+            // But is intentionally DISABLED starting with manta v3.3.0
+            vec![]
         }
     }
 


### PR DESCRIPTION
## Description

relates to: #751 

* Create changelog
* Update nimbus
* Disable parachain block parsing test

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels out of `A-` and `C-` groups to this PR
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
