### PR TITLE
Use finalized_hash instead of best_hash in pull_ledger_diff

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -325,7 +325,7 @@ pub fn run_with(cli: Cli) -> Result {
                     &polkadot_cli,
                     config.tokio_handle.clone(),
                 )
-                .map_err(|err| format!("Relay chain argument error: {}", err))?;
+                .map_err(|err| format!("Relay chain argument error: {err}"))?;
 
                 cmd.run(config, polkadot_config)
             })
@@ -397,7 +397,7 @@ pub fn run_with(cli: Cli) -> Result {
                 .map(|cfg| &cfg.registry);
             let task_manager =
                 sc_service::TaskManager::new(runner.config().tokio_handle.clone(), *registry)
-                    .map_err(|e| format!("Error: {:?}", e))?;
+                    .map_err(|e| format!("Error: {e:?}"))?;
 
             if runner.config().chain_spec.is_manta() {
                 runner.async_run(|config| {
@@ -453,13 +453,13 @@ pub fn run_with(cli: Cli) -> Result {
 
                 let block: crate::service::Block =
                     generate_genesis_block(&*config.chain_spec, state_version)
-                        .map_err(|e| format!("{:?}", e))?;
+                    .map_err(|e| format!("{e:?}"))?;
                 let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
                 let tokio_handle = config.tokio_handle.clone();
                 let polkadot_config =
                     SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
-                        .map_err(|err| format!("Relay chain argument error: {}", err))?;
+                        .map_err(|err| format!("Relay chain argument error: {err}"))?;
 
                 info!("Parachain id: {:?}", id);
                 info!("Parachain Account: {}", parachain_account);

--- a/pallets/collator-selection/src/lib.rs
+++ b/pallets/collator-selection/src/lib.rs
@@ -639,7 +639,7 @@ pub mod pallet {
                             })
                             .unwrap_or_else(|why| {
                                 log::warn!("Failed to remove candidate due to underperformance {:?}", why);
-                                debug_assert!(false, "failed to remove candidate {:?}", why);
+                                debug_assert!(false, "failed to remove candidate {why:?}");
                             });
                     }
                 }

--- a/pallets/manta-pay/src/bin/precompute_coins.rs
+++ b/pallets/manta-pay/src/bin/precompute_coins.rs
@@ -167,8 +167,7 @@ fn main() -> Result<()> {
         .unwrap_or(env::current_dir()?.join("precomputed_coins.rs"));
     assert!(
         !target_file.exists(),
-        "Specify a file to place the generated files: {:?}.",
-        target_file,
+        "Specify a file to place the generated files: {target_file:?}.",
     );
     fs::create_dir_all(
         target_file
@@ -177,7 +176,7 @@ fn main() -> Result<()> {
     )?;
 
     let directory = tempfile::tempdir().expect("Unable to generate temporary test directory.");
-    println!("[INFO] Temporary Directory: {:?}", directory);
+    println!("[INFO] Temporary Directory: {directory:?}");
 
     let mut rng = ChaCha20Rng::from_seed([0; 32]);
     let (proving_context, _, parameters, utxo_accumulator_model) =

--- a/pallets/manta-pay/src/rpc.rs
+++ b/pallets/manta-pay/src/rpc.rs
@@ -80,7 +80,7 @@ where
         max_senders: u64,
     ) -> RpcResult<PullResponse> {
         let api = self.client.runtime_api();
-        let at = BlockId::hash(self.client.info().best_hash);
+        let at = BlockId::hash(self.client.info().finalized_hash);
         api.pull_ledger_diff(&at, checkpoint.into(), max_receivers, max_senders)
             .map_err(|err| {
                 CallError::Custom(ErrorObject::owned(

--- a/pallets/manta-pay/src/rpc.rs
+++ b/pallets/manta-pay/src/rpc.rs
@@ -86,7 +86,7 @@ where
                 CallError::Custom(ErrorObject::owned(
                     PULL_LEDGER_DIFF_ERROR,
                     "Unable to compute state diff for pull",
-                    Some(format!("{:?}", err)),
+                    Some(format!("{err:?}")),
                 ))
                 .into()
             })

--- a/pallets/manta-pay/src/test/payment.rs
+++ b/pallets/manta-pay/src/test/payment.rs
@@ -166,7 +166,7 @@ where
     let mut utxo_accumulator = UtxoAccumulator::new(UTXO_ACCUMULATOR_MODEL.clone());
     let mut asset_id = 8u128;
     for i in 0..total {
-        println!("Current: {:?}", i);
+        println!("Current: {i:?}");
         let mint0 = PalletTransferPost::from(test::payment::to_private::prove_full(
             &PROVING_CONTEXT.to_private,
             &PARAMETERS,

--- a/primitives/session-keys/src/util.rs
+++ b/primitives/session-keys/src/util.rs
@@ -32,7 +32,7 @@ pub fn unchecked_public_key<T>(seed: &str) -> PublicKey<T>
 where
     T: CryptoType,
 {
-    T::Pair::from_string(&format!("//{}", seed), None)
+    T::Pair::from_string(&format!("//{seed}"), None)
         .expect("The validity of the seed is unchecked.")
         .public()
 }

--- a/runtime/calamari/src/fee.rs
+++ b/runtime/calamari/src/fee.rs
@@ -140,7 +140,7 @@ mod multiplier_tests {
         // Configure the target cost depending on the current state of the network.
         let target_daily_congestion_cost_usd = 250000;
         let kma_price = fetch_kma_price().unwrap();
-        println!("KMA/USD price as read from CoinGecko = {}", kma_price);
+        println!("KMA/USD price as read from CoinGecko = {kma_price}");
         let target_daily_congestion_cost_kma =
             (target_daily_congestion_cost_usd as f32 * kma_price * KMA as f32) as u128;
 
@@ -181,8 +181,8 @@ mod multiplier_tests {
                 let next = runtime_multiplier_update(fee_adjustment);
                 // if no change or less, panic. This should never happen in this case.
                 if fee_adjustment >= next {
-                    println!("final fee_adjustment: {}", fee_adjustment);
-                    println!("final next: {}", next);
+                    println!("final fee_adjustment: {fee_adjustment}");
+                    println!("final next: {next}");
                     panic!("The fee should ever increase");
                 }
                 fee_adjustment = next;
@@ -225,9 +225,7 @@ mod multiplier_tests {
             let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
             assert!(
                 next > minimum_multiplier,
-                "{:?} !>= {:?}",
-                next,
-                minimum_multiplier
+                "{next:?} !>= {minimum_multiplier:?}",
             );
         })
     }
@@ -249,11 +247,11 @@ mod multiplier_tests {
             run_with_system_weight(block_weight, || {
                 let next = SlowAdjustingFeeUpdate::<Runtime>::convert(multiplier);
                 // ensure that it is growing as well.
-                assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
+                assert!(next > multiplier, "{next:?} !>= {multiplier:?}");
                 multiplier = next;
             });
             blocks += 1;
-            println!("block = {} multiplier {:?}", blocks, multiplier);
+            println!("block = {blocks} multiplier {multiplier:?}");
         }
     }
 }

--- a/runtime/calamari/tests/integrations_mock/integration_tests.rs
+++ b/runtime/calamari/tests/integrations_mock/integration_tests.rs
@@ -538,7 +538,7 @@ fn reward_fees_to_block_author_and_treasury() {
             );
 
             let author_received_reward = Balances::free_balance(alice) - INITIAL_BALANCE;
-            println!("The rewarded_amount is: {:?}", author_received_reward);
+            println!("The rewarded_amount is: {author_received_reward:?}");
 
             // Fees split: 40% burned, 40% to treasury, 10% to author.
             let author_percent = Percent::from_percent(FEES_PERCENTAGE_TO_AUTHOR);


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

## Description

closes: #773 

* Use finalized_hash instead of best_hash in pull_ledger_diff, in order for wallets or indexer to not fall out sync 

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
