### PR TITLE
Fix calamari-localdev RPC

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -455,7 +455,7 @@ pub fn run_with(cli: Cli) -> Result {
                     } else if config.chain_spec.is_calamari() {
                         return crate::service::start_dev_nimbus_node::<calamari_runtime::RuntimeApi, _>(
                             config,
-                            rpc::create_common_full,
+                            rpc::create_calamari_full,
                         ).await
                             .map_err(Into::into);
                     } else {


### PR DESCRIPTION
## Description

fix calamari-localdev to have MantaPay and MantaSBT rpc calls

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari`, `A-dolphin` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
