### PR TITLE
Followups to Staking

### DIFF
--- a/node/src/chain_specs/calamari.rs
+++ b/node/src/chain_specs/calamari.rs
@@ -173,10 +173,15 @@ fn calamari_dev_genesis(
             candidates: invulnerables
                 .iter()
                 .cloned()
-                .map(|(account, _)| (account, 4_000_000 * KMA)) // TODO: Change to use constant from primitives
+                .map(|(account, _)| {
+                    (
+                        account,
+                        calamari_runtime::staking::NORMAL_COLLATOR_MINIMUM_STAKE,
+                    )
+                }) // TODO: Change to use constant from primitives
                 .collect(),
             delegations,
-            inflation_config: calamari_runtime::currency::inflation_config::<
+            inflation_config: calamari_runtime::staking::inflation_config::<
                 calamari_runtime::Runtime,
             >(),
         },

--- a/node/src/chain_specs/calamari.rs
+++ b/node/src/chain_specs/calamari.rs
@@ -178,7 +178,7 @@ fn calamari_dev_genesis(
                         account,
                         calamari_runtime::staking::NORMAL_COLLATOR_MINIMUM_STAKE,
                     )
-                }) // TODO: Change to use constant from primitives
+                })
                 .collect(),
             delegations,
             inflation_config: calamari_runtime::staking::inflation_config::<

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -47,7 +47,7 @@ use xcm::{
 
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
-    pub const SS58Prefix: u8 = 78;
+    pub const SS58Prefix: u8 = manta_primitives::constants::CALAMARI_SS58PREFIX;
 }
 
 impl system::Config for Runtime {

--- a/pallets/manta-pay/src/mock.rs
+++ b/pallets/manta-pay/src/mock.rs
@@ -62,7 +62,7 @@ type BlockNumber = u64;
 
 parameter_types! {
     pub const BlockHashCount: BlockNumber = 250;
-    pub const SS58Prefix: u8 = 42;
+    pub const SS58Prefix: u8 = manta_primitives::constants::CALAMARI_SS58PREFIX;
 }
 
 impl frame_system::Config for Test {

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -61,7 +61,7 @@ parameter_types! {
     pub const MaximumBlockWeight: Weight = 1024;
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
-    pub const SS58Prefix: u8 = 42;
+    pub const SS58Prefix: u8 = manta_primitives::constants::CALAMARI_SS58PREFIX;
 }
 impl frame_system::Config for Test {
     type BaseCallFilter = Everything;

--- a/primitives/manta/src/constants.rs
+++ b/primitives/manta/src/constants.rs
@@ -60,8 +60,3 @@ pub const MANTA_PAY_PALLET_ID: PalletId = PalletId(*b"mantapay");
 
 /// Default Asset Existential Deposit: Should only be used in TEST
 pub const DEFAULT_ASSET_ED: Balance = 1;
-
-pub mod calamari_staking {
-    // TODO
-    // pub const MinCollatorStake: u32 = 4_000_000;
-}

--- a/runtime/calamari/src/currency.rs
+++ b/runtime/calamari/src/currency.rs
@@ -25,39 +25,3 @@ pub const uKMA: Balance = KMA / 1_000_000; // 6 decimal, micro-MA
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
     items as Balance * 15 * mKMA + (bytes as Balance) * 6 * mKMA // TODO: revisit the storage cost here
 }
-
-use pallet_parachain_staking::{BalanceOf, InflationInfo};
-pub fn inflation_config<T: frame_system::Config + pallet_parachain_staking::Config>(
-) -> InflationInfo<BalanceOf<T>> {
-    use pallet_parachain_staking::inflation::Range;
-    use sp_arithmetic::Perbill;
-    use sp_runtime::{traits::UniqueSaturatedInto, PerThing};
-
-    fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
-        use pallet_parachain_staking::inflation::{
-            perbill_annual_to_perbill_round, BLOCKS_PER_YEAR,
-        };
-        perbill_annual_to_perbill_round(
-            annual,
-            // rounds per year
-            BLOCKS_PER_YEAR / crate::DefaultBlocksPerRound::get(),
-        )
-    }
-    let annual = Range {
-        min: Perbill::from_rational_with_rounding(5u32, 200u32, sp_arithmetic::Rounding::Down)
-            .expect("constant denom is not 0. qed"), // = 2.5%
-        ideal: Perbill::from_percent(3),
-        max: Perbill::from_percent(3),
-    };
-    InflationInfo::<BalanceOf<T>> {
-        // staking expectations **per round**
-        expect: Range {
-            min: (170_000 * KMA).unique_saturated_into(),
-            ideal: (205_479 * KMA).unique_saturated_into(), // annual inflation / number of rounds
-            max: (210_000 * KMA).unique_saturated_into(),
-        },
-        // annual inflation
-        annual,
-        round: to_round_inflation(annual),
-    }
-}

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -76,6 +76,7 @@ pub mod fee;
 pub mod impls;
 pub mod migrations;
 mod nimbus_session_adapter;
+pub mod staking;
 pub mod xcm_config;
 
 use currency::*;
@@ -568,8 +569,8 @@ parameter_types! {
     pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(10);
     /// Default percent of inflation set aside for parachain bond every round
     pub const DefaultParachainBondReservePercent: Percent = Percent::zero();
-    pub DefaultBlocksPerRound: BlockNumber = prod_or_fast!(6 * HOURS ,15,"CALAMARI_DEFAULTBLOCKSPERROUND");
-    pub LeaveDelayRounds: BlockNumber = prod_or_fast!(28 ,1 ,"CALAMARI_LEAVEDELAYROUNDS"); // == 7 * DAYS / 6 * HOURS
+    pub DefaultBlocksPerRound: BlockNumber = prod_or_fast!(6 * HOURS,15,"CALAMARI_DEFAULTBLOCKSPERROUND");
+    pub LeaveDelayRounds: BlockNumber = prod_or_fast!(28,1,"CALAMARI_LEAVEDELAYROUNDS"); // == 7 * DAYS / 6 * HOURS
 }
 impl pallet_parachain_staking::Config for Runtime {
     type Event = Event;
@@ -603,12 +604,11 @@ impl pallet_parachain_staking::Config for Runtime {
     type DefaultCollatorCommission = DefaultCollatorCommission;
     type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
     /// Minimum stake on a collator to be considered for block production
-    // WHITELIST: Temporarily 400k to accomodate whitelisted collators
-    type MinCollatorStk = ConstU128<{ 400_000 * KMA }>;
+    type MinCollatorStk = ConstU128<{ crate::staking::MIN_BOND_TO_BE_CONSIDERED_COLLATOR }>;
     /// Minimum stake the collator runner must bond to register as collator candidate
-    type MinCandidateStk = ConstU128<{ 4_000_000 * KMA }>;
+    type MinCandidateStk = ConstU128<{ crate::staking::NORMAL_COLLATOR_MINIMUM_STAKE }>;
     /// WHITELIST: Minimum stake required for *a whitelisted* account to be a collator candidate
-    type MinWhitelistCandidateStk = ConstU128<{ 400_000 * KMA }>;
+    type MinWhitelistCandidateStk = ConstU128<{ crate::staking::EARLY_COLLATOR_MINIMUM_STAKE }>;
     /// Smallest amount that can be delegated
     type MinDelegation = ConstU128<{ 5_000 * KMA }>;
     /// Minimum stake required to be reserved to be a delegator

--- a/runtime/calamari/src/migrations/staking.rs
+++ b/runtime/calamari/src/migrations/staking.rs
@@ -109,7 +109,7 @@ where
         pallet_parachain_staking::Pallet::<T>::initialize_pallet(
             current_block,
             invulnerables,
-            crate::currency::inflation_config::<T>(),
+            crate::staking::inflation_config::<T>(),
         )
         .unwrap_or_else(|err| {
             log::error!(

--- a/runtime/calamari/src/staking.rs
+++ b/runtime/calamari/src/staking.rs
@@ -1,0 +1,57 @@
+// Copyright 2020-2022 Manta Network.
+// This file is part of Manta.
+//
+// Manta is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Manta is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Manta.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{currency::KMA, Balance};
+use pallet_parachain_staking::{BalanceOf, InflationInfo};
+
+pub const NORMAL_COLLATOR_MINIMUM_STAKE: Balance = 4_000_000 * KMA;
+pub const EARLY_COLLATOR_MINIMUM_STAKE: Balance = 400_000 * KMA;
+pub const MIN_BOND_TO_BE_CONSIDERED_COLLATOR: Balance = EARLY_COLLATOR_MINIMUM_STAKE;
+
+pub fn inflation_config<T: frame_system::Config + pallet_parachain_staking::Config>(
+) -> InflationInfo<BalanceOf<T>> {
+    use pallet_parachain_staking::inflation::Range;
+    use sp_arithmetic::Perbill;
+    use sp_runtime::{traits::UniqueSaturatedInto, PerThing};
+
+    fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
+        use pallet_parachain_staking::inflation::{
+            perbill_annual_to_perbill_round, BLOCKS_PER_YEAR,
+        };
+        perbill_annual_to_perbill_round(
+            annual,
+            // rounds per year
+            BLOCKS_PER_YEAR / crate::DefaultBlocksPerRound::get(),
+        )
+    }
+    let annual = Range {
+        min: Perbill::from_rational_with_rounding(5u32, 200u32, sp_arithmetic::Rounding::Down)
+            .expect("constant denom is not 0. qed"), // = 2.5%
+        ideal: Perbill::from_percent(3),
+        max: Perbill::from_percent(3),
+    };
+    InflationInfo::<BalanceOf<T>> {
+        // staking expectations **per round**
+        expect: Range {
+            min: (170_000 * KMA).unique_saturated_into(),
+            ideal: (205_479 * KMA).unique_saturated_into(), // annual inflation / number of rounds
+            max: (210_000 * KMA).unique_saturated_into(),
+        },
+        // annual inflation
+        annual,
+        round: to_round_inflation(annual),
+    }
+}


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description

partially addresses #798

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
