### PR TITLE
add zero balance check

### DIFF
--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -201,12 +201,6 @@ pub mod pallet {
         #[transactional]
         pub fn to_private(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
-            for source in post.sources.iter() {
-                ensure!(
-                    asset_value_decode(*source) > 0u128,
-                    Error::<T>::ZeroTransfer
-                );
-            }
             ensure!(
                 post.sources.len() == 1
                     && post.sender_posts.len() == 0
@@ -214,6 +208,12 @@ pub mod pallet {
                     && post.sinks.len() == 0,
                 Error::<T>::InvalidShape
             );
+            for source in post.sources.iter() {
+                ensure!(
+                    asset_value_decode(*source) > 0u128,
+                    Error::<T>::ZeroTransfer
+                );
+            }
             Self::post_transaction(None, vec![origin], vec![], post)
         }
 
@@ -224,16 +224,16 @@ pub mod pallet {
         #[transactional]
         pub fn to_public(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
-            for sink in post.sinks.iter() {
-                ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::ZeroTransfer);
-            }
             ensure!(
                 post.sources.len() == 0
                     && post.sender_posts.len() == 2
-                    && post.receiver_posts.len() == 0
+                    && post.receiver_posts.len() == 1
                     && post.sinks.len() == 1,
                 Error::<T>::InvalidShape
             );
+            for sink in post.sinks.iter() {
+                ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::ZeroTransfer);
+            }
             Self::post_transaction(None, vec![], vec![origin], post)
         }
 

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -203,9 +203,9 @@ pub mod pallet {
             let origin = ensure_signed(origin)?;
             ensure!(
                 post.sources.len() == 1
-                    && post.sender_posts.len() == 0
+                    && post.sender_posts.is_empty()
                     && post.receiver_posts.len() == 1
-                    && post.sinks.len() == 0,
+                    && post.sinks.is_empty(),
                 Error::<T>::InvalidShape
             );
             for source in post.sources.iter() {
@@ -225,7 +225,7 @@ pub mod pallet {
         pub fn to_public(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
             ensure!(
-                post.sources.len() == 0
+                post.sources.is_empty()
                     && post.sender_posts.len() == 2
                     && post.receiver_posts.len() == 1
                     && post.sinks.len() == 1,
@@ -252,10 +252,10 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
             ensure!(
-                post.sources.len() == 0
+                post.sources.is_empty()
                     && post.sender_posts.len() == 2
                     && post.receiver_posts.len() == 2
-                    && post.sinks.len() == 0,
+                    && post.sinks.is_empty(),
                 Error::<T>::InvalidShape
             );
             Self::post_transaction(Some(origin), vec![], vec![], post)

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -202,8 +202,18 @@ pub mod pallet {
         pub fn to_private(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
             for source in post.sources.iter() {
-                ensure!(asset_value_decode(*source) > 0u128, Error::<T>::ZeroTransfer);
+                ensure!(
+                    asset_value_decode(*source) > 0u128,
+                    Error::<T>::ZeroTransfer
+                );
             }
+            ensure!(
+                post.sources.len() == 1
+                    && post.sender_posts.len() == 0
+                    && post.receiver_posts.len() == 1
+                    && post.sinks.len() == 0,
+                Error::<T>::InvalidShape
+            );
             Self::post_transaction(None, vec![origin], vec![], post)
         }
 
@@ -217,6 +227,13 @@ pub mod pallet {
             for sink in post.sinks.iter() {
                 ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::ZeroTransfer);
             }
+            ensure!(
+                post.sources.len() == 0
+                    && post.sender_posts.len() == 2
+                    && post.receiver_posts.len() == 0
+                    && post.sinks.len() == 1,
+                Error::<T>::InvalidShape
+            );
             Self::post_transaction(None, vec![], vec![origin], post)
         }
 
@@ -234,6 +251,13 @@ pub mod pallet {
             post: TransferPost,
         ) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
+            ensure!(
+                post.sources.len() == 0
+                    && post.sender_posts.len() == 2
+                    && post.receiver_posts.len() == 2
+                    && post.sinks.len() == 0,
+                Error::<T>::InvalidShape
+            );
             Self::post_transaction(Some(origin), vec![], vec![], post)
         }
 

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -202,7 +202,7 @@ pub mod pallet {
         pub fn to_private(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
             for source in post.sources.iter() {
-                ensure!(asset_value_decode(*source) > 0u128, Error::<T>::BalanceLow);
+                ensure!(asset_value_decode(*source) > 0u128, Error::<T>::ZeroTransfer);
             }
             Self::post_transaction(None, vec![origin], vec![], post)
         }
@@ -215,7 +215,7 @@ pub mod pallet {
         pub fn to_public(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
             for sink in post.sinks.iter() {
-                ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::BalanceLow);
+                ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::ZeroTransfer);
             }
             Self::post_transaction(None, vec![], vec![origin], post)
         }
@@ -315,7 +315,7 @@ pub mod pallet {
 
         /// Zero Transfer
         ///
-        /// Public transfers cannot include amounts equal to zero.
+        /// Transfers cannot include amounts equal to zero.
         ZeroTransfer,
 
         /// Balance Low

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -201,6 +201,9 @@ pub mod pallet {
         #[transactional]
         pub fn to_private(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
+            for source in post.sources.iter() {
+                ensure!(asset_value_decode(*source) > 0u128, Error::<T>::BalanceLow);
+            }
             Self::post_transaction(None, vec![origin], vec![], post)
         }
 
@@ -211,6 +214,9 @@ pub mod pallet {
         #[transactional]
         pub fn to_public(origin: OriginFor<T>, post: TransferPost) -> DispatchResultWithPostInfo {
             let origin = ensure_signed(origin)?;
+            for sink in post.sinks.iter() {
+                ensure!(asset_value_decode(*sink) > 0u128, Error::<T>::BalanceLow);
+            }
             Self::post_transaction(None, vec![], vec![origin], post)
         }
 


### PR DESCRIPTION
Signed-off-by: zqhxuyuan <zqhxuyuan@gmail.com>

## Description

relates to OR closes: #947

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] This PR is targeted against the *current*  Milestone ( otherwise discuss if it can be added in time)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
- If runtime changes, need to update the version numbers properly:
   * `authoring_version`: The version of the authorship interface. An authoring node will not attempt to author blocks unless this is equal to its native runtime.
   * `spec_version`: The version of the runtime specification. A full node will not attempt to use its native runtime in substitute for the on-chain Wasm runtime unless all of spec_name, spec_version, and authoring_version are the same between Wasm and native.
   * `impl_version`: The version of the implementation of the specification. Nodes are free to ignore this; it serves only as an indication that the code is different; as long as the other two versions are the same then while the actual code may be different, it is nonetheless required to do the same thing. Non-consensus-breaking optimizations are about the only changes that could be made which would result in only the impl_version changing.
   * `transaction_version`: The version of the extrinsics interface. This number must be updated in the following circumstances: extrinsic parameters (number, order, or types) have been changed; extrinsics or pallets have been removed; or the pallet order in the construct_runtime! macro or extrinsic order in a pallet has been changed. You can run the `metadata_diff.yml` workflow for help. If this number is updated, then the `spec_version` must also be updated
- Verify benchmarks & weights have been updated for any modified runtime logics
