### PR TITLE
Update baikal branch for manta-baikal deployment

### DIFF
--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: public-baikal
           AWS_ACCESS_KEY_ID: "AKIAZ6VD3QKGIIAZR5IJ"

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: jakejarvis/s3-sync-action@master
         with:
-          args: --follow-symlinks --delete
+          args: --acl public-read --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: public-baikal
           AWS_ACCESS_KEY_ID: "AKIAZ6VD3QKGIIAZR5IJ"

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -4,7 +4,7 @@ name: build and prepare baikal deployment
 on:
   push:
     branches:
-      - "ghzlatarev/baikal"
+      - "baikal"
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -2,15 +2,9 @@
 # baikal is not meant to be upgraded, it is meant to be redeployed with every change
 name: build and prepare baikal deployment
 on:
-  workflow_dispatch:
-    inputs:
-      deployment:
-        description: The name of the baikal deployment to generate files for
-        default: manta-baikal
-        required: true
-      chain:
-        description: The chain spec to build with
-        required: true
+  push:
+    branches:
+      - "ghzlatarev/baikal"
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -103,6 +97,8 @@ jobs:
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
     steps:
       - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: public-baikal
           AWS_ACCESS_KEY_ID: "AKIAZ6VD3QKGIIAZR5IJ"

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -81,7 +81,7 @@ jobs:
       - name: copy to workspace
         run: |
           mkdir ${{github.workspace}}/export
-          cp target/release/manta ${{github.workspace}}/export/manta
+          cp target/release/manta ${{github.workspace}}/export/$CHAIN
   build-genesis-files:
     needs: [start-node-builder-current, build-node-current]
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}
@@ -89,9 +89,9 @@ jobs:
       - name: Export genesis files
         run: |
           cd ${{github.workspace}}/export
-          ./manta build-spec --chain manta-dev --raw > $CHAIN-genesis.json
-          ./manta export-genesis-state --chain $CHAIN-genesis.json > $CHAIN-genesis.state
-          ./manta export-genesis-wasm --chain $CHAIN-genesis.json > $CHAIN-genesis.wasm
+          ./$CHAIN build-spec --chain manta-dev --raw > $CHAIN-genesis.json
+          ./$CHAIN export-genesis-state --chain $CHAIN-genesis.json > $CHAIN-genesis.state
+          ./$CHAIN export-genesis-wasm --chain $CHAIN-genesis.json > $CHAIN-genesis.wasm
   push-to-s3:
     needs: [start-node-builder-current, build-node-current, build-genesis-files]
     runs-on: ${{ needs.start-node-builder-current.outputs.runner-label }}

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -105,6 +105,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MANTA_DEV_S3_KEY }}
           AWS_REGION: "us-east-2"
           SOURCE_DIR: ${{github.workspace}}/export
+          DEST_DIR: $CHAIN
   start-node-builder-current:
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/deploy_baikal.yml
+++ b/.github/workflows/deploy_baikal.yml
@@ -4,7 +4,7 @@ name: build and prepare baikal deployment
 on:
   push:
     branches:
-      - "baikal"
+      - "ghzlatarev/baikal"
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/node/src/chain_specs/manta/local_testnets_geneses.rs
+++ b/node/src/chain_specs/manta/local_testnets_geneses.rs
@@ -31,11 +31,6 @@ pub fn genesis_spec_dev() -> MantaChainSpec {
             None,
             SessionKeys::from_seed_unchecked("Bob"),
         ),
-        Collator::new(
-            unchecked_account_id::<sr25519::Public>("Charlie"),
-            None,
-            SessionKeys::from_seed_unchecked("Charlie"),
-        ),
     ];
     let genesis_collators_clone = genesis_collators.clone(); // so we can move it into the constructor closure
 

--- a/node/src/chain_specs/manta/local_testnets_geneses.rs
+++ b/node/src/chain_specs/manta/local_testnets_geneses.rs
@@ -19,7 +19,7 @@
 use super::*;
 use session_key_primitives::util::unchecked_account_id;
 
-pub fn genesis_spec_dev() -> MantaChainSpec {
+pub fn genesis_spec_baikal() -> MantaChainSpec {
     let genesis_collators: Vec<Collator> = vec![
         Collator::new(
             unchecked_account_id::<sr25519::Public>("Alice"),
@@ -34,15 +34,17 @@ pub fn genesis_spec_dev() -> MantaChainSpec {
     ];
     let genesis_collators_clone = genesis_collators.clone(); // so we can move it into the constructor closure
 
+    let boot_nodes = vec![
+            "/dns/crispy.baikal.testnet.calamari.systems/tcp/30433/p2p/12D3KooW9yqGrHvonaSaRGuhk164p6V2rgBmjgxCVsGG4zPVzC3Q".parse().unwrap(),
+            "/dns/crunchy.baikal.testnet.calamari.systems/tcp/30433/p2p/12D3KooWG87weajSoHuLwW4PBHUswtMJzdnJaMNJSt7MRhi4jRFC".parse().unwrap(),
+    ];
+
     MantaChainSpec::from_genesis(
         "Manta Parachain Fast",
         "manta",
         ChainType::Live,
         move || manta_devnet_genesis(genesis_collators_clone.clone()),
-        genesis_collators
-            .into_iter()
-            .filter_map(|collator| collator.nodeid)
-            .collect(),
+        boot_nodes,
         None,
         Some(MANTA_PROTOCOL_ID),
         None,

--- a/node/src/chain_specs/manta/mod.rs
+++ b/node/src/chain_specs/manta/mod.rs
@@ -85,8 +85,8 @@ pub fn manta_local_config() -> MantaChainSpec {
     local_testnets_geneses::genesis_spec_local()
 }
 /// Returns the Manta development chainspec.
-pub fn manta_development_config() -> MantaChainSpec {
-    local_testnets_geneses::genesis_spec_dev()
+pub fn manta_baikal_config() -> MantaChainSpec {
+    local_testnets_geneses::genesis_spec_baikal()
 }
 
 // common helper to create the above configs

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -100,7 +100,7 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 fn load_spec(id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
     match id {
         // manta chainspec
-        "manta-baikal" => Ok(Box::new(chain_specs::manta_development_config())),
+        "manta-baikal" => Ok(Box::new(chain_specs::manta_baikal_config())),
         "manta-local" => Ok(Box::new(chain_specs::manta_local_config())),
         "manta-testnet" => Ok(Box::new(chain_specs::manta_testnet_config())),
         "manta" => Ok(Box::new(chain_specs::manta_mainnet_config()?)),


### PR DESCRIPTION
## Description

* upload manta and calamari artefacts in separate s3 bucket directories, so when we want to change one we don't delete the other artefacts as well
* Remove the charlie collator from manta-baikal deployment
* Successful run: https://github.com/Manta-Network/Manta/actions/runs/5446475622
* ansible companion: https://github.com/Manta-Network/testnet-deployment/pull/33

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
