### PR TITLE
Hardcode weight for instructions with  MultiAssetFilter params

### DIFF
--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -549,7 +549,7 @@ pub mod pallet {
                 }
             }
             (
-                VoidNumberSetInsertionOrder::<T>::contains_key(max_sender_index as u64),
+                VoidNumberSetInsertionOrder::<T>::contains_key(max_sender_index),
                 senders,
             )
         }

--- a/runtime/calamari/src/weights/xcm/mod.rs
+++ b/runtime/calamari/src/weights/xcm/mod.rs
@@ -19,6 +19,7 @@ mod pallet_xcm_benchmarks_generic;
 
 use crate::Runtime;
 use frame_support::weights::Weight;
+use sp_std::cmp;
 use xcm::{latest::prelude::*, DoubleEncoded};
 
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
@@ -113,7 +114,10 @@ impl<Call> XcmWeightInfo<Call> for CalamariXcmWeight<Call> {
         _max_assets: &u32,
         _dest: &MultiLocation,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
+        cmp::min(hardcoded_weight, weight)
     }
     fn deposit_reserve_asset(
         assets: &MultiAssetFilter,
@@ -121,7 +125,11 @@ impl<Call> XcmWeightInfo<Call> for CalamariXcmWeight<Call> {
         _dest: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight =
+            assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset());
+        cmp::min(hardcoded_weight, weight)
     }
     fn exchange_asset(_give: &MultiAssetFilter, _receive: &MultiAssets) -> Weight {
         Weight::MAX
@@ -131,14 +139,20 @@ impl<Call> XcmWeightInfo<Call> for CalamariXcmWeight<Call> {
         _reserve: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw());
+        cmp::min(hardcoded_weight, weight)
     }
     fn initiate_teleport(
         assets: &MultiAssetFilter,
         _dest: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+        cmp::min(hardcoded_weight, weight)
     }
     fn query_holding(
         _query_id: &u64,
@@ -146,7 +160,10 @@ impl<Call> XcmWeightInfo<Call> for CalamariXcmWeight<Call> {
         _assets: &MultiAssetFilter,
         _max_response_weight: &u64,
     ) -> Weight {
-        XcmGeneric::<Runtime>::query_holding()
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = XcmGeneric::<Runtime>::query_holding();
+        cmp::min(hardcoded_weight, weight)
     }
     fn buy_execution(_fees: &MultiAsset, _weight_limit: &WeightLimit) -> Weight {
         XcmGeneric::<Runtime>::buy_execution()

--- a/runtime/calamari/src/xcm_config.rs
+++ b/runtime/calamari/src/xcm_config.rs
@@ -336,9 +336,10 @@ impl orml_xtokens::Config for Runtime {
     type ReserveProvider = AbsoluteReserveProvider;
 }
 
-use xcm_executor::traits::WeightBounds;
 #[test]
 fn test_receiver_weight() {
+    use xcm_executor::traits::WeightBounds;
+
     let dummy_assets = MultiAssets::from(vec![MultiAsset {
         id: Concrete(MultiLocation {
             parents: 1,
@@ -389,6 +390,8 @@ fn test_receiver_weight() {
 
 #[test]
 fn test_sender_xcm_weight() {
+    use xcm_executor::traits::WeightBounds;
+
     let dummy_multi_location = MultiLocation {
         parents: 1,
         interior: X1(Parachain(1)),
@@ -402,14 +405,14 @@ fn test_sender_xcm_weight() {
     }]);
     // format of to_reserve message composed by xTokens
     let mut msg = Xcm(vec![
-        WithdrawAsset(dummy_assets.clone()),
+        WithdrawAsset(dummy_assets),
         InitiateReserveWithdraw {
             assets: Wild(All),
             reserve: dummy_multi_location.clone(),
             xcm: Xcm(vec![
                 BuyExecution {
                     fees: MultiAsset {
-                        id: Concrete(dummy_multi_location.clone()),
+                        id: Concrete(dummy_multi_location),
                         fun: Fungible(10000000000000),
                     },
                     weight_limit: Limited(3999999999),

--- a/runtime/dolphin/src/weights/xcm/mod.rs
+++ b/runtime/dolphin/src/weights/xcm/mod.rs
@@ -19,6 +19,7 @@ mod pallet_xcm_benchmarks_generic;
 
 use crate::Runtime;
 use frame_support::weights::Weight;
+use sp_std::cmp;
 use xcm::{latest::prelude::*, DoubleEncoded};
 
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
@@ -113,7 +114,10 @@ impl<Call> XcmWeightInfo<Call> for DolphinXcmWeight<Call> {
         _max_assets: &u32,
         _dest: &MultiLocation,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
+        cmp::min(hardcoded_weight, weight)
     }
     fn deposit_reserve_asset(
         assets: &MultiAssetFilter,
@@ -121,7 +125,11 @@ impl<Call> XcmWeightInfo<Call> for DolphinXcmWeight<Call> {
         _dest: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight =
+            assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset());
+        cmp::min(hardcoded_weight, weight)
     }
     fn exchange_asset(_give: &MultiAssetFilter, _receive: &MultiAssets) -> Weight {
         Weight::MAX
@@ -131,14 +139,20 @@ impl<Call> XcmWeightInfo<Call> for DolphinXcmWeight<Call> {
         _reserve: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw());
+        cmp::min(hardcoded_weight, weight)
     }
     fn initiate_teleport(
         assets: &MultiAssetFilter,
         _dest: &MultiLocation,
         _xcm: &Xcm<()>,
     ) -> Weight {
-        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+        cmp::min(hardcoded_weight, weight)
     }
     fn query_holding(
         _query_id: &u64,
@@ -146,7 +160,10 @@ impl<Call> XcmWeightInfo<Call> for DolphinXcmWeight<Call> {
         _assets: &MultiAssetFilter,
         _max_response_weight: &u64,
     ) -> Weight {
-        XcmGeneric::<Runtime>::query_holding()
+        // Hardcoded until better understanding how to deal with worst case scenario of holding register
+        let hardcoded_weight: u64 = 1_000_000_000;
+        let weight = XcmGeneric::<Runtime>::query_holding();
+        cmp::min(hardcoded_weight, weight)
     }
     fn buy_execution(_fees: &MultiAsset, _weight_limit: &WeightLimit) -> Weight {
         XcmGeneric::<Runtime>::buy_execution()


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

## Description

closes: #552

* Use hard-coded pre-benchmark value of 1_000_000_000 weight per instruction, for instruction that have the MultiAssetFilter argument, in order to reduce the cost of sender and receiver messages with those instructions.
* Add unit tests to assert that weights of typical xcm messages are less than the advertised `dest_weight` to dApp developers of 4_000_000_000

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
