### PR TITLE
Fix check-tests CI workflow

### DIFF
--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -77,16 +77,16 @@ jobs:
           rustup toolchain install nightly-2023-03-03
           rustup default nightly-2023-03-03
           rustup target add wasm32-unknown-unknown
-      - name: Run Integration Tests
-        env:
-          RUST_BACKTRACE: full
-          RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 120G
-          SCCACHE_DIR: /home/runner/.cache/sccache
-        run: |
-          source ${HOME}/.cargo/env
-          RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=calamari --no-default-features
-          RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=manta --no-default-features
+      # - name: Run Integration Tests
+      #   env:
+      #     RUST_BACKTRACE: full
+      #     RUSTC_WRAPPER: sccache
+      #     SCCACHE_CACHE_SIZE: 120G
+      #     SCCACHE_DIR: /home/runner/.cache/sccache
+      #   run: |
+      #     source ${HOME}/.cargo/env
+      #     RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=calamari --no-default-features
+      #     RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=manta --no-default-features
       - name: Run congestion test (allowed to fail)
         id: congestion_test
         env:

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [manta]
   push:
-    branches: [ghzlatarev/check-tests-ci]
+    branches: [manta]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -14,7 +14,7 @@ env:
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
-  start-unit-test-checks:
+  start-integration-test-checks:
     timeout-minutes: 480
     runs-on: ubuntu-20.04
     outputs:
@@ -77,15 +77,6 @@ jobs:
           rustup toolchain install nightly-2023-03-03
           rustup default nightly-2023-03-03
           rustup target add wasm32-unknown-unknown
-      - name: Run Unit Tests
-        env:
-          RUST_BACKTRACE: full
-          RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 120G
-          SCCACHE_DIR: /home/runner/.cache/sccache
-        run: |
-          source ${HOME}/.cargo/env
-          RUSTC_BOOTSTRAP=1 cargo test --release --features=runtime-benchmarks,try-runtime --workspace --exclude integration-tests
       - name: Run Integration Tests
         env:
           RUST_BACKTRACE: full
@@ -133,9 +124,9 @@ jobs:
             await octokit.rest.issues.updateComment({ owner, repo, comment_id: existingComment.id, body: updatedComment });
       - name: stop sccache server
         run: sccache --stop-server || true
-  stop-unit-test-checks:
+  stop-integration-test-checks:
     timeout-minutes: 15
-    needs: start-unit-test-checks
+    needs: start-integration-test-checks
     runs-on: ubuntu-20.04
     if: ${{ always() }}
     steps:
@@ -146,9 +137,9 @@ jobs:
           github-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN  }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ needs.start-unit-test-checks.outputs.aws-region }}
-          runner-label: ${{ needs.start-unit-test-checks.outputs.runner-label }}
-          aws-instance-id: ${{ needs.start-unit-test-checks.outputs.aws-instance-id }}
+          aws-region: ${{ needs.start-integration-test-checks.outputs.aws-region }}
+          runner-label: ${{ needs.start-integration-test-checks.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-integration-test-checks.outputs.aws-instance-id }}
       - name: discard stopper success/failure
         run: true
   start-benchmark-checks:
@@ -245,5 +236,96 @@ jobs:
           aws-region: ${{ needs.start-benchmark-checks.outputs.aws-region }}
           runner-label: ${{ needs.start-benchmark-checks.outputs.runner-label }}
           aws-instance-id: ${{ needs.start-benchmark-checks.outputs.aws-instance-id }}
+      - name: discard stopper success/failure
+        run: true
+  start-unit-test-checks:
+    timeout-minutes: 480
+    runs-on: ubuntu-20.04
+    outputs:
+      runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
+      aws-region: ${{ steps.start-self-hosted-runner.outputs.aws-region }}
+      aws-instance-id: ${{ steps.start-self-hosted-runner.outputs.aws-instance-id }}
+    steps:
+      - id: start-self-hosted-runner
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: start
+          github-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN  }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
+          aws-instance-root-volume-size: ${{ env.AWS_INSTANCE_ROOT_VOLUME_SIZE }}
+          aws-image-search-pattern: ${{ env.AWS_IMAGE_SEARCH_PATTERN }}
+          aws-image-search-owners: ${{ env.AWS_IMAGE_SEARCH_OWNERS }}
+      - uses: actions/checkout@v2
+      - name: install sccache
+        env:
+          SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: v0.2.15
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
+          mkdir -p $HOME/.local/bin
+          curl -L "$SCCACHE_RELEASE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-
+      - name: cache sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sccache-
+      - name: start sccache server
+        run: sccache --start-server
+      - name: init
+        run: |
+          sudo apt update
+          sudo apt install -y pkg-config libssl-dev protobuf-compiler
+          protoc --version
+          curl -s https://sh.rustup.rs -sSf | sh -s -- -y
+          source ${HOME}/.cargo/env
+          rustup update
+          rustup toolchain install nightly-2023-03-03
+          rustup default nightly-2023-03-03
+          rustup target add wasm32-unknown-unknown
+      - name: Run Unit Tests
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 120G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+        run: |
+          source ${HOME}/.cargo/env
+          RUSTC_BOOTSTRAP=1 cargo test --release --features=runtime-benchmarks,try-runtime --workspace --exclude integration-tests
+      - name: stop sccache server
+        run: sccache --stop-server || true
+  stop-unit-test-checks:
+    needs: start-unit-test-checks
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    steps:
+      - continue-on-error: true
+        uses: audacious-network/aws-github-runner@v1.0.33
+        with:
+          mode: stop
+          github-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN  }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ needs.start-integration-test-checks.outputs.aws-region }}
+          runner-label: ${{ needs.start-integration-test-checks.outputs.runner-label }}
+          aws-instance-id: ${{ needs.start-integration-test-checks.outputs.aws-instance-id }}
       - name: discard stopper success/failure
         run: true

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -15,7 +15,7 @@ env:
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
   start-unit-test-checks:
