### PR TITLE
feat: add ledger total count api

### DIFF
--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -607,7 +607,8 @@ pub mod pallet {
         pub fn pull_ledger_total_count() -> [u8; 16] {
             let receivers_total = (0..=255)
                 .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
-                .sum::<u128>() + 256u128;
+                .sum::<u128>()
+                + 256u128;
             let senders_total = NullifierSetSize::<T>::get() as u128;
             asset_value_encode(receivers_total + senders_total)
         }

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -599,6 +599,19 @@ pub mod pallet {
             )
         }
 
+        /// Returns ledger total count
+        /// In the initial state of the ledger, the total value will be 256;
+        /// if we want to get an accurate value, we need to request `pull_receivers` to fix this value;
+        /// but a simple total count interface does not need to add more complicated logic.
+        #[inline]
+        pub fn pull_ledger_total_count() -> [u8; 16] {
+            let receivers_total = (0..=255)
+                .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
+                .sum::<u128>() + 256u128;
+            let senders_total = NullifierSetSize::<T>::get() as u128;
+            asset_value_encode(receivers_total + senders_total)
+        }
+
         /// Returns the diff of ledger state since the given `checkpoint`, `max_receivers`, and
         /// `max_senders`.
         #[inline]
@@ -610,23 +623,12 @@ pub mod pallet {
             let (more_receivers, receivers) =
                 Self::pull_receivers(*checkpoint.receiver_index, max_receivers);
             let (more_senders, senders) = Self::pull_senders(checkpoint.sender_index, max_senders);
-            let mut senders_receivers_total = (0..=255)
-                .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
-                .sum::<u128>();
-            // Workaround for the fact that we index the receivers from 0
-            if senders_receivers_total == 0u128 {
-                // The cast is fine because the vector sizes are limited by PULL_MAX_RECEIVER_UPDATE_SIZE and PULL_MAX_SENDER_UPDATE_SIZE
-                senders_receivers_total = receivers.len() as u128;
-            } else {
-                senders_receivers_total += 256u128;
-            }
-            senders_receivers_total += NullifierSetSize::<T>::get() as u128;
 
             PullResponse {
                 should_continue: more_receivers || more_senders,
                 receivers,
                 senders,
-                senders_receivers_total: asset_value_encode(senders_receivers_total),
+                senders_receivers_total: Self::pull_ledger_total_count(),
             }
         }
 

--- a/pallets/manta-pay/src/rpc.rs
+++ b/pallets/manta-pay/src/rpc.rs
@@ -185,14 +185,13 @@ where
     fn pull_ledger_total_count(&self) -> RpcResult<[u8; 16]> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(self.client.info().finalized_hash);
-        api.pull_ledger_total_count(&at)
-            .map_err(|err| {
-                CallError::Custom(ErrorObject::owned(
-                    PULL_LEDGER_DIFF_ERROR,
-                    "Unable to compute total count for pull",
-                    Some(format!("{err:?}")),
-                ))
-                .into()
-            })
+        api.pull_ledger_total_count(&at).map_err(|err| {
+            CallError::Custom(ErrorObject::owned(
+                PULL_LEDGER_DIFF_ERROR,
+                "Unable to compute total count for pull",
+                Some(format!("{err:?}")),
+            ))
+            .into()
+        })
     }
 }

--- a/pallets/manta-pay/src/rpc.rs
+++ b/pallets/manta-pay/src/rpc.rs
@@ -69,6 +69,9 @@ pub trait PullApi {
         checkpoint: Checkpoint,
         max_receivers: u64,
     ) -> RpcResult<DenseInitialSyncResponse>;
+
+    #[method(name = "mantaPay_pull_ledger_total_count", blocking)]
+    fn pull_ledger_total_count(&self) -> RpcResult<[u8; 16]>;
 }
 
 /// Pull RPC API Implementation
