### PR TITLE
Use safe-math in xcm `buy_weight` impl

### DIFF
--- a/primitives/manta/src/constants.rs
+++ b/primitives/manta/src/constants.rs
@@ -148,6 +148,7 @@ mod constants_tests {
         };
 
         assert_eq!(WEIGHT_PER_SECOND, IMPORTED_WEIGHT_PER_SECOND);
+        assert_ne!(WEIGHT_PER_SECOND, 0);
         assert_eq!(WEIGHT_PER_MILLIS, IMPORTED_WEIGHT_PER_MILLIS);
         assert_eq!(WEIGHT_PER_MICROS, IMPORTED_WEIGHT_PER_MICROS);
         assert_eq!(WEIGHT_PER_NANOS, IMPORTED_WEIGHT_PER_NANOS);

--- a/primitives/manta/src/xcm.rs
+++ b/primitives/manta/src/xcm.rs
@@ -180,9 +180,8 @@ where
                     XcmError::TooExpensive
                 })?;
 
-                let amount = (units_per_second.saturating_mul(weight as u128))
-                    .checked_div(WEIGHT_PER_SECOND as u128)
-                    .ok_or(XcmError::TooExpensive)?;
+                let amount =
+                    (units_per_second.saturating_mul(weight as u128)) / (WEIGHT_PER_SECOND as u128);
 
                 // we don't need to proceed if amount is zero.
                 // This is very useful in tests.
@@ -252,8 +251,8 @@ where
         if let Some((id, prev_amount, units_per_second)) = &mut self.refund_cache {
             let weight = weight.min(self.weight);
             self.weight = self.weight.saturating_sub(weight);
-            let amount = ((*units_per_second).saturating_mul(weight as u128))
-                .checked_div(WEIGHT_PER_SECOND as u128)?;
+            let amount =
+                ((*units_per_second).saturating_mul(weight as u128)) / (WEIGHT_PER_SECOND as u128);
             *prev_amount = prev_amount.saturating_sub(amount);
             Some(MultiAsset {
                 fun: Fungibility::Fungible(amount),

--- a/primitives/manta/src/xcm.rs
+++ b/primitives/manta/src/xcm.rs
@@ -180,7 +180,10 @@ where
                     XcmError::TooExpensive
                 })?;
 
-                let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+                let amount = (units_per_second.saturating_mul(weight as u128))
+                    .checked_div(WEIGHT_PER_SECOND as u128)
+                    .ok_or(XcmError::TooExpensive)?;
+
                 // we don't need to proceed if amount is zero.
                 // This is very useful in tests.
                 if amount.is_zero() {
@@ -248,8 +251,9 @@ where
     fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
         if let Some((id, prev_amount, units_per_second)) = &mut self.refund_cache {
             let weight = weight.min(self.weight);
-            self.weight -= weight;
-            let amount = *units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+            self.weight = self.weight.saturating_sub(weight);
+            let amount = ((*units_per_second).saturating_mul(weight as u128))
+                .checked_div(WEIGHT_PER_SECOND as u128)?;
             *prev_amount = prev_amount.saturating_sub(amount);
             Some(MultiAsset {
                 fun: Fungibility::Fungible(amount),


### PR DESCRIPTION
## Description

* This was not going to happen with current values but just in case for future additions we protect against accidental overflows.
* The division is impossible to underflow because the dividend will be saturated to the max value of u128. And u128::Max can be divided by the second smallest u128 number.
* A divide by zero is possible but we can assert that `WEIGHT_PER_SECOND` is never 0 with an integration test.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
