### PR TITLE
Fix round changes

### DIFF
--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1023,10 +1023,33 @@ impl_runtime_apis! {
 
     impl nimbus_primitives::NimbusApi<Block> for Runtime {
         fn can_author(author: NimbusId, relay_parent: u32, parent_header: &<Block as BlockT>::Header) -> bool {
-            System::initialize(&(parent_header.number + 1), &parent_header.hash(), &parent_header.digest);
-
-            // And now the actual prediction call
-            <AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &relay_parent)
+            let next_block_number = parent_header.number + 1;
+            let slot = relay_parent;
+            // Because the staking solution calculates the next staking set at the beginning
+            // of the first block in the new round, the only way to accurately predict the
+            // authors is to compute the selection during prediction.
+            // NOTE: This logic must manually be kept in sync with the nimbus filter pipeline
+            if pallet_parachain_staking::Pallet::<Self>::round().should_update(next_block_number)
+            {
+                // lookup account from nimbusId
+                // mirrors logic in `pallet_author_inherent`
+                use nimbus_primitives::AccountLookup;
+                let account = match manta_collator_selection::Pallet::<Self>::lookup_account(&author) {
+                    Some(account) => account,
+                    // Authors whose account lookups fail will not be eligible
+                    None => {
+                        return false;
+                    }
+                };
+                // manually check aura eligibility (in the new round)
+                // mirrors logic in `aura_style_filter`
+                let truncated_half_slot = (slot >> 1) as usize;
+                let active: Vec<AccountId> = pallet_parachain_staking::Pallet::<Self>::compute_top_candidates();
+                return account == active[truncated_half_slot % active.len()];
+            } else {
+                // We're not changing rounds, `PotentialAuthors` is not changing, just use can_author
+                <AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &relay_parent)
+            }
         }
     }
 

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1045,7 +1045,7 @@ impl_runtime_apis! {
                 // mirrors logic in `aura_style_filter`
                 let truncated_half_slot = (slot >> 1) as usize;
                 let active: Vec<AccountId> = pallet_parachain_staking::Pallet::<Self>::compute_top_candidates();
-                return account == active[truncated_half_slot % active.len()];
+                account == active[truncated_half_slot % active.len()]
             } else {
                 // We're not changing rounds, `PotentialAuthors` is not changing, just use can_author
                 <AuthorInherent as nimbus_primitives::CanAuthor<_>>::can_author(&author, &relay_parent)


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description

Logic as per https://github.com/PureStake/moonbeam/blob/d069c1a68fa185d89cf3699ebd6c61edeb74883c/runtime/common/src/apis.rs#L404

Continued in #868 
Followup to https://github.com/Manta-Network/Manta/issues/794

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