@@ -172,6 +175,21 @@ where
                 CallError::Custom(ErrorObject::owned(
                     PULL_LEDGER_DIFF_ERROR,
                     "Unable to compute state diff for initial pull",
+                    Some(format!("{err:?}")),
+                ))
+                .into()
+            })
+    }
+
+    #[inline]
+    fn pull_ledger_total_count(&self) -> RpcResult<[u8; 16]> {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(self.client.info().finalized_hash);
+        api.pull_ledger_total_count(&at)
+            .map_err(|err| {
+                CallError::Custom(ErrorObject::owned(
+                    PULL_LEDGER_DIFF_ERROR,
+                    "Unable to compute total count for pull",
                     Some(format!("{err:?}")),
                 ))
                 .into()

--- a/pallets/manta-pay/src/runtime.rs
+++ b/pallets/manta-pay/src/runtime.rs
@@ -21,6 +21,7 @@ use manta_support::manta_pay::{InitialSyncResponse, PullResponse, RawCheckpoint}
 sp_api::decl_runtime_apis! {
     pub trait PullLedgerDiffApi {
         fn pull_ledger_diff(checkpoint: RawCheckpoint, max_receivers: u64, max_senders: u64) -> PullResponse;
+        fn pull_ledger_total_count() -> [u8; 16];
         fn initial_pull(checkpoint: RawCheckpoint, max_receivers: u64) -> InitialSyncResponse;
     }
 }

--- a/pallets/manta-sbt/src/lib.rs
+++ b/pallets/manta-sbt/src/lib.rs
@@ -875,6 +875,18 @@ where
         Shards::<T>::contains_key(shard_index, max_receiver_index)
     }
 
+    /// Returns ledger total count
+    /// In the initial state of the ledger, the total value will be 256;
+    /// if we want to get an accurate value, we need to request `pull_receivers` to fix this value;
+    /// but a simple total count interface does not need to add more complicated logic.
+    #[inline]
+    pub fn pull_ledger_total_count() -> [u8; 16] {
+        let receivers_total = (0..=255)
+            .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
+            .sum::<u128>() + 256u128;
+        asset_value_encode(receivers_total)
+    }
+
     /// Returns the diff of ledger state since the given `checkpoint` and `max_receivers`.
     /// This `Ledger` implementation has no senders by definition, cannot transfer SBTs.
     #[inline]
@@ -885,21 +897,11 @@ where
     ) -> PullResponse {
         let (more_receivers, receivers) =
             Self::pull_receivers(*checkpoint.receiver_index, max_receivers);
-        let mut receivers_total = (0..=255)
-            .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
-            .sum::<u128>();
-        // Workaround for the fact that we index the receivers from 0
-        if receivers_total == 0u128 {
-            // The cast is fine because the vector sizes are limited by PULL_MAX_RECEIVER_UPDATE_SIZE
-            receivers_total = receivers.len() as u128;
-        } else {
-            receivers_total += 256u128;
-        }
         PullResponse {
             should_continue: more_receivers,
             receivers,
             senders: vec![],
-            senders_receivers_total: asset_value_encode(receivers_total),
+            senders_receivers_total: Self::pull_ledger_total_count(),
         }
     }
 

--- a/pallets/manta-sbt/src/lib.rs
+++ b/pallets/manta-sbt/src/lib.rs
@@ -883,7 +883,8 @@ where
     pub fn pull_ledger_total_count() -> [u8; 16] {
         let receivers_total = (0..=255)
             .map(|i| ShardTrees::<T>::get(i).current_path.leaf_index as u128)
-            .sum::<u128>() + 256u128;
+            .sum::<u128>()
+            + 256u128;
         asset_value_encode(receivers_total)
     }
 

--- a/pallets/manta-sbt/src/rpc.rs
+++ b/pallets/manta-sbt/src/rpc.rs
@@ -52,6 +52,9 @@ pub trait SBTPullApi {
         max_receivers: u64,
         max_senders: u64,
     ) -> RpcResult<DensePullResponse>;
+
+    #[method(name = "mantaSBT_pull_ledger_total_count", blocking)]
+    fn sbt_pull_ledger_total_count(&self) -> RpcResult<[u8; 16]>;
 }
 
 /// Pull RPC API Implementation
