### PR TITLE
Fix XCM tests

### DIFF
--- a/primitives/manta/src/xcm.rs
+++ b/primitives/manta/src/xcm.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 use sp_runtime::traits::{CheckedConversion, Convert, Zero};
-use sp_std::{marker::PhantomData, result};
+use sp_std::{marker::PhantomData, result, vec};
 
 use frame_support::{
     pallet_prelude::Get,
@@ -30,7 +30,13 @@ use frame_support::{
 
 use crate::assets::{AssetIdLocationGetter, UnitsToWeightRatio};
 use xcm::{
-    latest::{prelude::Concrete, Error as XcmError, Result as XcmResult},
+    latest::{
+        prelude::{
+            All, Any, BuyExecution, ClearOrigin, Concrete, DepositAsset, InitiateReserveWithdraw,
+            Limited, MultiAssets, ReserveAssetDeposited, TransferReserveAsset, Wild, WithdrawAsset,
+        },
+        Error as XcmError, Result as XcmResult, Xcm,
+    },
     v1::{
         AssetId as xcmAssetId, Fungibility,
         Fungibility::*,
@@ -445,4 +451,171 @@ impl<
 
         Ok((asset_id, amount, receiver))
     }
+}
+
+// 4_000_000_000 is a typical configuration value provided to dApp developers for `dest_weight`
+// argument when sending xcm message to Calamari. ie moonbeam, sub-wallet, phala, etc
+pub const ADVERTISED_DEST_WEIGHT: u64 = 4_000_000_000;
+
+// Composition of self_reserve message composed by xTokens on the sender side
+pub fn self_reserve_xcm_message_receiver_side<T>() -> Xcm<T> {
+    Xcm(vec![
+        ReserveAssetDeposited(MultiAssets::from(vec![MultiAsset {
+            id: Concrete(MultiLocation {
+                parents: 1,
+                interior: X1(Parachain(1)),
+            }),
+            fun: Fungible(10000000000000),
+        }])),
+        ClearOrigin,
+        BuyExecution {
+            fees: MultiAsset {
+                id: Concrete(MultiLocation {
+                    parents: 1,
+                    interior: X1(Parachain(1)),
+                }),
+                fun: Fungible(10000000000000),
+            },
+            weight_limit: Limited(3999999999),
+        },
+        DepositAsset {
+            assets: Wild(All),
+            max_assets: 1,
+            beneficiary: MultiLocation {
+                parents: 0,
+                interior: X1(AccountId32 {
+                    network: Any,
+                    id: [
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0,
+                    ],
+                }),
+            },
+        },
+    ])
+}
+
+// Composition of to_reserve message composed by xTokens on the receiver side
+pub fn to_reserve_xcm_message_receiver_side<T>() -> Xcm<T> {
+    Xcm(vec![
+        WithdrawAsset(MultiAssets::from(vec![MultiAsset {
+            id: Concrete(MultiLocation {
+                parents: 1,
+                interior: X1(Parachain(1)),
+            }),
+            fun: Fungible(10000000000000),
+        }])),
+        ClearOrigin,
+        BuyExecution {
+            fees: MultiAsset {
+                id: Concrete(MultiLocation {
+                    parents: 1,
+                    interior: X1(Parachain(1)),
+                }),
+                fun: Fungible(10000000000000),
+            },
+            weight_limit: Limited(3999999999),
+        },
+        DepositAsset {
+            assets: Wild(All),
+            max_assets: 1,
+            beneficiary: MultiLocation {
+                parents: 0,
+                interior: X1(AccountId32 {
+                    network: Any,
+                    id: [
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0,
+                    ],
+                }),
+            },
+        },
+    ])
+}
+
+// Composition of to_reserve message composed by xTokens on the sender side
+pub fn to_reserve_xcm_message_sender_side<T>() -> Xcm<T> {
+    let dummy_multi_location = MultiLocation {
+        parents: 1,
+        interior: X1(Parachain(1)),
+    };
+    let dummy_assets = MultiAssets::from(vec![MultiAsset {
+        id: Concrete(MultiLocation {
+            parents: 1,
+            interior: X1(Parachain(1)),
+        }),
+        fun: Fungible(10000000000000),
+    }]);
+    Xcm(vec![
+        WithdrawAsset(dummy_assets),
+        InitiateReserveWithdraw {
+            assets: Wild(All),
+            reserve: dummy_multi_location.clone(),
+            xcm: Xcm(vec![
+                BuyExecution {
+                    fees: MultiAsset {
+                        id: Concrete(dummy_multi_location),
+                        fun: Fungible(10000000000000),
+                    },
+                    weight_limit: Limited(3999999999),
+                },
+                DepositAsset {
+                    assets: Wild(All),
+                    max_assets: 1,
+                    beneficiary: MultiLocation {
+                        parents: 0,
+                        interior: X1(AccountId32 {
+                            network: Any,
+                            id: [
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            ],
+                        }),
+                    },
+                },
+            ]),
+        },
+    ])
+}
+
+// Composition of self_reserve message composed by xTokens on the sender side
+pub fn self_reserve_xcm_message_sender_side<T>() -> Xcm<T> {
+    let dummy_multi_location = MultiLocation {
+        parents: 1,
+        interior: X1(Parachain(1)),
+    };
+    let dummy_assets = MultiAssets::from(vec![MultiAsset {
+        id: Concrete(MultiLocation {
+            parents: 1,
+            interior: X1(Parachain(1)),
+        }),
+        fun: Fungible(10000000000000),
+    }]);
+    Xcm(vec![TransferReserveAsset {
+        assets: dummy_assets,
+        dest: dummy_multi_location.clone(),
+        xcm: Xcm(vec![
+            BuyExecution {
+                fees: MultiAsset {
+                    id: Concrete(dummy_multi_location),
+                    fun: Fungible(10000000000000),
+                },
+                weight_limit: Limited(3999999999),
+            },
+            DepositAsset {
+                assets: Wild(All),
+                max_assets: 1,
+                beneficiary: MultiLocation {
+                    parents: 0,
+                    interior: X1(AccountId32 {
+                        network: Any,
+                        id: [
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                    }),
+                },
+            },
+        ]),
+    }])
 }


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

## Description

closes: #552

* Cleanup of v3.4.2 release

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
