### PR TITLE
Unfilter outgoing assets extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4200,6 +4200,7 @@ dependencies = [
  "pallet-manta-pay",
  "pallet-manta-sbt",
  "pallet-manta-support",
+ "pallet-membership",
  "pallet-parachain-staking",
  "pallet-ranked-collective",
  "pallet-referenda",

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -584,7 +584,7 @@ pub mod pallet {
             filtered_location: T::Location,
             should_add: bool,
         ) -> DispatchResult {
-            T::ModifierOrigin::ensure_origin(origin)?;
+            T::SuspenderOrigin::ensure_origin(origin)?;
             if should_add {
                 FilteredOutgoingAssetLocations::<T>::insert(filtered_location.clone().into(), ());
                 Self::deposit_event(Event::<T>::AssetLocationFilteredForOutgoingTransfers {

--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -297,6 +297,7 @@ impl Contains<RuntimeCall> for BaseFilter {
             | RuntimeCall::XTokens(orml_xtokens::Call::transfer {..}
                 | orml_xtokens::Call::transfer_multicurrencies {..})
             | RuntimeCall::TransactionPause(_)
+            | RuntimeCall::AssetManager(pallet_asset_manager::Call::update_outgoing_filtered_assets {..})
             | RuntimeCall::Utility(_) => true,
 
             // DISALLOW anything else

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -284,6 +284,7 @@ impl Contains<RuntimeCall> for BaseFilter {
             | RuntimeCall::Preimage(_)
             | RuntimeCall::MantaSbt(_)
             | RuntimeCall::TransactionPause(_)
+            | RuntimeCall::AssetManager(pallet_asset_manager::Call::update_outgoing_filtered_assets {..})
             | RuntimeCall::Utility(_) => true,
 
             // DISALLOW anything else

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -220,7 +220,6 @@ impl Contains<RuntimeCall> for BaseFilter {
         match call {
             // Explicitly DISALLOWED calls
             | RuntimeCall::Assets(_) // Filter Assets. Assets should only be accessed by AssetManager.
-            | RuntimeCall::AssetManager(_) // AssetManager is also filtered because all of its extrinsics
                                     // are callable only by Root, and Root calls skip this whole filter.
             // Currently, we filter `register_as_candidate` as this call is not yet ready for community.
             | RuntimeCall::CollatorSelection( manta_collator_selection::Call::register_as_candidate{..})

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -16,25 +16,26 @@ pallet-ranked-collective = { git = "https://github.com/paritytech/substrate.git"
 pallet-referenda = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", version = '3.1.2', default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", version = '3.1.2', features = ["derive", "max-encoded-len"] }
 frame-support = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37", default-features = false }
 frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
 lazy_static = "1.4.0"
-pallet-assets = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.37" }
-pallet-balances = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-collective = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-democracy = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-scheduler = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-session = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-transaction-payment = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-pallet-utility = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.37" }
-pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', default-features = false, branch = "release-v0.9.37" }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-sp-core = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-sp-io = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
-sp-std = { git = 'https://github.com/paritytech/substrate.git', default-features = false, branch = "polkadot-v0.9.37" }
+pallet-assets = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+pallet-balances = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-collective = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-democracy = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-membership = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-scheduler = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-session = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-transaction-payment = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+pallet-utility = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
+pallet-xcm = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
+scale-info = { version = "2.1.2", features = ["derive"] }
+sp-arithmetic = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+sp-core = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+sp-io = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
+sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.37" }
 xcm = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
 xcm-builder = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
 xcm-executor = { git = 'https://github.com/paritytech/polkadot.git', branch = "release-v0.9.37" }
@@ -58,19 +59,19 @@ orml-traits = { git = "https://github.com/manta-network/open-runtime-module-libr
 orml-xtokens = { git = "https://github.com/manta-network/open-runtime-module-library.git", branch = "polkadot-v0.9.37" }
 
 # Self dependencies
-calamari-vesting = { path = '../../pallets/vesting', default-features = false }
-manta-collator-selection = { path = '../../pallets/collator-selection', default-features = false }
+calamari-vesting = { path = '../../pallets/vesting' }
+manta-collator-selection = { path = '../../pallets/collator-selection' }
 pallet-asset-manager = { path = '../../pallets/asset-manager' }
-pallet-manta-pay = { path = '../../pallets/manta-pay', default-features = false, features = ["runtime"] }
-pallet-manta-sbt = { path = '../../pallets/manta-sbt', default-features = false, features = ["runtime"] }
-pallet-parachain-staking = { path = '../../pallets/parachain-staking', default-features = false }
-pallet-tx-pause = { path = '../../pallets/tx-pause', default-features = false }
+pallet-manta-pay = { path = '../../pallets/manta-pay', features = ["runtime"] }
+pallet-manta-sbt = { path = '../../pallets/manta-sbt', features = ["runtime"] }
+pallet-parachain-staking = { path = '../../pallets/parachain-staking' }
+pallet-tx-pause = { path = '../../pallets/tx-pause' }
 
-manta-primitives = { path = '../../primitives/manta', default-features = false }
-manta-support = { package = "pallet-manta-support", path = "../../pallets/manta-support", default-features = false }
-nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.8", default-features = false }
+manta-primitives = { path = '../../primitives/manta' }
+manta-support = { package = "pallet-manta-support", path = "../../pallets/manta-support" }
+nimbus-primitives = { git = "https://github.com/manta-network/nimbus.git", tag = "v4.0.8" }
 runtime-common = { path = '../common', features = ["test-helpers"] }
-session-key-primitives = { path = '../../primitives/session-keys', default-features = false }
+session-key-primitives = { path = '../../primitives/session-keys' }
 
 [features]
 calamari = [

--- a/runtime/integration-tests/src/integrations_mock/test_common.rs
+++ b/runtime/integration-tests/src/integrations_mock/test_common.rs
@@ -851,7 +851,7 @@ mod tx_pause_tests {
         let all_pallet_names: Vec<&str> = all_pallets.into_iter().map(|info| info.name).collect();
         for pallet in NonPausablePallets::get() {
             let pallet_str = sp_std::str::from_utf8(&pallet).unwrap();
-            assert!(all_pallet_names.contains(&pallet_str), "{:?}", pallet_str);
+            assert!(all_pallet_names.contains(&pallet_str), "{pallet_str:?}");
         }
     }
 }

--- a/runtime/integration-tests/src/integrations_mock/test_common.rs
+++ b/runtime/integration-tests/src/integrations_mock/test_common.rs
@@ -1512,4 +1512,33 @@ mod governance_tests {
             );
         });
     }
+
+    #[test]
+    fn asset_manager_filters_outgoing_assets_with_council() {
+        ExtBuilder::default().build().execute_with(|| {
+            // Setup the preimage and preimage hash
+            let runtime_call = RuntimeCall::AssetManager(
+                pallet_asset_manager::Call::update_outgoing_filtered_assets {
+                    filtered_location: MultiLocation::default().into(),
+                    should_add: true,
+                },
+            );
+
+            assert_ok!(Council::set_members(
+                root_origin(),
+                vec![ALICE.clone()],
+                None,
+                0
+            ));
+            let council_motion_hash = propose_council_motion(&runtime_call, &ALICE);
+
+            assert_eq!(
+                last_event(),
+                RuntimeEvent::Council(pallet_collective::Event::Executed {
+                    proposal_hash: council_motion_hash,
+                    result: Ok(())
+                })
+            );
+        });
+    }
 }

--- a/runtime/manta/src/assets_config.rs
+++ b/runtime/manta/src/assets_config.rs
@@ -15,7 +15,7 @@
 // along with Manta.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{
-    weights, xcm_config::SelfReserve, AssetManager, Assets, Balances,
+    weights, xcm_config::SelfReserve, AssetManager, Assets, Balances, CouncilCollective,
     NativeTokenExistentialDeposit, Runtime, RuntimeEvent, RuntimeOrigin,
 };
 
@@ -31,7 +31,7 @@ use manta_primitives::{
 use frame_support::{
     pallet_prelude::DispatchResult,
     parameter_types,
-    traits::{AsEnsureOriginWithArg, ConstU32},
+    traits::{AsEnsureOriginWithArg, ConstU32, EitherOfDiverse},
     PalletId,
 };
 use frame_system::EnsureRoot;
@@ -174,7 +174,10 @@ impl pallet_asset_manager::Config for Runtime {
     type Location = AssetLocation;
     type AssetConfig = MantaAssetConfig;
     type ModifierOrigin = EnsureRoot<AccountId>;
-    type SuspenderOrigin = EnsureRoot<AccountId>;
+    type SuspenderOrigin = EitherOfDiverse<
+        EnsureRoot<AccountId>,
+        pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 3, 4>,
+    >;
     type PalletId = AssetManagerPalletId;
     type WeightInfo = weights::pallet_asset_manager::SubstrateWeight<Runtime>;
 }

--- a/runtime/manta/src/fee.rs
+++ b/runtime/manta/src/fee.rs
@@ -101,7 +101,7 @@ mod multiplier_tests {
                 TransactionPayment::on_finalize(1);
                 let next = TransactionPayment::next_fee_multiplier();
 
-                assert!(next > multiplier, "{:?} !>= {:?}", next, multiplier);
+                assert!(next > multiplier, "{next:?} !>= {multiplier:?}");
                 multiplier = next;
 
                 println!(
@@ -162,10 +162,10 @@ mod multiplier_tests {
                 TransactionPayment::on_finalize(1);
                 let next = TransactionPayment::next_fee_multiplier();
 
-                assert!(next < multiplier, "{:?} !>= {:?}", next, multiplier);
+                assert!(next < multiplier, "{next:?} !>= {multiplier:?}");
                 multiplier = next;
 
-                println!("block = {} / multiplier {:?}", blocks, multiplier);
+                println!("block = {blocks} / multiplier {multiplier:?}");
             });
             blocks += 1;
         }
@@ -173,7 +173,7 @@ mod multiplier_tests {
         let cooldown_target = 10f32;
         let days = blocks as f32 / DAYS as f32;
         if days > cooldown_target {
-            panic!("It will take more than 10 days to cool down: {:?}", days);
+            panic!("It will take more than 10 days to cool down: {days:?}");
         }
     }
 }

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -238,6 +238,7 @@ impl Contains<RuntimeCall> for MantaFilter {
             | RuntimeCall::Balances(_)
             | RuntimeCall::Preimage(_)
             | RuntimeCall::TransactionPause(_)
+            | RuntimeCall::AssetManager(pallet_asset_manager::Call::update_outgoing_filtered_assets {..})
             | RuntimeCall::Utility(_) => true,
 
             // DISALLOW anything else


### PR DESCRIPTION
## Description

* unfilter update_outgoing_filtered_assets in Calamari and Manta so it can be executed by the Council origin
* fix the origin check in th extrinsic to use the SuspenderOrigin instead of the ModifierOrigin
* Add a test case for this
* Clean up toml file

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
