### PR TITLE
Revert to v0942 polkadot binary

### DIFF
--- a/.github/resources/config-for-integration-test.json
+++ b/.github/resources/config-for-integration-test.json
@@ -5,9 +5,9 @@
       "nodes": [
         {
           "name": "alice",
+          "wsPort": 9911,
           "port": 31331,
           "flags": [
-            "--rpc-port=9911",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]
@@ -15,8 +15,8 @@
         {
           "name": "bob",
           "port": 31332,
+          "wsPort": 9912,
           "flags": [
-            "--rpc-port=9912",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]
@@ -24,8 +24,8 @@
         {
           "name": "charlie",
           "port": 31333,
+          "wsPort": 9913,
           "flags": [
-            "--rpc-port=9913",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]

--- a/.github/resources/config-for-integration-test.json
+++ b/.github/resources/config-for-integration-test.json
@@ -5,27 +5,27 @@
       "nodes": [
         {
           "name": "alice",
-          "wsPort": 9911,
           "port": 31331,
           "flags": [
+            "--rpc-port=9911",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]
         },
         {
           "name": "bob",
-          "wsPort": 9912,
           "port": 31332,
           "flags": [
+            "--rpc-port=9912",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]
         },
         {
           "name": "charlie",
-          "wsPort": 9913,
           "port": 31333,
           "flags": [
+            "--rpc-port=9913",
             "--rpc-cors=all",
             "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
           ]

--- a/.github/resources/config-for-runtime-upgrade-test.json
+++ b/.github/resources/config-for-runtime-upgrade-test.json
@@ -5,27 +5,27 @@
     "nodes": [
       {
         "name": "alice",
-        "wsPort": 9911,
         "port": 31331,
         "flags": [
           "--rpc-cors=all",
+          "--rpc-port=9911",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]
       },
       {
         "name": "bob",
-        "wsPort": 9912,
         "port": 31332,
         "flags": [
+          "--rpc-port=9912",
           "--rpc-cors=all",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]
       },
       {
         "name": "charlie",
-        "wsPort": 9913,
         "port": 31333,
         "flags": [
+          "--rpc-port=9913",
           "--rpc-cors=all",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]

--- a/.github/resources/config-for-runtime-upgrade-test.json
+++ b/.github/resources/config-for-runtime-upgrade-test.json
@@ -5,18 +5,18 @@
     "nodes": [
       {
         "name": "alice",
+        "wsPort": 9911,
         "port": 31331,
         "flags": [
           "--rpc-cors=all",
-          "--rpc-port=9911",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]
       },
       {
         "name": "bob",
+        "wsPort": 9912,
         "port": 31332,
         "flags": [
-          "--rpc-port=9912",
           "--rpc-cors=all",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]
@@ -24,8 +24,8 @@
       {
         "name": "charlie",
         "port": 31333,
+        "wsPort": 9913,
         "flags": [
-          "--rpc-port=9913",
           "--rpc-cors=all",
           "--telemetry-url=wss://api.telemetry.manta.systems/submit 0"
         ]

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -17,7 +17,7 @@ env:
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
-  POLKADOT_BINARY: https://github.com/paritytech/polkadot/releases/download/v0.9.43/polkadot
+  POLKADOT_BINARY: https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot
 jobs:
   print-rust-versions:
     if: contains(github.event.pull_request.labels.*.name, 'A-calamari' || github.ref == 'refs/heads/manta')

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -17,7 +17,7 @@ env:
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'
-  POLKADOT_BINARY: https://github.com/paritytech/polkadot/releases/download/v0.9.43/polkadot
+  POLKADOT_BINARY: https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot
 jobs:
   print-rust-versions:
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ cargo build --release
 --bob \
 --rpc-cors 'all' \
 --unsafe-ws-external \
---rpc-port 9945 \
+--ws-port 9945 \
 --discover-local \
 --port 30334
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ cargo build --release
 --bob \
 --rpc-cors 'all' \
 --unsafe-ws-external \
---ws-port 9945 \
+--rpc-port 9945 \
 --discover-local \
 --port 30334
 ```


### PR DESCRIPTION
## Description

* In v0943 polkadot release they replace ws-port with rpc-port. Thats why our integration test jobs were failing, as it breaks polkdot-launch.
* Until we switch to zombienet we can revert to 0942 binaries so our tests can work.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
