### PR TITLE
Update nimbus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#e55102cfedce5af8cf040ecbe4c47b480a837031"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#e55102cfedce5af8cf040ecbe4c47b480a837031"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#e55102cfedce5af8cf040ecbe4c47b480a837031"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6090,7 +6090,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v3.4.3#e55102cfedce5af8cf040ecbe4c47b480a837031"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#364ce7ae41f36723320c4858a39d98528d2aee0e"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#364ce7ae41f36723320c4858a39d98528d2aee0e"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura-style-filter"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#364ce7ae41f36723320c4858a39d98528d2aee0e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6090,7 +6090,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#77359a76f643fc915e8c902ce7b9ee02dc1cb7e5"
+source = "git+https://github.com/manta-network/nimbus.git?tag=v4.0.0#364ce7ae41f36723320c4858a39d98528d2aee0e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -87,9 +87,9 @@ cumulus-relay-chain-interface = { git = 'https://github.com/paritytech/cumulus.g
 cumulus-relay-chain-rpc-interface = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.26" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3" }
+nimbus-consensus = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0" }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0" }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0" }
 
 # Polkadot dependencies
 polkadot-cli = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.26" }

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -40,7 +40,6 @@ where
 /// Extend RuntimeApi trait bound for Nimbus
 pub trait RuntimeApiNimbus:
     cumulus_primitives_core::CollectCollationInfo<Block>
-    + nimbus_primitives::AuthorFilterAPI<Block, NimbusId>
     + nimbus_primitives::NimbusApi<Block>
 {
 }
@@ -61,7 +60,6 @@ where
 
 impl<Api> RuntimeApiNimbus for Api where
     Api: cumulus_primitives_core::CollectCollationInfo<Block>
-        + nimbus_primitives::AuthorFilterAPI<Block, NimbusId>
         + nimbus_primitives::NimbusApi<Block>
 {
 }

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -17,7 +17,6 @@
 //! RuntimeApi for client
 
 use manta_primitives::types::{AccountId, Balance, Block, Index as Nonce};
-use session_key_primitives::NimbusId;
 use sp_runtime::traits::BlakeTwo256;
 
 /// RuntimeApiCommon + RuntimeApiNimbus: nimbus

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -39,8 +39,7 @@ where
 
 /// Extend RuntimeApi trait bound for Nimbus
 pub trait RuntimeApiNimbus:
-    cumulus_primitives_core::CollectCollationInfo<Block>
-    + nimbus_primitives::NimbusApi<Block>
+    cumulus_primitives_core::CollectCollationInfo<Block> + nimbus_primitives::NimbusApi<Block>
 {
 }
 
@@ -59,7 +58,6 @@ where
 }
 
 impl<Api> RuntimeApiNimbus for Api where
-    Api: cumulus_primitives_core::CollectCollationInfo<Block>
-        + nimbus_primitives::NimbusApi<Block>
+    Api: cumulus_primitives_core::CollectCollationInfo<Block> + nimbus_primitives::NimbusApi<Block>
 {
 }

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.140", default-features = false }
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26", optional = true }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
 pallet-authorship = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }
 sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.26" }

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -8,7 +8,7 @@ version = '4.0.0-alpha.1'
 
 [dependencies]
 manta-primitives = { path = "../manta", default-features = false }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26", default-features = false }

--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -71,9 +71,9 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1082,13 +1082,6 @@ impl_runtime_apis! {
         }
     }
 
-    // We also implement the old AuthorFilterAPI to meet the trait bounds on the client side.
-    impl nimbus_primitives::AuthorFilterAPI<Block, NimbusId> for Runtime {
-        fn can_author(_: NimbusId, _: u32, _: &<Block as BlockT>::Header) -> bool {
-            panic!("AuthorFilterAPI is no longer supported. Please update your client.")
-        }
-    }
-
     #[cfg(feature = "try-runtime")]
     impl frame_try_runtime::TryRuntime<Block> for Runtime {
         fn on_runtime_upgrade() -> (Weight, Weight) {

--- a/runtime/dolphin/Cargo.toml
+++ b/runtime/dolphin/Cargo.toml
@@ -71,9 +71,9 @@ cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus.git'
 parachain-info = { git = 'https://github.com/paritytech/cumulus.git', default-features = false, branch = "polkadot-v0.9.26" }
 
 # Nimbus Dependencies
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
-pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
-pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v3.4.3", default-features = false }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
+pallet-aura-style-filter = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
+pallet-author-inherent = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.0", default-features = false }
 
 # Polkadot dependencies
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.26" }

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -970,13 +970,6 @@ impl_runtime_apis! {
         }
     }
 
-    // We also implement the old AuthorFilterAPI to meet the trait bounds on the client side.
-    impl nimbus_primitives::AuthorFilterAPI<Block, NimbusId> for Runtime {
-        fn can_author(_: NimbusId, _: u32, _: &<Block as BlockT>::Header) -> bool {
-            panic!("AuthorFilterAPI is no longer supported. Please update your client.")
-        }
-    }
-
     #[cfg(feature = "try-runtime")]
     impl frame_try_runtime::TryRuntime<Block> for Runtime {
         fn on_runtime_upgrade() -> (Weight, Weight) {


### PR DESCRIPTION
## Description
This change removes `AuthorFilterAPI` runtime API as a result of 
https://github.com/PureStake/nimbus/commit/17ba75f10fad24e49dd86a53fb2e1b69cc331be2

Our client was already not using this API so there should be no impact.

There are no further functional changes to the previous `v3.4.3` tag (run `git diff v3.4.3..v4.0.0` to verify)

It also changes us to a simplified branch structure on nimbus.
- upstreamable: branched off from main. Contains changes we can eventually upstream
- manta: branched off from upstreamable. Manta-specific changes that we likely won't upstream

the `v4.0.0` tag this PR uses and all future tags always point to the `manta` branch, which will get changes from main merged in periodically.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
