### PR TITLE
Fix dex ed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14986,7 +14986,7 @@ dependencies = [
 [[package]]
 name = "zenlink-protocol"
 version = "0.4.4"
-source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#af453d294541b87033a6ee4e22ce5151c581acc1"
+source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#c2acc36bea02e6c2aa38f3b290e255dfd5c164dd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -15006,7 +15006,7 @@ dependencies = [
 [[package]]
 name = "zenlink-protocol-rpc"
 version = "0.4.4"
-source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#af453d294541b87033a6ee4e22ce5151c581acc1"
+source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#c2acc36bea02e6c2aa38f3b290e255dfd5c164dd"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "zenlink-protocol-runtime-api"
 version = "0.4.4"
-source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#af453d294541b87033a6ee4e22ce5151c581acc1"
+source = "git+https://github.com/manta-network/Zenlink?branch=polkadot-v0.9.37#c2acc36bea02e6c2aa38f3b290e255dfd5c164dd"
 dependencies = [
  "parity-scale-codec",
  "sp-api",


### PR DESCRIPTION
## Description
fix dex ed when last user remove liquidity failed.

DEX commit: https://github.com/Manta-Network/Zenlink/commit/853f41c124951e70c3ec3b6fcf5b2f684e2bc2f5#diff-48b4d8abc9afad5d3c79f61c7ad9b831eb830423e5709aaff6b6fd67acc3be3cR105-R110
> PS: did some refactor on zenlink

i.e. A pair of(KMA,KSM), when add liquidity, user's KMA and KSM transfer to pair acocunt. And the liquidity amount is record as total_supply on pair account. when user remove liquidity, KMA and KSM return back to user account.

https://github.com/Manta-Network/Zenlink/blob/c2acc36bea02e6c2aa38f3b290e255dfd5c164dd/zenlink-protocol/src/swap/mod.rs#L135-L143

```
let reserve_0 = T::MultiAssetsHandler::balance_of(asset_0, lp_account);
let reserve_1 = T::MultiAssetsHandler::balance_of(asset_1, lp_account);

let (amount_0, amount_1) = calculate_share_amounts(
	remove_liquidity,
	status.total_supply,
	reserve_0,
	reserve_1,
);
```

amount = remove_liquidity * reserve / total_supply, Let's say there's only one user add liquidity, now when user remove liquidity, remove_liquidity=total_supply, so the amount=reserve. amount_0 = KMA_balance(lp_account).

**deposit ED of KMA to pair account is not going to work, because amount = KMA balance of pair account, and all the KMA on pair account will be transfer to user.**

https://github.com/Manta-Network/Zenlink/blob/c2acc36bea02e6c2aa38f3b290e255dfd5c164dd/zenlink-protocol/src/swap/mod.rs#L176

The `T::MultiAssetsHandler::transfer` on original zenlink when transfer native token is using KeepAlive:

https://github.com/zenlinkpro/Zenlink-DEX-Module/blob/7662acbff71cea3b35db918ceb9370e8929be991/zenlink-protocol/src/multiassets.rs#L100-L106
```
T::MultiAssetsHandler::transfer(asset_0, lp_account, recipient, amount_0)?; 
```

This will failed, because pair account can't transfer all KMA while keep alive at the same time.

For non native token, we already set as AllowDeath:

https://github.com/Manta-Network/Manta/blob/51038dfe49c10045e43ee170444062989be0657a/runtime/manta/src/zenlink.rs#L153-L157

> transfer on LocalAssetHandler is `local_withdraw` + `local_deposit`: https://github.com/zenlinkpro/Zenlink-DEX-Module/blob/7662acbff71cea3b35db918ceb9370e8929be991/zenlink-protocol/src/traits.rs#L17-L24

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
