### PR TITLE
Add missing runtime-benchmarks features

### DIFF
--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -74,6 +74,11 @@ runtime-common = { path = '../common', features = ["test-helpers"] }
 session-key-primitives = { path = '../../primitives/session-keys' }
 
 [features]
+runtime-benchmarks = [
+  "pallet-conviction-voting/runtime-benchmarks",
+  "pallet-referenda/runtime-benchmarks",
+  "pallet-ranked-collective/runtime-benchmarks",
+]
 calamari = [
   "dep:calamari-runtime",
 ]
@@ -81,4 +86,3 @@ default = ["manta"]
 manta = [
   "dep:manta-runtime",
 ]
-runtime-benchmarks = []

--- a/runtime/integration-tests/Cargo.toml
+++ b/runtime/integration-tests/Cargo.toml
@@ -74,15 +74,15 @@ runtime-common = { path = '../common', features = ["test-helpers"] }
 session-key-primitives = { path = '../../primitives/session-keys' }
 
 [features]
-runtime-benchmarks = [
-  "pallet-conviction-voting/runtime-benchmarks",
-  "pallet-referenda/runtime-benchmarks",
-  "pallet-ranked-collective/runtime-benchmarks",
-]
 calamari = [
   "dep:calamari-runtime",
 ]
 default = ["manta"]
 manta = [
   "dep:manta-runtime",
+]
+runtime-benchmarks = [
+  "pallet-conviction-voting/runtime-benchmarks",
+  "pallet-referenda/runtime-benchmarks",
+  "pallet-ranked-collective/runtime-benchmarks",
 ]


### PR DESCRIPTION
## Description

* runtime-benchmarks build and linter were failing because the integration-tests crate had missing runtime-benchmarks feature on some of its imports
* added those for the fix

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
