### PR TITLE
Release v4.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,7 +959,7 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "calamari-runtime"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "calamari-vesting",
  "cumulus-pallet-dmp-queue",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "calamari-vesting"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "dolphin-runtime"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "manta"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "async-trait",
  "calamari-runtime",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "manta-collator-selection"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "manta-primitives"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "manta-runtime"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-manager"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6544,7 +6544,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-staking"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-tx-pause"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9068,7 +9068,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "frame-support",
  "manta-primitives",
@@ -10523,7 +10523,7 @@ dependencies = [
 
 [[package]]
 name = "session-key-primitives"
-version = "3.4.3"
+version = "4.0.0-alpha.1"
 dependencies = [
  "manta-primitives",
  "nimbus-primitives",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,7 @@ license = 'GPL-3.0'
 name = 'manta'
 repository = 'https://github.com/Manta-Network/Manta/'
 rust-version = '1.59'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "pallet-asset-manager"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false }

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -7,7 +7,7 @@ license = 'GPL-3.0'
 name = 'manta-collator-selection'
 readme = 'README.md'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -6,7 +6,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "pallet-parachain-staking"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 log = { version = "0.4", default-features = false }

--- a/pallets/tx-pause/Cargo.toml
+++ b/pallets/tx-pause/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "pallet-tx-pause"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false }

--- a/pallets/vesting/Cargo.toml
+++ b/pallets/vesting/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "calamari-vesting"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }

--- a/primitives/manta/Cargo.toml
+++ b/primitives/manta/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "manta-primitives"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -4,7 +4,7 @@ description = "Primitives for session keys"
 edition = "2021"
 license = 'GPL-3.0'
 name = "session-key-primitives"
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'calamari-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("calamari"),
     impl_name: create_runtime_str!("calamari"),
     authoring_version: 2,
-    spec_version: 3432,
+    spec_version: 4000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 9,

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = "runtime-common"
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 # Substrate dependencies

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'dolphin-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dolphin"),
     impl_name: create_runtime_str!("dolphin"),
     authoring_version: 2,
-    spec_version: 3432,
+    spec_version: 4000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/manta/Cargo.toml
+++ b/runtime/manta/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://manta.network'
 license = 'GPL-3.0'
 name = 'manta-runtime'
 repository = 'https://github.com/Manta-Network/Manta/'
-version = '3.4.3'
+version = '4.0.0-alpha.1'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("manta"),
     impl_name: create_runtime_str!("manta"),
     authoring_version: 1,
-    spec_version: 3432,
+    spec_version: 4000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

closes #883

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
