### PR TITLE
Unfilter parachain staking extrinsics

### DIFF
--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -234,6 +234,29 @@ impl Contains<RuntimeCall> for MantaFilter {
             | RuntimeCall::Sudo(_)
             | RuntimeCall::Multisig(_)
             | RuntimeCall::AuthorInherent(pallet_author_inherent::Call::kick_off_authorship_validation {..}) // executes unsigned on every block
+            | RuntimeCall::Session(_) // User must be able to set their session key when applying for a collator
+            | RuntimeCall::ParachainStaking(
+                // Collator extrinsics
+                pallet_parachain_staking::Call::join_candidates{..}
+                | pallet_parachain_staking::Call::schedule_leave_candidates{..}
+                | pallet_parachain_staking::Call::execute_leave_candidates{..}
+                | pallet_parachain_staking::Call::cancel_leave_candidates{..}
+                | pallet_parachain_staking::Call::go_offline{..}
+                | pallet_parachain_staking::Call::go_online{..}
+                | pallet_parachain_staking::Call::candidate_bond_more{..}
+                | pallet_parachain_staking::Call::schedule_candidate_bond_less{..}
+                | pallet_parachain_staking::Call::execute_candidate_bond_less{..}
+                | pallet_parachain_staking::Call::cancel_candidate_bond_less{..}
+                // Delegator extrinsics
+                | pallet_parachain_staking::Call::delegate{..}
+                | pallet_parachain_staking::Call::schedule_leave_delegators{..}
+                | pallet_parachain_staking::Call::execute_leave_delegators{..}
+                | pallet_parachain_staking::Call::cancel_leave_delegators{..}
+                | pallet_parachain_staking::Call::schedule_revoke_delegation{..}
+                | pallet_parachain_staking::Call::delegator_bond_more{..}
+                | pallet_parachain_staking::Call::schedule_delegator_bond_less{..}
+                | pallet_parachain_staking::Call::execute_delegation_request{..}
+                | pallet_parachain_staking::Call::cancel_delegation_request{..})
             | RuntimeCall::XTokens(orml_xtokens::Call::transfer {..})
             | RuntimeCall::Balances(_)
             | RuntimeCall::Preimage(_)


### PR DESCRIPTION
## Description

* Unfilter parachain staking and session extrinsics on Manta

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
