### PR TITLE
Release v4.1.0-1

### DIFF
--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("calamari"),
     impl_name: create_runtime_str!("calamari"),
     authoring_version: 2,
-    spec_version: 4100,
+    spec_version: 4101,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 13,

--- a/runtime/dolphin/src/lib.rs
+++ b/runtime/dolphin/src/lib.rs
@@ -126,7 +126,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("dolphin"),
     impl_name: create_runtime_str!("dolphin"),
     authoring_version: 2,
-    spec_version: 4100,
+    spec_version: 4101,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 8,

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("manta"),
     impl_name: create_runtime_str!("manta"),
     authoring_version: 1,
-    spec_version: 4100,
+    spec_version: 4103,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("manta"),
     impl_name: create_runtime_str!("manta"),
     authoring_version: 1,
-    spec_version: 4103,
+    spec_version: 4101,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/manta/src/xcm_config.rs
+++ b/runtime/manta/src/xcm_config.rs
@@ -63,9 +63,9 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type SelfParaId = parachain_info::Pallet<Runtime>;
     type DmpMessageHandler = DmpQueue;
     type ReservedDmpWeight = ReservedDmpWeight;
-    type OutboundXcmpMessageSource = ();
-    type XcmpMessageHandler = ();
-    type ReservedXcmpWeight = ();
+    type OutboundXcmpMessageSource = XcmpQueue;
+    type XcmpMessageHandler = XcmpQueue;
+    type ReservedXcmpWeight = ReservedXcmpWeight;
     type OnSystemEvent = ();
     type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
 }


### PR DESCRIPTION
## Description

* Enable XCMP queue in Manta
* Bump spec versions

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