@@ -116,6 +119,21 @@ where
                 CallError::Custom(ErrorObject::owned(
                     PULL_LEDGER_DIFF_ERROR,
                     "Unable to compute dense state diff for pull",
+                    Some(format!("{err:?}")),
+                ))
+                .into()
+            })
+    }
+
+    #[inline]
+    fn sbt_pull_ledger_total_count(&self) -> RpcResult<[u8; 16]> {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(self.client.info().finalized_hash);
+        api.sbt_pull_ledger_total_count(&at)
+            .map_err(|err| {
+                CallError::Custom(ErrorObject::owned(
+                    PULL_LEDGER_DIFF_ERROR,
+                    "Unable to compute total count for pull",
                     Some(format!("{err:?}")),
                 ))
                 .into()

--- a/pallets/manta-sbt/src/rpc.rs
+++ b/pallets/manta-sbt/src/rpc.rs
@@ -129,14 +129,13 @@ where
     fn sbt_pull_ledger_total_count(&self) -> RpcResult<[u8; 16]> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(self.client.info().finalized_hash);
-        api.sbt_pull_ledger_total_count(&at)
-            .map_err(|err| {
-                CallError::Custom(ErrorObject::owned(
-                    PULL_LEDGER_DIFF_ERROR,
-                    "Unable to compute total count for pull",
-                    Some(format!("{err:?}")),
-                ))
-                .into()
-            })
+        api.sbt_pull_ledger_total_count(&at).map_err(|err| {
+            CallError::Custom(ErrorObject::owned(
+                PULL_LEDGER_DIFF_ERROR,
+                "Unable to compute total count for pull",
+                Some(format!("{err:?}")),
+            ))
+            .into()
+        })
     }
 }

--- a/pallets/manta-sbt/src/runtime.rs
+++ b/pallets/manta-sbt/src/runtime.rs
@@ -21,5 +21,6 @@ use manta_support::manta_pay::{PullResponse, RawCheckpoint};
 sp_api::decl_runtime_apis! {
     pub trait SBTPullLedgerDiffApi {
         fn sbt_pull_ledger_diff(checkpoint: RawCheckpoint, max_receivers: u64, max_senders: u64) -> PullResponse;
+        fn sbt_pull_ledger_total_count() -> [u8; 16];
     }
 }

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -1067,6 +1067,9 @@ impl_runtime_apis! {
         ) -> PullResponse {
             MantaPay::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
         }
+        fn pull_ledger_total_count() -> [u8; 16] {
+            MantaPay::pull_ledger_total_count()
+        }
         fn initial_pull(checkpoint: RawCheckpoint, max_receiver: u64) -> InitialSyncResponse {
             MantaPay::initial_pull(checkpoint.into(), max_receiver)
         }
@@ -1079,6 +1082,9 @@ impl_runtime_apis! {
             max_sender: u64
         ) -> PullResponse {
             MantaSbt::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
+        }
+        fn sbt_pull_ledger_total_count() -> [u8; 16] {
+            MantaSbt::pull_ledger_total_count()
         }
     }
 

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -976,6 +976,9 @@ impl_runtime_apis! {
         ) -> PullResponse {
             MantaPay::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
         }
+        fn pull_ledger_total_count() -> [u8; 16] {
+            MantaPay::pull_ledger_total_count()
+        }
         fn initial_pull(checkpoint: RawCheckpoint, max_receiver: u64) -> InitialSyncResponse {
             MantaPay::initial_pull(checkpoint.into(), max_receiver)
         }
@@ -988,6 +991,9 @@ impl_runtime_apis! {
             max_sender: u64
         ) -> PullResponse {
             MantaSbt::pull_ledger_diff(checkpoint.into(), max_receiver, max_sender)
+        }
+        fn sbt_pull_ledger_total_count() -> [u8; 16] {
+            MantaSbt::pull_ledger_total_count()
         }
     }
 


### PR DESCRIPTION
## Description

Add ledger total count api

Goes together with https://github.com/Manta-Network/sdk/pull/128

This is a newly created branch to fix the issue of https://github.com/Manta-Network/Manta/pull/1107 signoff, related discussions can also refer to this PR

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
