### PR TITLE
Minor CI: genesis job fixed

### DIFF
--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -26,10 +26,10 @@ jobs:
           ls -ahl .
       - name: Export genesis files
         run: |
-          manta build-spec --chain $CHAIN --raw > $CHAIN-genesis.json
-          manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
-          manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
-          sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee $CHAIN-genesis.sha256
+          ./manta build-spec --chain $CHAIN --raw > ${{CHAIN}}-genesis.json
+          ./manta export-genesis-state --chain $CHAIN > ${{CHAIN}}-genesis.state
+          ./manta export-genesis-wasm --chain $CHAIN > ${{CHAIN}}-genesis.wasm
+          sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee ${{CHAIN}}-genesis.sha256
       # upload artifacts
       - name: upload genesis
         uses: actions/upload-artifact@v2

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -21,37 +21,37 @@ jobs:
           sudo apt install -y curl
       - name: fetch and chmod manta release
         run: |
-          curl -L -o ./manta https://github.com/Manta-Network/Manta/releases/download/$VERSION/manta
-          chmod +x ./manta
+          curl -L -o manta https://github.com/Manta-Network/Manta/releases/download/$VERSION/manta
+          chmod +x manta
           ls -ahl .
       - name: Export genesis files
         run: |
-          ./manta build-spec --chain $CHAIN --raw > ./$CHAIN-genesis.json
-          ./manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
-          ./manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
+          manta build-spec --chain $CHAIN --raw > $CHAIN-genesis.json
+          manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
+          manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
           sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee $CHAIN-genesis.sha256
       # upload artifacts
       - name: upload genesis
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.json
-          path: ./$CHAIN-genesis.json
+          path: $CHAIN-genesis.json
       - name: upload state
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.state
-          path: ./$CHAIN-genesis.state
+          path: $CHAIN-genesis.state
       - name: upload wasm
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.wasm
-          path: ./$CHAIN-genesis.wasm
+          path: $CHAIN-genesis.wasm
       # download artifacts and compare sha checksums
       - name: remove files
         run: |
-          rm ./$CHAIN-genesis.json
-          rm ./$CHAIN-genesis.state
-          rm ./$CHAIN-genesis.wasm
+          rm $CHAIN-genesis.json
+          rm $CHAIN-genesis.state
+          rm $CHAIN-genesis.wasm
       - name: download json
         uses: actions/download-artifact@v3
         with:
@@ -66,4 +66,4 @@ jobs:
           name: $CHAIN-genesis.wasm
       - name: compare sha checksums
         run: |
-          sha256sum --check --strict ./$CHAIN-genesis.sha256
+          sha256sum --check --strict $CHAIN-genesis.sha256

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - name: get curl
         run: |
-          apt update
-          apt install -y curl
+          sudo apt update
+          sudo apt install -y curl
       - name: fetch and chmod manta release
         run: |
           curl -L -o $HOME/manta https://github.com/Manta-Network/Manta/releases/download/$VERSION/manta

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -21,37 +21,37 @@ jobs:
           sudo apt install -y curl
       - name: fetch and chmod manta release
         run: |
-          curl -L -o $HOME/manta https://github.com/Manta-Network/Manta/releases/download/$VERSION/manta
-          chmod +x $HOME/manta
-          ls -ahl $HOME
+          curl -L -o ./manta https://github.com/Manta-Network/Manta/releases/download/$VERSION/manta
+          chmod +x ./manta
+          ls -ahl .
       - name: Export genesis files
         run: |
-          $HOME/manta build-spec --chain $CHAIN --raw > ./$CHAIN-genesis.json
-          $HOME/manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
-          $HOME/manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
+          ./manta build-spec --chain $CHAIN --raw > ./$CHAIN-genesis.json
+          ./manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
+          ./manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
           sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee $CHAIN-genesis.sha256
       # upload artifacts
       - name: upload genesis
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.json
-          path: $HOME/$CHAIN-genesis.json
+          path: ./$CHAIN-genesis.json
       - name: upload state
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.state
-          path: $HOME/$CHAIN-genesis.state
+          path: ./$CHAIN-genesis.state
       - name: upload wasm
         uses: actions/upload-artifact@v2
         with:
           name: $CHAIN-genesis.wasm
