### PR TITLE
Release v3.4.3-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#69313a4233744f9e4ed3533ac497afde0cd5bc14"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#69313a4233744f9e4ed3533ac497afde0cd5bc14"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#69313a4233744f9e4ed3533ac497afde0cd5bc14"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#fdd2ff5f9f57a22b343c5d2dec54a0582dc95b33"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#69313a4233744f9e4ed3533ac497afde0cd5bc14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("calamari"),
     impl_name: create_runtime_str!("calamari"),
     authoring_version: 2,
-    spec_version: 3430,
+    spec_version: 3431,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 9,

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dolphin"),
     impl_name: create_runtime_str!("dolphin"),
     authoring_version: 2,
-    spec_version: 3430,
+    spec_version: 3431,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("manta"),
     impl_name: create_runtime_str!("manta"),
     authoring_version: 1,
-    spec_version: 3430,
+    spec_version: 3431,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

- Nimbus: use two chances per 12s to produce instead of skipping the second 6s slot

relates to 

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
