### PR TITLE
Fix sequence skipping when a collator misses its slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.1#a0720c7fabb3f8ea1bfe173ed34a820ef1592f24"
+source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#1b1e46f6cdbadffb6cf4ba031d15be4205960c6d"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?branch=manta-v3.4.3#37f5d9a35063a869cc004195d177de7bbc63886a"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#f3fa9b44b8665891f2fadc2bdfcbf945f0cc20cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,9 +86,9 @@ cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.g
 cumulus-relay-chain-rpc-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.26" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
+nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
 
 # Polkadot dependencies
 polkadot-cli = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.26" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -86,9 +86,9 @@ cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.g
 cumulus-relay-chain-rpc-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.26" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1" }
+nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3" }
 
 # Polkadot dependencies
 polkadot-cli = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.26" }

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.140", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26", optional = true }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 pallet-authorship = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.140", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26", optional = true }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
 pallet-authorship = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -8,8 +8,8 @@ version = "3.4.0"
 
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }
-# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", default-features = false }

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -8,7 +8,6 @@ version = "3.4.0"
 
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }
-# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
 nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -9,7 +9,7 @@ version = "3.4.0"
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }
 # `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -72,9 +72,9 @@ parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-fe
 
 # Nimbus Dependencies
 # `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -71,7 +71,6 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
 nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -71,10 +71,10 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -72,9 +72,9 @@ parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-fe
 
 # Nimbus Dependencies
 # `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -71,7 +71,6 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
 nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
 pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -71,10 +71,10 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-# `manta-v3.4.1` is a temporary branch until the official v0.9.26 Nimbus release.
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.1", default-features = false }
+# `manta-v3.4.3` is a temporary branch until the official v0.9.26 Nimbus release.
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", branch = "manta-v3.4.3", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }


### PR DESCRIPTION
## Description

- Block production now skips all ~~even~~odd relaychain block numbers
- Also changes nimbus to pull from tag instead of branch
- Also changes the non-eligible log print to
`🔮 Skipping candidate production because we are not eligible for slot 1234`
to clarify non-eligibility only for the current slot

Nimbus diff: https://github.com/Manta-Network/nimbus/compare/manta-v3.4.1...Manta-Network:nimbus:v3.4.3

closes #845 
closes #799
prep for #825 

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
