### PR TITLE
Enable manta runtime xcm tests

### DIFF
--- a/runtime/manta/tests/mod.rs
+++ b/runtime/manta/tests/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2020-2023 Manta Network.
+// This file is part of Manta.
+//
+// Manta is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Manta is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Manta.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+pub mod xcm_mock;

--- a/runtime/manta/tests/xcm_mock/xcm_tests.rs
+++ b/runtime/manta/tests/xcm_mock/xcm_tests.rs
@@ -34,7 +34,6 @@ use xcm_executor::traits::{Convert, WeightBounds};
 use xcm_simulator::TestExt;
 
 use super::{
-    super::*,
     parachain::{
         create_asset_location, create_asset_metadata, register_assets_on_parachain, AssetManager,
         ParaTokenPerSecond, XcmExecutorConfig as ParaXcmExecutorConfig, PALLET_ASSET_INDEX,


### PR DESCRIPTION
## Description

* Add manta runtime xcm-mock module to run xcm tests in CI

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