-          path: $HOME/$CHAIN-genesis.wasm
+          path: ./$CHAIN-genesis.wasm
       # download artifacts and compare sha checksums
       - name: remove files
         run: |
-          rm $HOME/$CHAIN-genesis.json
-          rm $HOME/$CHAIN-genesis.state
-          rm $HOME/$CHAIN-genesis.wasm
+          rm ./$CHAIN-genesis.json
+          rm ./$CHAIN-genesis.state
+          rm ./$CHAIN-genesis.wasm
       - name: download json
         uses: actions/download-artifact@v3
         with:
@@ -66,4 +66,4 @@ jobs:
           name: $CHAIN-genesis.wasm
       - name: compare sha checksums
         run: |
-          sha256sum --check --strict $HOME/$CHAIN-genesis.sha256
+          sha256sum --check --strict ./$CHAIN-genesis.sha256

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -34,18 +34,18 @@ jobs:
       - name: upload genesis
         uses: actions/upload-artifact@v2
         with:
-          name: $CHAIN-genesis.json
-          path: $CHAIN-genesis.json
+          name: ${{env.CHAIN}}-genesis.json
+          path: ${{env.CHAIN}}-genesis.json
       - name: upload state
         uses: actions/upload-artifact@v2
         with:
-          name: $CHAIN-genesis.state
-          path: $CHAIN-genesis.state
+          name: ${{env.CHAIN}}-genesis.state
+          path: ${{env.CHAIN}}-genesis.state
       - name: upload wasm
         uses: actions/upload-artifact@v2
         with:
-          name: $CHAIN-genesis.wasm
-          path: $CHAIN-genesis.wasm
+          name: ${{env.CHAIN}}-genesis.wasm
+          path: ${{env.CHAIN}}-genesis.wasm
       # download artifacts and compare sha checksums
       - name: remove files
         run: |

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -26,10 +26,10 @@ jobs:
           ls -ahl .
       - name: Export genesis files
         run: |
-          ./manta build-spec --chain $CHAIN --raw > ${{CHAIN}}-genesis.json
-          ./manta export-genesis-state --chain $CHAIN > ${{CHAIN}}-genesis.state
-          ./manta export-genesis-wasm --chain $CHAIN > ${{CHAIN}}-genesis.wasm
-          sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee ${{CHAIN}}-genesis.sha256
+          ./manta build-spec --chain $CHAIN --raw > $CHAIN-genesis.json
+          ./manta export-genesis-state --chain $CHAIN > $CHAIN-genesis.state
+          ./manta export-genesis-wasm --chain $CHAIN > $CHAIN-genesis.wasm
+          sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee $CHAIN-genesis.sha256
       # upload artifacts
       - name: upload genesis
         uses: actions/upload-artifact@v2

--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -55,15 +55,15 @@ jobs:
       - name: download json
         uses: actions/download-artifact@v3
         with:
-          name: $CHAIN-genesis.json
+          name: ${{env.CHAIN}}-genesis.json
       - name: download state
         uses: actions/download-artifact@v3
         with:
-          name: $CHAIN-genesis.state
+          name: ${{env.CHAIN}}-genesis.state
       - name: download wasm
         uses: actions/download-artifact@v3
         with:
-          name: $CHAIN-genesis.wasm
+          name: ${{env.CHAIN}}-genesis.wasm
       - name: compare sha checksums
         run: |
           sha256sum --check --strict $CHAIN-genesis.sha256


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description

Now that the job is showing up and can be tested it turned out syntax was wrong, fixed and tested. Generates files correctly.
---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
