### PR TITLE
Fix integration test compile options, deps cleanup & clippy

### DIFF
--- a/runtime/calamari/Cargo.toml
+++ b/runtime/calamari/Cargo.toml
@@ -108,48 +108,19 @@ targets = ['x86_64-unknown-linux-gnu']
 substrate-wasm-builder = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
 
 [dev-dependencies]
+# Generic 3rd-party dependencies
 lazy_static = "1.4.0"
 reqwest = { version = "0.11.6", features = ["blocking"] }
 serde_json = "1.0"
 
-# 3rd dependencies
-codec = { package = "parity-scale-codec", version = "3.4.0" }
-scale-info = { version = "2.1.2", features = ["derive"] }
-
-# Substrate dependencies
-frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-pallet-assets = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-pallet-utility = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-sp-io = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
-
-# Polkadot dependencies
-pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-polkadot-core-primitives = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-polkadot-parachain = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-polkadot-runtime-parachains = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-xcm = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-xcm-builder = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-xcm-simulator = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
-
-# Cumulus dependencies
-cumulus-pallet-dmp-queue = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.37" }
-cumulus-pallet-parachain-system = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.37" }
-cumulus-pallet-xcm = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.37" }
-cumulus-pallet-xcmp-queue = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.37" }
+# Substrate 3rd-party dependencies
 cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.37" }
 cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.37" }
-parachain-info = { git = 'https://github.com/paritytech/cumulus.git', branch = "polkadot-v0.9.37" }
-
-# Orml dependencies
-orml-traits = { git = "https://github.com/manta-network/open-runtime-module-library.git", branch = "polkadot-v0.9.37" }
-orml-xtokens = { git = "https://github.com/manta-network/open-runtime-module-library.git", branch = "polkadot-v0.9.37" }
+polkadot-core-primitives = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
+polkadot-runtime-parachains = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
+xcm-simulator = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
 
 # Self dependencies
-pallet-asset-manager = { path = '../../pallets/asset-manager' }
 runtime-common = { path = '../common', features = ["test-helpers"] }
 
 [features]

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -11,16 +11,16 @@ version = "4.0.7"
 calamari-runtime = { path = "../calamari", optional = true }
 cfg-if = "1.0"
 manta-runtime = { path = "../manta", optional = true }
-pallet-conviction-voting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37", features = ["runtime-benchmarks"] }
-pallet-ranked-collective = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37", features = ["runtime-benchmarks"] }
-pallet-referenda = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37", features = ["runtime-benchmarks"] }
+pallet-conviction-voting = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+pallet-ranked-collective = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+pallet-referenda = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37", default-features = false }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
 lazy_static = "1.4.0"
-pallet-assets = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.37", features = ["runtime-benchmarks"] }
+pallet-assets = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.37" }
 pallet-balances = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
 pallet-collective = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
 pallet-democracy = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
@@ -75,12 +75,9 @@ session-key-primitives = { path = '../../primitives/session-keys', default-featu
 [features]
 calamari = [
   "dep:calamari-runtime",
-  "calamari-runtime?/runtime-benchmarks",
-  "runtime-benchmarks",
 ]
+default = ["manta"]
 manta = [
   "dep:manta-runtime",
-  "manta-runtime?/runtime-benchmarks",
-  "runtime-benchmarks",
 ]
 runtime-benchmarks = []


### PR DESCRIPTION
Signed-off-by: Adam Reif <Garandor@manta.network>

## Description
**Affects testing code only**
- Integration test hard-depended on `runtime-benchmarks` breaking `cargo test`, this is now fixed
- manta integration test is now the default unless the `calamari` feature is set 
- calamari cargo.toml had dev-deps duplicating many of the crates in deps. cleaned
- 


---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
