### PR TITLE
Add self-bond filter condition when computing new set of collators

### DIFF
--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -76,7 +76,7 @@ jobs:
       - name: init
         run: |
           sudo apt update
-          sudo apt install -y pkg-config libssl-dev
+          sudo apt install -y pkg-config libssl-dev yarn
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
           rustup toolchain install stable

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -72,8 +72,8 @@ jobs:
         run: |
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install nightly-2023-03-13
+          rustup default nightly-2023-03-13
           cargo install taplo-cli
       - name: Check Formatting
         env:

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1688,7 +1688,14 @@ pub mod pallet {
                 .into_iter()
                 .rev()
                 .take(top_n)
-                .filter(|x| x.amount >= T::MinCollatorStk::get())
+                .filter(|x| {
+                    // Only consider collators above minimum total stake and self-bond
+                    x.amount >= T::MinCollatorStk::get()
+                        && Self::candidate_info(x.owner.clone())
+                            .expect("looping candidates. therefore canidateinfo exists. qed")
+                            .bond
+                            > T::MinCandidateStk::get()
+                })
                 .map(|x| x.owner)
                 .collect::<Vec<T::AccountId>>();
             collators.sort();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1690,7 +1690,7 @@ pub mod pallet {
                 .filter(|x| {
                     // Only consider collators above minimum total stake and self-bond
                     x.amount >= T::MinCollatorStk::get()
-                        && Self::is_candidate(x.owner.clone())
+                        && Self::is_candidate(&x.owner)
                         && Self::candidate_info(x.owner.clone())
                             .expect("is_candidate => canidateinfo exists. qed")
                             .bond

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1689,12 +1689,13 @@ pub mod pallet {
                 .rev()
                 .filter(|x| {
                     // Only consider collators above minimum total stake and self-bond
-                    x.amount >= T::MinCollatorStk::get()
-                        && Self::is_candidate(&x.owner)
-                        && Self::candidate_info(x.owner.clone())
-                            .expect("is_candidate => canidateinfo exists. qed")
-                            .bond
-                            >= T::MinCandidateStk::get()
+                    x.amount >= T::MinCollatorStk::get() &&
+                    if let Some(info) = Self::candidate_info(x.owner.clone()) {
+                        info.bond >= T::MinCandidateStk::get()
+                    } else {
+                        log::error!("Candidate did not have CandidateInfo in storage, this should not happen");
+                        false
+                    }
                 })
                 .take(top_n)
                 .map(|x| x.owner)

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1694,7 +1694,7 @@ pub mod pallet {
                         && Self::candidate_info(x.owner.clone())
                             .expect("looping candidates. therefore canidateinfo exists. qed")
                             .bond
-                            > T::MinCandidateStk::get()
+                            >= T::MinCandidateStk::get()
                 })
                 .map(|x| x.owner)
                 .collect::<Vec<T::AccountId>>();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1687,7 +1687,6 @@ pub mod pallet {
             let mut collators = candidates
                 .into_iter()
                 .rev()
-                .take(top_n)
                 .filter(|x| {
                     // Only consider collators above minimum total stake and self-bond
                     x.amount >= T::MinCollatorStk::get()
@@ -1696,6 +1695,7 @@ pub mod pallet {
                             .bond
                             >= T::MinCandidateStk::get()
                 })
+                .take(top_n)
                 .map(|x| x.owner)
                 .collect::<Vec<T::AccountId>>();
             collators.sort();

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1690,8 +1690,9 @@ pub mod pallet {
                 .filter(|x| {
                     // Only consider collators above minimum total stake and self-bond
                     x.amount >= T::MinCollatorStk::get()
+                        && Self::is_candidate(x.owner.clone())
                         && Self::candidate_info(x.owner.clone())
-                            .expect("looping candidates. therefore canidateinfo exists. qed")
+                            .expect("is_candidate => canidateinfo exists. qed")
                             .bond
                             >= T::MinCandidateStk::get()
                 })

--- a/runtime/calamari/tests/integrations_mock/integration_tests.rs
+++ b/runtime/calamari/tests/integrations_mock/integration_tests.rs
@@ -660,7 +660,7 @@ fn collator_with_large_stake_but_too_low_self_bond_not_selected_for_block_produc
                 ));
             }
 
-            // Ensure ALICE is not selected despite having a large stake although it has a large total stake
+            // Ensure ALICE is not selected despite having a large total stake through delegation
             // NOTE: Must use 6 or more collators because 5 is the minimum on calamari
             assert!(!ParachainStaking::compute_top_candidates().contains(&ALICE));
             assert!(ParachainStaking::compute_top_candidates().contains(&BOB));

--- a/runtime/calamari/tests/integrations_mock/integration_tests.rs
+++ b/runtime/calamari/tests/integrations_mock/integration_tests.rs
@@ -650,7 +650,7 @@ fn collator_with_large_stake_but_too_low_self_bond_not_selected_for_block_produc
             }
 
             // Delegate a large amount of tokens
-            for collator in vec![EVE.clone(), USER.clone()] {
+            for collator in vec![EVE.clone(), FERDIE.clone()] {
                 assert_ok!(ParachainStaking::delegate(
                     Origin::signed(USER.clone()),
                     collator,

--- a/runtime/calamari/tests/integrations_mock/integration_tests.rs
+++ b/runtime/calamari/tests/integrations_mock/integration_tests.rs
@@ -608,13 +608,13 @@ fn collator_cant_join_below_standard_bond() {
 fn collator_with_large_stake_but_too_low_self_bond_not_selected_for_block_production() {
     ExtBuilder::default()
         .with_balances(vec![
-            (ALICE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
+            (ALICE.clone(), EARLY_COLLATOR_MINIMUM_STAKE + 100),
             (BOB.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (CHARLIE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (DAVE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (EVE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
-            (FERDIE.clone(), EARLY_COLLATOR_MINIMUM_STAKE + 100),
-            (USER.clone(), 40_000_000 * KMA),
+            (FERDIE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
+            (USER.clone(), 400_000_000 * KMA),
         ])
         .with_invulnerables(vec![])
         .with_authorities(vec![
@@ -635,13 +635,13 @@ fn collator_with_large_stake_but_too_low_self_bond_not_selected_for_block_produc
                 EVE.clone(),
                 FERDIE.clone(),
             ]);
-            // Increase bond for everyone but FERDIE
+            // Increase self-bond for everyone but ALICE
             for collator in vec![
-                ALICE.clone(),
                 BOB.clone(),
                 CHARLIE.clone(),
                 DAVE.clone(),
                 EVE.clone(),
+                FERDIE.clone(),
             ] {
                 assert_ok!(ParachainStaking::candidate_bond_more(
                     Origin::signed(collator.clone()),
@@ -649,25 +649,25 @@ fn collator_with_large_stake_but_too_low_self_bond_not_selected_for_block_produc
                 ));
             }
 
-            // Delegate a large amount of tokens
-            for collator in vec![EVE.clone(), FERDIE.clone()] {
+            // Delegate a large amount of tokens to EVE and ALICE
+            for collator in vec![EVE.clone(), ALICE.clone()] {
                 assert_ok!(ParachainStaking::delegate(
                     Origin::signed(USER.clone()),
                     collator,
-                    10_000_000 * KMA,
+                    100_000_000 * KMA,
                     50,
                     50
                 ));
             }
 
-            // Ensure FERDIE is not selected despite having a large stake
+            // Ensure ALICE is not selected despite having a large stake although it has a large total stake
             // NOTE: Must use 6 or more collators because 5 is the minimum on calamari
-            assert!(ParachainStaking::compute_top_candidates().contains(&ALICE));
+            assert!(!ParachainStaking::compute_top_candidates().contains(&ALICE));
             assert!(ParachainStaking::compute_top_candidates().contains(&BOB));
             assert!(ParachainStaking::compute_top_candidates().contains(&CHARLIE));
             assert!(ParachainStaking::compute_top_candidates().contains(&DAVE));
             assert!(ParachainStaking::compute_top_candidates().contains(&EVE));
-            assert!(!ParachainStaking::compute_top_candidates().contains(&FERDIE));
+            assert!(ParachainStaking::compute_top_candidates().contains(&FERDIE));
         });
 }
 
@@ -713,12 +713,12 @@ fn collator_can_leave_if_below_standard_bond() {
 fn collator_with_400k_not_selected_for_block_production() {
     ExtBuilder::default()
         .with_balances(vec![
-            (ALICE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
+            (ALICE.clone(), EARLY_COLLATOR_MINIMUM_STAKE + 100),
             (BOB.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (CHARLIE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (DAVE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
             (EVE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
-            (FERDIE.clone(), EARLY_COLLATOR_MINIMUM_STAKE + 100),
+            (FERDIE.clone(), MIN_BOND_TO_BE_CONSIDERED_COLLATOR + 100),
         ])
         .with_invulnerables(vec![])
         .with_authorities(vec![
@@ -741,11 +741,11 @@ fn collator_with_400k_not_selected_for_block_production() {
             ]);
             // Increase bond for everyone but FERDIE
             for collator in vec![
-                ALICE.clone(),
                 BOB.clone(),
                 CHARLIE.clone(),
                 DAVE.clone(),
                 EVE.clone(),
+                FERDIE.clone(),
             ] {
                 assert_ok!(ParachainStaking::candidate_bond_more(
                     Origin::signed(collator.clone()),
@@ -755,12 +755,12 @@ fn collator_with_400k_not_selected_for_block_production() {
 
             // Ensure CHARLIE and later are not selected
             // NOTE: Must use 6 or more collators because 5 is the minimum on calamari
-            assert!(ParachainStaking::compute_top_candidates().contains(&ALICE));
+            assert!(!ParachainStaking::compute_top_candidates().contains(&ALICE));
             assert!(ParachainStaking::compute_top_candidates().contains(&BOB));
             assert!(ParachainStaking::compute_top_candidates().contains(&CHARLIE));
             assert!(ParachainStaking::compute_top_candidates().contains(&DAVE));
             assert!(ParachainStaking::compute_top_candidates().contains(&EVE));
-            assert!(!ParachainStaking::compute_top_candidates().contains(&FERDIE));
+            assert!(ParachainStaking::compute_top_candidates().contains(&FERDIE));
         });
 }
 

--- a/runtime/calamari/tests/integrations_mock/mod.rs
+++ b/runtime/calamari/tests/integrations_mock/mod.rs
@@ -97,5 +97,8 @@ pub fn initialize_collators_through_whitelist(collators: Vec<AccountId>) {
         ParachainStaking::candidate_pool().len(),
         candidate_count as usize
     );
-    assert_ok!(ParachainStaking::set_total_selected(root_origin(), candidate_count));
+    assert_ok!(ParachainStaking::set_total_selected(
+        root_origin(),
+        candidate_count
+    ));
 }

--- a/runtime/calamari/tests/integrations_mock/mod.rs
+++ b/runtime/calamari/tests/integrations_mock/mod.rs
@@ -97,4 +97,5 @@ pub fn initialize_collators_through_whitelist(collators: Vec<AccountId>) {
         ParachainStaking::candidate_pool().len(),
         candidate_count as usize
     );
+    assert_ok!(ParachainStaking::set_total_selected(root_origin(), candidate_count));
 }

--- a/runtime/calamari/tests/integrations_mock/mod.rs
+++ b/runtime/calamari/tests/integrations_mock/mod.rs
@@ -44,6 +44,7 @@ lazy_static! {
     pub(crate) static ref DAVE: AccountId = unchecked_account_id::<Public>("Dave");
     pub(crate) static ref EVE: AccountId = unchecked_account_id::<Public>("Eve");
     pub(crate) static ref FERDIE: AccountId = unchecked_account_id::<Public>("Ferdie");
+    pub(crate) static ref USER: AccountId = unchecked_account_id::<Public>("User");
     pub(crate) static ref ALICE_SESSION_KEYS: SessionKeys =
         SessionKeys::from_seed_unchecked("Alice");
     pub(crate) static ref BOB_SESSION_KEYS: SessionKeys = SessionKeys::from_seed_unchecked("Bob");


### PR DESCRIPTION
## Description

This will result in collators on calamari below 4M self-bond no longer being eligible to produce blocks.

- Previously, tests were not handling the 6th collator correctly, causing the fact that it wasn't offboarded in the old PR to be missed.
- A take-N-before-filter sequence bug in `parachain-staking` led to fewer-than-expected collators being selected
- Added regression test for correct offboarding

Followup to #937

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
