### PR TITLE
Check for supported multilocation type when creating/updating assets

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -619,6 +619,7 @@ pub mod pallet {
             }
         }
 
+        /// defines what types of locations can be registered as assets
         fn is_allowed_location_shape(location: &MultiLocation) -> bool {
             // check parents
             if location.parents != 1 {

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -261,6 +261,9 @@ pub mod pallet {
         /// Location Already Exists
         LocationAlreadyExists,
 
+        /// MultiLocation Type Not Supported
+        LocationNotSupported,
+
         /// An error occured while creating a new asset at the [`AssetRegistry`].
         ErrorCreatingAsset,
 
@@ -348,6 +351,7 @@ pub mod pallet {
                 !LocationAssetId::<T>::contains_key(&location),
                 Error::<T>::LocationAlreadyExists
             );
+            ensure!(Self::contains(&location), Error::<T>::LocationNotSupported);
             let asset_id = Self::next_asset_id_and_increment()?;
             <T::AssetConfig as AssetConfig<T>>::AssetRegistry::create_asset(
                 asset_id,
@@ -399,6 +403,7 @@ pub mod pallet {
                 !LocationAssetId::<T>::contains_key(&location),
                 Error::<T>::LocationAlreadyExists
             );
+            ensure!(Self::contains(&location), Error::<T>::LocationNotSupported);
             // change the ledger state.
             let old_location =
                 AssetIdLocation::<T>::get(asset_id).ok_or(Error::<T>::UpdateNonExistentAsset)?;

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -627,13 +627,14 @@ pub mod pallet {
             }
 
             match location.interior {
+                // Local transfers
+                Junctions::Here => true,
                 // Send tokens back to relaychain.
                 Junctions::X1(Junction::AccountId32 { .. }) => true,
                 // Send tokens to sibling chain.
                 Junctions::X2(Junction::Parachain(para_id), Junction::AccountId32 { .. })
-                | Junctions::X2(Junction::Parachain(para_id), Junction::AccountKey20 { .. }) => {
-                    AllowedDestParaIds::<T>::contains_key(para_id)
-                }
+                | Junctions::X2(Junction::Parachain(para_id), Junction::PalletInstance { .. })
+                | Junctions::X2(Junction::Parachain(para_id), Junction::AccountKey20 { .. }) => true,
                 // We don't support X3 or longer Junctions.
                 _ => false,
             }

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -351,7 +351,9 @@ pub mod pallet {
                 !LocationAssetId::<T>::contains_key(&location),
                 Error::<T>::LocationAlreadyExists
             );
-            ensure!(Self::contains(&location), Error::<T>::LocationNotSupported);
+            if let Some(multi) = location.clone().into() {
+                ensure!(Self::contains(&multi), Error::<T>::LocationNotSupported);
+            }
             let asset_id = Self::next_asset_id_and_increment()?;
             <T::AssetConfig as AssetConfig<T>>::AssetRegistry::create_asset(
                 asset_id,
@@ -403,7 +405,9 @@ pub mod pallet {
                 !LocationAssetId::<T>::contains_key(&location),
                 Error::<T>::LocationAlreadyExists
             );
-            ensure!(Self::contains(&location), Error::<T>::LocationNotSupported);
+            if let Some(multi) = location.clone().into() {
+                ensure!(Self::contains(&multi), Error::<T>::LocationNotSupported);
+            }
             // change the ledger state.
             let old_location =
                 AssetIdLocation::<T>::get(asset_id).ok_or(Error::<T>::UpdateNonExistentAsset)?;

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -639,7 +639,7 @@ pub mod pallet {
         }
     }
 
-    /// impl used by xtokens to filter multilocations allowed to send to
+    /// impl used by xtokens as `MultiLocationsFilter`. Defines where we're allowed to send to
     impl<T> Contains<MultiLocation> for Pallet<T>
     where
         T: Config,

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -653,7 +653,7 @@ pub mod pallet {
                 return false;
             }
             // xtokens / XCM must not be used to send transfers local to our parachain
-            if location.parents != 1 {
+            if location.parents == 0 {
                 return false;
             }
             // if sending to sibling, only siblings whose assets we registered are allowed

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -630,11 +630,9 @@ pub mod pallet {
                 // Send tokens back to relaychain.
                 Junctions::X1(Junction::AccountId32 { .. }) => true,
                 // Send tokens to sibling chain.
-                Junctions::X2(Junction::Parachain(para_id), Junction::AccountId32 { .. })
-                | Junctions::X2(Junction::Parachain(para_id), Junction::PalletInstance { .. })
-                | Junctions::X2(Junction::Parachain(para_id), Junction::AccountKey20 { .. }) => {
-                    true
-                }
+                Junctions::X2(Junction::Parachain { .. }, Junction::AccountId32 { .. })
+                | Junctions::X2(Junction::Parachain { .. }, Junction::PalletInstance { .. })
+                | Junctions::X2(Junction::Parachain { .. }, Junction::AccountKey20 { .. }) => true,
                 // We don't support X3 or longer Junctions.
                 _ => false,
             }

--- a/runtime/calamari/src/xcm_config.rs
+++ b/runtime/calamari/src/xcm_config.rs
@@ -350,6 +350,7 @@ impl orml_xtokens::Config for Runtime {
     type LocationInverter = LocationInverter<Ancestry>;
     type MaxAssetsForTransfer = MaxAssetsForTransfer;
     type MinXcmFee = AssetManager;
+    /// filter multilocations our chain is allowed to send XCM to
     type MultiLocationsFilter = AssetManager;
     type ReserveProvider = AbsoluteReserveProvider;
 }


### PR DESCRIPTION
If an asset has a valid Multilocation, we only allow to register it if we're sure it can be sent via xtokens ( i.e. passes the `Contains` filter )

Signed-off-by: Adam Reif <Garandor@manta.network>## Description

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
