### PR TITLE
Add dense_pull_ledger_diff rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,7 +4421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b4b888cfbeb1f5551acd3aa1366e01bf88ede26cc3c4645d0d2d004d5ca7b0"
 dependencies = [
  "asynchronous-codec",
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fnv",
@@ -4803,7 +4809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.13.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -6470,6 +6476,7 @@ name = "pallet-manta-pay"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "base64 0.20.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -8958,7 +8965,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -9264,7 +9271,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -10871,7 +10878,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "flate2",
  "futures 0.3.25",
@@ -12726,7 +12733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1df23c642e1376892f3b72f311596976979cbf8b85469680cdd3a8a063d12a2"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "directories-next",
  "file-per-thread-logger",

--- a/pallets/manta-pay/Cargo.toml
+++ b/pallets/manta-pay/Cargo.toml
@@ -86,6 +86,7 @@ precompute-coins = [
 [dependencies]
 # utils
 anyhow = { version = "1.0.55", optional = true, default-features = false }
+base64 = { version = "0.20", default-features = false, features = ["alloc"] }
 indoc = { version = "1.0.3", optional = true, default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 tempfile = { version = "3.3.0", optional = true, default-features = false }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -85,7 +85,7 @@ use manta_util::{codec::Encode, into_array_unchecked, Array};
 
 pub use crate::types::{Checkpoint, RawCheckpoint};
 pub use pallet::*;
-pub use types::PullResponse;
+pub use types::{DensePullResponse, PullResponse};
 pub use weights::WeightInfo;
 
 #[cfg(test)]
@@ -118,6 +118,7 @@ pub mod pallet {
     use super::*;
     use frame_support::{pallet_prelude::*, traits::StorageVersion};
     use frame_system::pallet_prelude::*;
+    use scale_codec::Encode;
     use sp_runtime::traits::AccountIdConversion;
 
     const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -617,6 +618,29 @@ pub mod pallet {
                 should_continue: more_receivers || more_senders,
                 receivers,
                 senders,
+                senders_receivers_total: asset_value_encode(senders_receivers_total),
+            }
+        }
+
+        /// Returns the diff of ledger state since the given `checkpoint`, `max_receivers`, and
+        /// `max_senders`.
+        #[inline]
+        pub fn dense_pull_ledger_diff(
+            checkpoint: Checkpoint,
+            max_receivers: u64,
+            max_senders: u64,
+        ) -> DensePullResponse {
+            let (more_receivers, receivers) =
+                Self::pull_receivers(*checkpoint.receiver_index, max_receivers);
+            let (more_senders, senders) = Self::pull_senders(checkpoint.sender_index, max_senders);
+            let senders_receivers_total = (0..=255)
+                .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
+                .sum::<u128>()
+                + NullifierSetSize::<T>::get() as u128;
+            DensePullResponse {
+                should_continue: more_receivers || more_senders,
+                receivers: base64::encode(&receivers.encode()),
+                senders: base64::encode(&senders.encode()),
                 senders_receivers_total: asset_value_encode(senders_receivers_total),
             }
         }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -639,8 +639,8 @@ pub mod pallet {
                 + NullifierSetSize::<T>::get() as u128;
             DensePullResponse {
                 should_continue: more_receivers || more_senders,
-                receivers: base64::encode(&receivers.encode()),
-                senders: base64::encode(&senders.encode()),
+                receivers: base64::encode(receivers.encode()),
+                senders: base64::encode(senders.encode()),
                 senders_receivers_total: asset_value_encode(senders_receivers_total),
             }
         }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -640,9 +640,7 @@ pub mod pallet {
             DensePullResponse {
                 should_continue: more_receivers || more_senders,
                 receivers: base64::encode(receivers.encode()),
-                receivers_len: receivers.len() as u32,
                 senders: base64::encode(senders.encode()),
-                senders_len: senders.len() as u32,
                 senders_receivers_total: asset_value_encode(senders_receivers_total),
                 next_checkpoint: None,
             }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -640,8 +640,11 @@ pub mod pallet {
             DensePullResponse {
                 should_continue: more_receivers || more_senders,
                 receivers: base64::encode(receivers.encode()),
+                receivers_len: receivers.len() as u32,
                 senders: base64::encode(senders.encode()),
+                senders_len: senders.len() as u32,
                 senders_receivers_total: asset_value_encode(senders_receivers_total),
+                next_checkpoint: None,
             }
         }
 

--- a/pallets/manta-pay/src/rpc.rs
+++ b/pallets/manta-pay/src/rpc.rs
@@ -16,7 +16,7 @@
 
 //! MantaPay RPC Interfaces
 
-use crate::{runtime::PullLedgerDiffApi, Checkpoint, PullResponse};
+use crate::{runtime::PullLedgerDiffApi, Checkpoint, DensePullResponse, PullResponse};
 use alloc::sync::Arc;
 use core::marker::PhantomData;
 use jsonrpsee::{
@@ -43,6 +43,14 @@ pub trait PullApi {
         max_receivers: u64,
         max_senders: u64,
     ) -> RpcResult<PullResponse>;
+
+    #[method(name = "mantaPay_dense_pull_ledger_diff", blocking)]
+    fn dense_pull_ledger_diff(
+        &self,
+        checkpoint: Checkpoint,
+        max_receivers: u64,
+        max_senders: u64,
+    ) -> RpcResult<DensePullResponse>;
 }
 
 /// Pull RPC API Implementation
@@ -86,6 +94,26 @@ where
                 CallError::Custom(ErrorObject::owned(
                     PULL_LEDGER_DIFF_ERROR,
                     "Unable to compute state diff for pull",
+                    Some(format!("{err:?}")),
+                ))
+                .into()
+            })
+    }
+
+    #[inline]
+    fn dense_pull_ledger_diff(
+        &self,
+        checkpoint: Checkpoint,
+        max_receivers: u64,
+        max_senders: u64,
+    ) -> RpcResult<DensePullResponse> {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(self.client.info().finalized_hash);
+        api.dense_pull_ledger_diff(&at, checkpoint.into(), max_receivers, max_senders)
+            .map_err(|err| {
+                CallError::Custom(ErrorObject::owned(
+                    PULL_LEDGER_DIFF_ERROR,
+                    "Unable to compute dense state diff for pull",
                     Some(format!("{err:?}")),
                 ))
                 .into()

--- a/pallets/manta-pay/src/runtime.rs
+++ b/pallets/manta-pay/src/runtime.rs
@@ -16,10 +16,12 @@
 
 //! MantaPay Runtime APIs
 
-use crate::{PullResponse, RawCheckpoint};
+use crate::{DensePullResponse, PullResponse, RawCheckpoint};
 
 sp_api::decl_runtime_apis! {
     pub trait PullLedgerDiffApi {
         fn pull_ledger_diff(checkpoint: RawCheckpoint, max_receivers: u64, max_senders: u64) -> PullResponse;
+
+        fn dense_pull_ledger_diff(checkpoint: RawCheckpoint, max_receivers: u64, max_senders: u64) -> DensePullResponse;
     }
 }

--- a/pallets/manta-pay/src/test/payment.rs
+++ b/pallets/manta-pay/src/test/payment.rs
@@ -514,3 +514,50 @@ fn check_number_conversions() {
     assert_eq!(start, id_from_field);
     assert_eq!(fp, decoded);
 }
+
+#[test]
+fn pull_ledger_diff_should_work() {
+    use scale_codec::Decode;
+    new_test_ext().execute_with(|| {
+        for _ in 0..2 {
+            let mut rng = OsRng;
+            let asset_id = rng.gen();
+            let total_free_supply = rng.gen();
+            initialize_test(asset_id, total_free_supply + TEST_DEFAULT_ASSET_ED);
+            mint_private_tokens(
+                asset_id,
+                &value_distribution(5, total_free_supply, &mut rng),
+                &mut rng,
+            );
+        }
+
+        let (max_receivers, max_senders) = (128, 128);
+        let check_point = crate::Checkpoint::default();
+        let pull_response =
+            MantaPayPallet::pull_ledger_diff(check_point, max_receivers, max_senders);
+        let dense_pull_response =
+            MantaPayPallet::dense_pull_ledger_diff(check_point, max_receivers, max_senders);
+        assert_eq!(
+            pull_response.senders_receivers_total,
+            dense_pull_response.senders_receivers_total
+        );
+        assert_eq!(
+            pull_response.should_continue,
+            dense_pull_response.should_continue
+        );
+        assert_eq!(
+            pull_response.should_continue,
+            dense_pull_response.should_continue
+        );
+
+        let dense_receivers = base64::decode(dense_pull_response.receivers).unwrap();
+        let mut slice_of = dense_receivers.as_slice();
+        let decoded_receivers = <crate::ReceiverChunk as Decode>::decode(&mut slice_of).unwrap();
+        assert_eq!(pull_response.receivers, decoded_receivers);
+
+        let dense_senders = base64::decode(dense_pull_response.senders).unwrap();
+        let mut slice_of = dense_senders.as_slice();
+        let decoded_senders = <crate::SenderChunk as Decode>::decode(&mut slice_of).unwrap();
+        assert_eq!(pull_response.senders, decoded_senders);
+    });
+}

--- a/pallets/manta-pay/src/types.rs
+++ b/pallets/manta-pay/src/types.rs
@@ -913,14 +913,10 @@ pub struct DensePullResponse {
     // we decode the receivers/senders with our own way
     #[codec(skip)]
     pub receivers: String,
-    /// Total amount of dense `ReceiverChunk`
-    pub receivers_len: u32,
 
     /// Ledger Sender Chunk
     #[codec(skip)]
     pub senders: String,
-    /// Total amount of dense `SenderChunk`
-    pub senders_len: u32,
 
     /// Total Number of Senders/Receivers in Ledger
     pub senders_receivers_total: [u8; 16],

--- a/pallets/manta-pay/src/types.rs
+++ b/pallets/manta-pay/src/types.rs
@@ -913,13 +913,25 @@ pub struct DensePullResponse {
     // we decode the receivers/senders with our own way
     #[codec(skip)]
     pub receivers: String,
+    /// Total amount of dense `ReceiverChunk`
+    pub receivers_len: u32,
 
     /// Ledger Sender Chunk
     #[codec(skip)]
     pub senders: String,
+    /// Total amount of dense `SenderChunk`
+    pub senders_len: u32,
 
     /// Total Number of Senders/Receivers in Ledger
     pub senders_receivers_total: [u8; 16],
+
+    /// Next request checkpoint calculated from server.
+    /// If should_continue = false, this data makes no sense.
+    /// Else, the client can just use this one as next request cursor,
+    /// It avoids complex computing on the client side,
+    /// and the potential risk of inconsistent computing rules between the client and server
+    #[codec(skip)]
+    pub next_checkpoint: Option<Checkpoint>,
 }
 
 /// Raw Checkpoint for Encoding and Decoding

--- a/pallets/manta-pay/src/types.rs
+++ b/pallets/manta-pay/src/types.rs
@@ -16,7 +16,7 @@
 
 //! Type Definitions for Manta Pay
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use manta_crypto::merkle_tree;
 use manta_pay::{
     config::{
@@ -890,6 +890,33 @@ pub struct PullResponse {
 
     /// Ledger Sender Chunk
     pub senders: SenderChunk,
+
+    /// Total Number of Senders/Receivers in Ledger
+    pub senders_receivers_total: [u8; 16],
+}
+
+/// Ledger Source Dense Pull Response
+#[cfg_attr(
+    feature = "serde",
+    derive(Deserialize, Serialize),
+    serde(crate = "manta_util::serde", deny_unknown_fields)
+)]
+#[derive(Clone, Debug, Encode, Default, Eq, Hash, Decode, PartialEq, TypeInfo)]
+pub struct DensePullResponse {
+    /// Pull Continuation Flag
+    ///
+    /// The `should_continue` flag is set to `true` if the client should request more data from the
+    /// ledger to finish the pull.
+    pub should_continue: bool,
+
+    /// Ledger Receiver Chunk
+    // we decode the receivers/senders with our own way
+    #[codec(skip)]
+    pub receivers: String,
+
+    /// Ledger Sender Chunk
+    #[codec(skip)]
+    pub senders: String,
 
     /// Total Number of Senders/Receivers in Ledger
     pub senders_receivers_total: [u8; 16],

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1031,6 +1031,14 @@ impl_runtime_apis! {
         ) -> pallet_manta_pay::PullResponse {
             MantaPay::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
         }
+
+        fn dense_pull_ledger_diff(
+            checkpoint: pallet_manta_pay::RawCheckpoint,
+            max_receiver: u64,
+            max_sender: u64
+        ) -> pallet_manta_pay::DensePullResponse {
+            MantaPay::dense_pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
+        }
     }
 
     impl nimbus_primitives::NimbusApi<Block> for Runtime {

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -939,6 +939,14 @@ impl_runtime_apis! {
         ) -> pallet_manta_pay::PullResponse {
             MantaPay::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
         }
+
+        fn dense_pull_ledger_diff(
+            checkpoint: pallet_manta_pay::RawCheckpoint,
+            max_receiver: u64,
+            max_sender: u64
+        ) -> pallet_manta_pay::DensePullResponse {
+            MantaPay::dense_pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
+        }
     }
 
     impl nimbus_primitives::NimbusApi<Block> for Runtime {


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

## Description

With [base64](https://en.wikipedia.org/wiki/Base64), the size of response can be reduced 30% around.

- [ ] ~~CI should support `dense_pull_ledger_diff`~~(will support in PR #919)
- [ ] About the performance, which should be equal to `pull_ledger_diff`, or not worse too much.
  - [ ] pulling time
  - [ ] the performance on `base64.encode`
  - [ ] client decoding time

relates to OR closes: #XXXX

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