-    timeout-minutes: 240
+    timeout-minutes: 360
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -15,7 +15,7 @@ env:
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
   start-unit-test-checks:
-    timeout-minutes: 360
+    timeout-minutes: 480
     runs-on: ubuntu-20.04
     outputs:
       runner-label: ${{ steps.start-self-hosted-runner.outputs.runner-label }}
@@ -77,16 +77,24 @@ jobs:
           rustup toolchain install nightly-2023-03-03
           rustup default nightly-2023-03-03
           rustup target add wasm32-unknown-unknown
-      # - name: Run Integration Tests
-      #   env:
-      #     RUST_BACKTRACE: full
-      #     RUSTC_WRAPPER: sccache
-      #     SCCACHE_CACHE_SIZE: 120G
-      #     SCCACHE_DIR: /home/runner/.cache/sccache
-      #   run: |
-      #     source ${HOME}/.cargo/env
-      #     RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=calamari --no-default-features
-      #     RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=manta --no-default-features
+      - name: Run Unit Tests
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 120G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+        run: |
+          source ${HOME}/.cargo/env
+      - name: Run Integration Tests
+        env:
+          RUST_BACKTRACE: full
+          RUSTC_WRAPPER: sccache
+          SCCACHE_CACHE_SIZE: 120G
+          SCCACHE_DIR: /home/runner/.cache/sccache
+        run: |
+          source ${HOME}/.cargo/env
+          RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=calamari --no-default-features
+          RUSTC_BOOTSTRAP=1 cargo test -p integration-tests --release --features=manta --no-default-features
       - name: Run congestion test (allowed to fail)
         id: congestion_test
         env:

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -85,6 +85,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
+          RUSTC_BOOTSTRAP=1 cargo test --release --features=runtime-benchmarks,try-runtime --workspace --exclude integration-tests
       - name: Run Integration Tests
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -10,7 +10,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   AWS_INSTANCE_TYPE: c5.9xlarge
-  AWS_INSTANCE_ROOT_VOLUME_SIZE: 2048
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 512
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -10,7 +10,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   AWS_INSTANCE_TYPE: c5.9xlarge
-  AWS_INSTANCE_ROOT_VOLUME_SIZE: 512
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 1024
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [manta]
   push:
-    branches: [manta]
+    branches: [ghzlatarev/check-tests-ci]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -73,6 +73,7 @@ jobs:
           protoc --version
           curl -s https://sh.rustup.rs -sSf | sh -s -- -y
           source ${HOME}/.cargo/env
+          rustup update
           rustup toolchain install nightly-2023-03-03
           rustup default nightly-2023-03-03
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -77,15 +77,6 @@ jobs:
           rustup toolchain install nightly-2023-03-03
           rustup default nightly-2023-03-03
           rustup target add wasm32-unknown-unknown
-      - name: Run Unit Tests
-        env:
-          RUST_BACKTRACE: full
-          RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 120G
-          SCCACHE_DIR: /home/runner/.cache/sccache
-        run: |
-          source ${HOME}/.cargo/env
-          RUSTC_BOOTSTRAP=1 cargo test --release --features=runtime-benchmarks,try-runtime --workspace --exclude integration-tests
       - name: Run Integration Tests
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -10,7 +10,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   AWS_INSTANCE_TYPE: c5.9xlarge
-  AWS_INSTANCE_ROOT_VOLUME_SIZE: 1024
+  AWS_INSTANCE_ROOT_VOLUME_SIZE: 2048
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
 jobs:
@@ -81,7 +81,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 20G
+          SCCACHE_CACHE_SIZE: 120G
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
@@ -90,7 +90,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 20G
+          SCCACHE_CACHE_SIZE: 120G
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
@@ -101,7 +101,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 20G
+          SCCACHE_CACHE_SIZE: 120G
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
@@ -217,7 +217,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUSTC_WRAPPER: sccache
-          SCCACHE_CACHE_SIZE: 20G
+          SCCACHE_CACHE_SIZE: 120G
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           RUSTC_BOOTSTRAP=1 cargo run --release --features runtime-benchmarks,try-runtime \


### PR DESCRIPTION
## Description

* The check-tests workflow was running out of space and timing out
* bumped the timeouts
* bumped the sccache size
* split the unit-tests and the integration tests into 2 jobs

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
