### PR TITLE
Archive nodes as bootnodes to Manta genesis

### DIFF
--- a/genesis/manta-genesis.json
+++ b/genesis/manta-genesis.json
@@ -3,6 +3,9 @@
   "id": "manta",
   "chainType": "Live",
   "bootNodes": [
+    "/dns/a1.manta.systems/tcp/30333/p2p/12D3KooWCpnkG834s9ETesFTWtGqRDjs6Te1UCXHib3iD8GEmXLU",
+    "/dns/a2.manta.systems/tcp/30333/p2p/12D3KooWDwTeTxyyp8tVzrnHQk7jo3hLWs7ukZEC642cduKgp2Fd",
+    "/dns/a3.manta.systems/tcp/30333/p2p/12D3KooWAjiBUsKPJesAHoZHbLQqjN8bA6QTtjJjkwwZPenHjbMR",
     "/dns/c1.manta.systems/tcp/30333/p2p/12D3KooWSNwD7tJkqKGdMfCVTJbbzrGFTGbXoeMFZCTwEytpFCM4",
     "/dns/c2.manta.systems/tcp/30333/p2p/12D3KooWSyPTkVytQwurRBt73wPQDTgypw88bdhsE4Rb6RnQvCJ9",
     "/dns/c3.manta.systems/tcp/30333/p2p/12D3KooWJwHqCEjTF46eAUDspKKwxa15TMfs7x8DNr3Gs71Qr64j",


### PR DESCRIPTION
## Description

As requested by DevOps

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
