### PR TITLE
Charge 0-asset XCM instructions as if they were 1-asset

### DIFF
--- a/runtime/calamari/src/weights/xcm/mod.rs
+++ b/runtime/calamari/src/weights/xcm/mod.rs
@@ -35,7 +35,8 @@ impl WeighMultiAssets for MultiAssetFilter {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
         match self {
             Self::Definite(assets) => {
-                (assets.inner().iter().count() as Weight).saturating_mul(weight)
+                // NOTE: We charge fees for at least 1 asset even if 0 were requested to punish spam
+                (assets.inner().iter().count().max(1) as Weight).saturating_mul(weight)
             }
             Self::Wild(_) => (MAX_ASSETS as Weight).saturating_mul(weight),
         }
@@ -44,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
-        (self.inner().iter().count() as Weight).saturating_mul(weight)
+        (self.inner().iter().count().max(1) as Weight).saturating_mul(weight)
     }
 }
 

--- a/runtime/dolphin/src/weights/xcm/mod.rs
+++ b/runtime/dolphin/src/weights/xcm/mod.rs
@@ -35,7 +35,8 @@ impl WeighMultiAssets for MultiAssetFilter {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
         match self {
             Self::Definite(assets) => {
-                (assets.inner().iter().count() as Weight).saturating_mul(weight)
+                // NOTE: We charge fees for at least 1 asset even if 0 were requested to punish spam
+                (assets.inner().iter().count().max(1) as Weight).saturating_mul(weight)
             }
             Self::Wild(_) => (MAX_ASSETS as Weight).saturating_mul(weight),
         }
@@ -44,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
-        (self.inner().iter().count() as Weight).saturating_mul(weight)
+        (self.inner().iter().count().max(1) as Weight).saturating_mul(weight)
     }
 }
 

--- a/runtime/manta/src/weights/xcm/mod.rs
+++ b/runtime/manta/src/weights/xcm/mod.rs
@@ -35,7 +35,8 @@ impl WeighMultiAssets for MultiAssetFilter {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
         match self {
             Self::Definite(assets) => {
-                (assets.inner().iter().count() as Weight).saturating_mul(weight)
+                // NOTE: We charge fees for at least 1 asset even if 0 were requested to punish spam
+                (assets.inner().iter().count().max(1) as Weight).saturating_mul(weight)
             }
             Self::Wild(_) => (MAX_ASSETS as Weight).saturating_mul(weight),
         }
@@ -44,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
     fn weigh_multi_assets(&self, weight: Weight) -> Weight {
-        (self.inner().iter().count() as Weight).saturating_mul(weight)
+        (self.inner().iter().count().max(1) as Weight).saturating_mul(weight)
     }
 }
 


### PR DESCRIPTION
Punish valid-but-pointless XCM instructions by charging a fee on our chain ( used to be 0 weight )

# Description

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
