### PR TITLE
Update fees splits, 50% burned, 50% to treasury

### DIFF
--- a/.github/workflows/label_checker.yml
+++ b/.github/workflows/label_checker.yml
@@ -9,11 +9,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: |
-            L-added,
-            L-changed,
-            L-fixed,
-            L-deprecated,
-            L-removed,
-            L-skip
+          one_of: L-added,L-changed,L-fixed,L-deprecated,L-removed,L-skip
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -24,8 +24,8 @@ pub use sp_runtime::Perbill;
 /// The block saturation level. Fees will be updates based on this value.
 pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
 
-pub const FEES_PERCENTAGE_TO_AUTHOR: u8 = 60;
-pub const FEES_PERCENTAGE_TO_TREASURY: u8 = 40;
+pub const FEES_PERCENTAGE_TO_TREASURY: u8 = 50;
+pub const FEES_PERCENTAGE_TO_BURN: u8 = 50;
 
 pub const TIPS_PERCENTAGE_TO_AUTHOR: u8 = 100;
 pub const TIPS_PERCENTAGE_TO_TREASURY: u8 = 0;

--- a/runtime/calamari/src/impls.rs
+++ b/runtime/calamari/src/impls.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     fee::{
-        FEES_PERCENTAGE_TO_AUTHOR, FEES_PERCENTAGE_TO_TREASURY, TIPS_PERCENTAGE_TO_AUTHOR,
+        FEES_PERCENTAGE_TO_BURN, FEES_PERCENTAGE_TO_TREASURY, TIPS_PERCENTAGE_TO_AUTHOR,
         TIPS_PERCENTAGE_TO_TREASURY,
     },
     Authorship, Balances, NegativeImbalance, Treasury,
@@ -36,22 +36,23 @@ pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
         if let Some(fees) = fees_then_tips.next() {
-            // for fees, 40% to treasury, 60% to author
-            let mut split = fees.ration(
+            // for fees, 50% to treasury, 50% to author
+            let (to_treasury, _) = fees.ration(
                 FEES_PERCENTAGE_TO_TREASURY.into(),
-                FEES_PERCENTAGE_TO_AUTHOR.into(),
+                FEES_PERCENTAGE_TO_BURN.into(),
             );
+            Treasury::on_unbalanced(to_treasury);
+
             if let Some(tips) = fees_then_tips.next() {
                 // for tips, 100% to block author.
-                tips.ration_merge_into(
-                    TIPS_PERCENTAGE_TO_TREASURY.into(),
-                    TIPS_PERCENTAGE_TO_AUTHOR.into(),
-                    &mut split,
-                );
+                let to_author = tips
+                    .ration(
+                        TIPS_PERCENTAGE_TO_TREASURY.into(),
+                        TIPS_PERCENTAGE_TO_AUTHOR.into(),
+                    )
+                    .1;
+                Author::on_unbalanced(to_author);
             }
-
-            Treasury::on_unbalanced(split.0);
-            Author::on_unbalanced(split.1);
         }
     }
 }

--- a/runtime/calamari/src/impls.rs
+++ b/runtime/calamari/src/impls.rs
@@ -36,7 +36,7 @@ pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
         if let Some(fees) = fees_then_tips.next() {
-            // for fees, 50% to treasury, 50% to author
+            // for fees, 50% to treasury, 50% burned
             let (to_treasury, _) = fees.ration(
                 FEES_PERCENTAGE_TO_TREASURY.into(),
                 FEES_PERCENTAGE_TO_BURN.into(),

--- a/runtime/calamari/tests/integration_tests.rs
+++ b/runtime/calamari/tests/integration_tests.rs
@@ -25,7 +25,7 @@ pub use calamari_runtime::{
     assets_config::{CalamariAssetConfig, CalamariConcreteFungibleLedger},
     currency::KMA,
     fee::{
-        FEES_PERCENTAGE_TO_AUTHOR, FEES_PERCENTAGE_TO_TREASURY, TIPS_PERCENTAGE_TO_AUTHOR,
+        FEES_PERCENTAGE_TO_BURN, FEES_PERCENTAGE_TO_TREASURY, TIPS_PERCENTAGE_TO_AUTHOR,
         TIPS_PERCENTAGE_TO_TREASURY,
     },
     xcm_config::XcmFeesAccount,
@@ -447,7 +447,7 @@ fn seal_header(mut header: Header, author: AccountId) -> Header {
 #[test]
 fn sanity_check_fees_and_tips_splits() {
     assert_eq!(100, TIPS_PERCENTAGE_TO_AUTHOR + TIPS_PERCENTAGE_TO_TREASURY);
-    assert_eq!(100, FEES_PERCENTAGE_TO_AUTHOR + FEES_PERCENTAGE_TO_TREASURY);
+    assert_eq!(100, FEES_PERCENTAGE_TO_BURN + FEES_PERCENTAGE_TO_TREASURY);
 }
 
 #[test]
@@ -515,7 +515,8 @@ fn reward_fees_to_block_author_and_treasury() {
             let author_received_reward = Balances::free_balance(alice) - INITIAL_BALANCE;
             println!("The rewarded_amount is: {:?}", author_received_reward);
 
-            let author_percent = Percent::from_percent(FEES_PERCENTAGE_TO_AUTHOR);
+            // Author should get none of the fees - 50% burned, 50% to treasury.
+            let author_percent = Percent::from_percent(0);
             let expected_fee =
                 TransactionPayment::compute_actual_fee(len as u32, &info, &post_info, 0);
             assert_eq!(author_received_reward, author_percent * expected_fee);

--- a/runtime/dolphin/src/impls.rs
+++ b/runtime/dolphin/src/impls.rs
@@ -30,13 +30,15 @@ pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
         if let Some(fees) = fees_then_tips.next() {
-            let mut split = fees.ration(80, 20);
+            // for fees, 50% to treasury, 50% to author
+            let (to_treasury, _) = fees.ration(50, 50);
+            Treasury::on_unbalanced(to_treasury);
+
             if let Some(tips) = fees_then_tips.next() {
-                // for tips, if any, 0% to treasury, 100% to block author (though this can be anything)
-                tips.ration_merge_into(0, 100, &mut split);
+                // for tips, 100% to block author.
+                let to_author = tips.ration(0, 100).1;
+                Author::on_unbalanced(to_author);
             }
-            Treasury::on_unbalanced(split.0);
-            Author::on_unbalanced(split.1);
         }
     }
 }

--- a/runtime/dolphin/src/impls.rs
+++ b/runtime/dolphin/src/impls.rs
@@ -30,7 +30,7 @@ pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
         if let Some(fees) = fees_then_tips.next() {
-            // for fees, 50% to treasury, 50% to author
+            // for fees, 50% to treasury, 50% burned
             let (to_treasury, _) = fees.ration(50, 50);
             Treasury::on_unbalanced(to_treasury);
 


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

## Description

relates to: #691 

* Update transaction fees split - 50% burned, 50% to treasury, because of the switch to proof of stake.
* Update related integration tests

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels out of `A-` and `C-` groups to this PR
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
