### PR TITLE
Fix: `update_asset_metadata` updates `min_balance` and `is_sufficient`

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -463,6 +463,8 @@ pub mod pallet {
             <T::AssetConfig as AssetConfig<T>>::AssetRegistry::update_asset_metadata(
                 &asset_id,
                 metadata.clone().into(),
+                metadata.min_balance().to_owned(),
+                metadata.is_sufficient()
             )?;
             AssetIdMetadata::<T>::insert(asset_id, &metadata);
             Self::deposit_event(Event::<T>::AssetMetadataUpdated { asset_id, metadata });

--- a/primitives/manta/src/assets.rs
+++ b/primitives/manta/src/assets.rs
@@ -108,9 +108,20 @@ pub trait AssetRegistry: AssetIdType + BalanceType {
     ///
     /// * `asset_id`: the asset id to be created.
     /// * `metadata`: the metadata that the implementation layer stores.
+    /// * `min_balance`: the minimum balance to hold this asset
+    /// * `is_sufficient`: whether this asset can be used as reserve asset,
+    ///     to the first approximation. More specifically, Whether a non-zero balance of this asset
+    ///     is deposit of sufficient value to account for the state bloat associated with its
+    ///     balance storage. If set to `true`, then non-zero balances may be stored without a
+    ///     `consumer` reference (and thus an ED in the Balances pallet or whatever else is used to
+    ///     control user-account state growth).
+    /// WARNING: Exercise extreme caution when changing `min_balance` or `is_sufficient`,
+    ///     ** these can put user's accounts into an invalid existing-but-below-ED state **
     fn update_asset_metadata(
         asset_id: &Self::AssetId,
         metadata: Self::Metadata,
+        min_balance: Self::Balance,
+        is_sufficient: bool,
     ) -> Result<(), Self::Error>;
 }
 

--- a/runtime/calamari/src/assets_config.rs
+++ b/runtime/calamari/src/assets_config.rs
@@ -105,6 +105,8 @@ impl AssetRegistry for CalamariAssetRegistry {
     fn update_asset_metadata(
         asset_id: &CalamariAssetId,
         metadata: AssetStorageMetadata,
+        min_balance: Self::Balance,
+        is_sufficient: bool,
     ) -> DispatchResult {
         Assets::force_set_metadata(
             Origin::root(),
@@ -112,6 +114,17 @@ impl AssetRegistry for CalamariAssetRegistry {
             metadata.name,
             metadata.symbol,
             metadata.decimals,
+            metadata.is_frozen,
+        )?;
+        Assets::force_asset_status(
+            Origin::root(),
+            *asset_id,
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            min_balance,
+            is_sufficient,
             metadata.is_frozen,
         )
     }

--- a/runtime/dolphin/src/assets_config.rs
+++ b/runtime/dolphin/src/assets_config.rs
@@ -108,6 +108,8 @@ impl AssetRegistry for MantaAssetRegistry {
     fn update_asset_metadata(
         asset_id: &DolphinAssetId,
         metadata: AssetStorageMetadata,
+        min_balance: Self::Balance,
+        is_sufficient: bool,
     ) -> DispatchResult {
         Assets::force_set_metadata(
             Origin::root(),
@@ -115,6 +117,17 @@ impl AssetRegistry for MantaAssetRegistry {
             metadata.name,
             metadata.symbol,
             metadata.decimals,
+            metadata.is_frozen,
+        )?;
+        Assets::force_asset_status(
+            Origin::root(),
+            *asset_id,
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            sp_runtime::MultiAddress::Id(AssetManager::account_id()),
+            min_balance,
+            is_sufficient,
             metadata.is_frozen,
         )
     }


### PR DESCRIPTION
It was unintuitive that `AssetManager::update_asset_metadata` took  `min_balance` and `is_sufficient` as parameters, but did not actually update them.

Also added a warning that this is very unsafe to do.
See also https://github.com/paritytech/substrate/pull/13486

This is alternative 1

## Description

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
