### PR TITLE
Bump storage trie version for manta RT

### DIFF
--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -126,7 +126,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
-    state_version: 0,
+    state_version: 1,
 };
 
 /// The version information used to identify this runtime when compiled natively.


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description

Simplest PR in the history of history. Relates to #385 

Applies only to manta, not to calamari as that would need a migration.

The only question is whether we do any low-level shenanigans in pallet-manta-pay that would break from a change in trie layout to the point where we can't roll out mantapay on this chain later because of the difference. I found us only using storage API so I think we're good.

Tested the new RT for block production and looks fine.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
