### PR TITLE
Add timeouts to CI workflows

### DIFF
--- a/.github/workflows/changelog_verification.yml
+++ b/.github/workflows/changelog_verification.yml
@@ -10,6 +10,7 @@ on:
       - 'v[0-9]+\.[0-9]+\.[0-9]+*'
 jobs:
   verify_changelog:
+    timeout-minutes: 30
     runs-on: ubuntu-20.04
     steps:
       - name: checkout

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -15,6 +15,7 @@ env:
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
   start-unit-test-checks:
+    timeout-minutes: 240
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
@@ -133,6 +134,7 @@ jobs:
       - name: stop sccache server
         run: sccache --stop-server || true
   stop-unit-test-checks:
+    timeout-minutes: 15
     needs: start-unit-test-checks
     runs-on: ubuntu-20.04
     if: ${{ always() }}
@@ -150,6 +152,7 @@ jobs:
       - name: discard stopper success/failure
         run: true
   start-benchmark-checks:
+    timeout-minutes: 180
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
       - published
 jobs:
   docker-hub-deploy:
+    timeout-minutes: 120
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -27,6 +28,7 @@ jobs:
           build-args: |
             PARA_BINARY_REF=${{ github.event.release.tag_name }}
   check-docker-hub-deploy:
+    timeout-minutes: 120
     needs: docker-hub-deploy
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -109,7 +109,6 @@ jobs:
           name: config-for-integration-test
           path: .github/resources/config-for-integration-test.json
   calamari-integration-test:
-    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-calamari' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-calamari-integration-tester]
     runs-on: ${{ needs.start-calamari-integration-tester.outputs.runner-label }}

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -35,6 +35,7 @@ jobs:
           echo "::set-output name=stable::$(rustc +stable --version)"
           echo "::set-output name=nightly::$(rustc +nightly --version)"
   build-node-current:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-calamari' || github.ref == 'refs/heads/manta')
     needs: start-node-builder-current
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
@@ -108,6 +109,7 @@ jobs:
           name: config-for-integration-test
           path: .github/resources/config-for-integration-test.json
   calamari-integration-test:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-calamari' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-calamari-integration-tester]
     runs-on: ${{ needs.start-calamari-integration-tester.outputs.runner-label }}
@@ -399,6 +401,7 @@ jobs:
           name: ${{ matrix.chain-spec.id }}-alice-stress.log
           path: ${{ github.workspace }}/polkadot-launch/9921.log
   docker-image-test:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-calamari' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-docker-image-tester]
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -35,6 +35,7 @@ jobs:
           echo "::set-output name=stable::$(rustc +stable --version)"
           echo "::set-output name=nightly::$(rustc +nightly --version)"
   build-node-current:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')
     needs: start-node-builder-current
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
@@ -108,6 +109,7 @@ jobs:
           name: config-for-integration-test
           path: .github/resources/config-for-integration-test.json
   manta-integration-test:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-manta-integration-tester]
     runs-on: ${{ needs.start-manta-integration-tester.outputs.runner-label }}
@@ -399,6 +401,7 @@ jobs:
       #     name: ${{ matrix.chain-spec.id }}-alice-stress.log
       #     path: ${{ github.workspace }}/polkadot-launch/9921.log
   docker-image-test:
+    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-docker-image-tester]
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -109,7 +109,6 @@ jobs:
           name: config-for-integration-test
           path: .github/resources/config-for-integration-test.json
   manta-integration-test:
-    timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')
     needs: [build-node-current, start-manta-integration-tester]
     runs-on: ${{ needs.start-manta-integration-tester.outputs.runner-label }}

--- a/.github/workflows/metadata_diff.yml
+++ b/.github/workflows/metadata_diff.yml
@@ -19,6 +19,7 @@ env:
   REF_BINARY: ${{github.event.inputs.reference_binary}}
 jobs:
   start-checks:
+    timeout-minutes: 120
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -33,6 +33,7 @@ jobs:
           echo "::set-output name=stable::$(rustc +stable --version)"
           echo "::set-output name=nightly::$(rustc +nightly --version)"
   build-runtimes:
+    timeout-minutes: 180
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     env:
@@ -78,6 +79,7 @@ jobs:
             ${{ steps.srtool-build.outputs.wasm }}
             ${{ steps.srtool-build.outputs.wasm_compressed }}
   build-node-current:
+    timeout-minutes: 180
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: start-node-builder-current
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}

--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -21,6 +21,7 @@ env:
   FULL_DB_FOLDER: full-db
 jobs:
   run-benchmarks:
+    timeout-minutes: 240
     needs: start-node-builder-current
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
     steps:

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -15,6 +15,7 @@ env:
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
   start-checks:
+    timeout-minutes: 120
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -30,6 +30,7 @@ env:
   MANTA_BINARY: ${{github.event.inputs.manta_base_url}}
 jobs:
   build-runtimes:
+    timeout-minutes: 120
     runs-on: ubuntu-20.04
     env:
       CARGO_TERM_COLOR: always
@@ -74,6 +75,7 @@ jobs:
           name: config-for-runtime-upgrade-test
           path: .github/resources/config-for-runtime-upgrade-test.json
   runtime-upgrade-test:
+    timeout-minutes: 120
     needs: [build-runtimes, start-runtime-upgrade-tester]
     runs-on: ${{ needs.start-runtime-upgrade-tester.outputs.runner-label }}
     timeout-minutes: 90

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -75,7 +75,6 @@ jobs:
           name: config-for-runtime-upgrade-test
           path: .github/resources/config-for-runtime-upgrade-test.json
   runtime-upgrade-test:
-    timeout-minutes: 120
     needs: [build-runtimes, start-runtime-upgrade-tester]
     runs-on: ${{ needs.start-runtime-upgrade-tester.outputs.runner-label }}
     timeout-minutes: 90

--- a/.github/workflows/try-runtime-mainnet.yml
+++ b/.github/workflows/try-runtime-mainnet.yml
@@ -25,6 +25,7 @@ env:
   RUNTIME: ${{github.event.inputs.runtime}}
 jobs:
   start-checks:
+    timeout-minutes: 120
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}


### PR DESCRIPTION
## Description

* Add more timeouts to CI workflows, to reduce chance of long hanging stuff.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
