### PR TITLE
Fix Block Producer Selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.3.0#13df4c6fc654d9f76c925078a4fd2bdaadeb18cd"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5962,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#b28ed20532396af9e25e447d0685d81619e2b9bb"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6545,7 +6545,6 @@ dependencies = [
  "log",
  "manta-collator-selection",
  "manta-primitives",
- "nimbus-primitives",
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,9 +86,9 @@ cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.g
 cumulus-relay-chain-rpc-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.26" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0" }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0" }
+nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
 
 # Polkadot dependencies
 polkadot-cli = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.26" }

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.140", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26", optional = true }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
 pallet-authorship = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -549,7 +549,7 @@ pub mod pallet {
                 }
             }
             (
-                VoidNumberSetInsertionOrder::<T>::contains_key(max_sender_index as u64),
+                VoidNumberSetInsertionOrder::<T>::contains_key(max_sender_index),
                 senders,
             )
         }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -23,9 +23,6 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "po
 sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", default-features = false }
 substrate-fixed = { git = "https://github.com/Manta-Network/substrate-fixed.git", tag = "v0.5.9", default-features = false }
 
-# Nimbus
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
-
 # Manta
 manta-primitives = { path = '../../primitives/manta', default-features = false }
 # TODO: remove after whitelist period
@@ -54,7 +51,6 @@ std = [
   "log/std",
   "manta-primitives/std",
   "manta-collator-selection/std",
-  "nimbus-primitives/std",
   'pallet-session/std',
   "parity-scale-codec/std",
   "scale-info/std",

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1837,12 +1837,7 @@ pub mod pallet {
             nimbus_primitives::CanAuthor<T::AccountId> + Get<Vec<T::AccountId>>,
     {
         fn can_author(account: &T::AccountId, _slot: &u32) -> bool {
-            // Migration specifics: If we have no eligible block producers yet, use the old selection method
-            if Self::selected_candidates().is_empty() {
-                manta_collator_selection::Pallet::<T>::can_author(account, _slot)
-            } else {
                 Self::is_selected_candidate(account)
-            }
         }
         #[cfg(feature = "runtime-benchmarks")]
         fn get_authors(_slot: &u32) -> Vec<T::AccountId> {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1830,33 +1830,13 @@ pub mod pallet {
         }
     }
 
-    impl<T> nimbus_primitives::CanAuthor<T::AccountId> for Pallet<T>
-    where
-        T: Config + manta_collator_selection::Config,
-        manta_collator_selection::Pallet<T>:
-            nimbus_primitives::CanAuthor<T::AccountId> + Get<Vec<T::AccountId>>,
-    {
-        fn can_author(account: &T::AccountId, _slot: &u32) -> bool {
-            Self::is_selected_candidate(account)
-        }
-        #[cfg(feature = "runtime-benchmarks")]
-        fn get_authors(_slot: &u32) -> Vec<T::AccountId> {
-            Self::get()
-        }
-    }
-
     impl<T> Get<Vec<T::AccountId>> for Pallet<T>
     where
         T: Config + manta_collator_selection::Config,
         manta_collator_selection::Pallet<T>: Get<Vec<T::AccountId>>,
     {
         fn get() -> Vec<T::AccountId> {
-            // Migration specifics: If we have no eligible block producers yet, use the old selection method
-            if Self::selected_candidates().is_empty() {
-                manta_collator_selection::Pallet::<T>::get()
-            } else {
-                Self::selected_candidates()
-            }
+            Self::selected_candidates()
         }
     }
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1837,7 +1837,7 @@ pub mod pallet {
             nimbus_primitives::CanAuthor<T::AccountId> + Get<Vec<T::AccountId>>,
     {
         fn can_author(account: &T::AccountId, _slot: &u32) -> bool {
-                Self::is_selected_candidate(account)
+            Self::is_selected_candidate(account)
         }
         #[cfg(feature = "runtime-benchmarks")]
         fn get_authors(_slot: &u32) -> Vec<T::AccountId> {

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -8,8 +8,8 @@ version = "3.4.0"
 
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }
-# `manta-v3.3.0` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
+# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -71,10 +71,10 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.3.0` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
+# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -122,6 +122,7 @@ runtime-benchmarks = [
   'frame-system/runtime-benchmarks',
   'manta-collator-selection/runtime-benchmarks',
   'nimbus-primitives/runtime-benchmarks',
+  'pallet-aura-style-filter/runtime-benchmarks',
   'pallet-author-inherent/runtime-benchmarks',
   'pallet-balances/runtime-benchmarks',
   'pallet-multisig/runtime-benchmarks',

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -625,7 +625,7 @@ impl pallet_author_inherent::Config for Runtime {
     type WeightInfo = weights::pallet_author_inherent::SubstrateWeight<Runtime>;
     /// Nimbus filter pipeline step 1:
     /// Filters out NimbusIds not registered as SessionKeys of some AccountId
-    type CanAuthor = ParachainStaking;
+    type CanAuthor = AuraAuthorFilter;
 }
 
 parameter_types! {

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -71,10 +71,10 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.3.0` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.3.0", default-features = false }
+# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }


### PR DESCRIPTION
## Description

The `pallet_aura_style_filter` is inactive in the current release.

part of #821 

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
