### PR TITLE
Add mantapay rpc tests to manta runtime

### DIFF
--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -338,17 +338,6 @@ jobs:
         with:
           name: block-time-rococo-relay-for-${{ matrix.chain-spec.id }}.json
           path: ${{ github.workspace }}/block-time-rococo.json
-      # - if: always()
-      # - name: parse calamari block times
-      #   run: |
-      #     grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
-      #     if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
-      #     jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
-      # - if: always()
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: block-time-${{ matrix.chain-spec.id }}.json
-      #     path: ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
       - if: always()
         name: test - rococo alice peered successfully
         run: |

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -338,17 +338,6 @@ jobs:
         with:
           name: block-time-rococo-relay-for-${{ matrix.chain-spec.id }}.json
           path: ${{ github.workspace }}/block-time-rococo.json
-      # - if: always()
-      # - name: parse manta block times
-      #   run: |
-      #     grep '#.*' ${{ github.workspace }}/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log | while read -r line; do words=($line); echo ${words[6]},${words[10]} | tee ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv; done
-      #     if [ ! -f ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv ]; then echo "block times not detected"; exit 1; fi
-      #     jq -s -R '[split("\n") | .[] | select(length > 0) | split(",") | {block:.[0]|tonumber, time:.[1]|tonumber} ]' ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.csv > ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
-      # - if: always()
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: block-time-${{ matrix.chain-spec.id }}.json
-      #     path: ${{ github.workspace }}/block-time-${{ matrix.chain-spec.id }}.json
       - if: always()
         name: test - rococo alice peered successfully
         run: |

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -361,43 +361,43 @@ jobs:
         name: test - manta alice peered successfully
         run: |
           grep '\[Parachain\] 💤 Idle (${{ matrix.chain-spec.expected.peer-count.para }} peers)' ${{ github.workspace }}/polkadot-launch/9921.log
-      # - name: append manta-pay storage
-      #   run: |
-      #     wget -P ${{ github.workspace }}/Manta/tests/data https://manta-ops.s3.amazonaws.com/integration-tests-data/storage.json
-      #     mv $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json ${{ github.workspace }}/Manta/tests/data/fork.json
-      #     cd ${{ github.workspace }}/Manta/tests
-      #     yarn install
-      #     yarn
-      #     node append_storage.js
-      #     cd ../../
-      #     mv ${{ github.workspace }}/Manta/tests/data/fork.json $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json
-      # - name: launch testnet
-      #   run: |
-      #     cd ${{ github.workspace }}/polkadot-launch
-      #     yarn install
-      #     yarn build
-      #     pm2 start dist/cli.js \
-      #       --name polkadot-launch \
-      #       --output ${{ github.workspace }}/polkadot-launch-for-${{ matrix.chain-spec.id }}-stdout.log \
-      #       --error ${{ github.workspace }}/polkadot-launch-for-${{ matrix.chain-spec.id }}-stderr.log \
-      #       --no-autorestart \
-      #       -- $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
-      # - name: run stress test
-      #   run: |
-      #     sleep 720
-      #     cd ${{ github.workspace }}/Manta/tests
-      #     yarn install
-      #     yarn
-      #     yarn stress_benchmark_test --address=ws://127.0.0.1:9921 --exit
-      # - name: stop testnet
-      #   run: |
-      #     cd ${{ github.workspace }}/polkadot-launch
-      #     pm2 stop polkadot-launch
-      # - if: always()
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: ${{ matrix.chain-spec.id }}-alice-stress.log
-      #     path: ${{ github.workspace }}/polkadot-launch/9921.log
+      - name: append manta-pay storage
+        run: |
+          wget -P ${{ github.workspace }}/Manta/tests/data https://manta-ops.s3.amazonaws.com/integration-tests-data/storage.json
+          mv $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json ${{ github.workspace }}/Manta/tests/data/fork.json
+          cd ${{ github.workspace }}/Manta/tests
+          yarn install
+          yarn
+          node append_storage.js
+          cd ../../
+          mv ${{ github.workspace }}/Manta/tests/data/fork.json $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json
+      - name: launch testnet
+        run: |
+          cd ${{ github.workspace }}/polkadot-launch
+          yarn install
+          yarn build
+          pm2 start dist/cli.js \
+            --name polkadot-launch \
+            --output ${{ github.workspace }}/polkadot-launch-for-${{ matrix.chain-spec.id }}-stdout.log \
+            --error ${{ github.workspace }}/polkadot-launch-for-${{ matrix.chain-spec.id }}-stderr.log \
+            --no-autorestart \
+            -- $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-launch-config.json
+      - name: run stress test
+        run: |
+          sleep 720
+          cd ${{ github.workspace }}/Manta/tests
+          yarn install
+          yarn
+          yarn stress_benchmark_test --address=ws://127.0.0.1:9921 --exit
+      - name: stop testnet
+        run: |
+          cd ${{ github.workspace }}/polkadot-launch
+          pm2 stop polkadot-launch
+      - if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.chain-spec.id }}-alice-stress.log
+          path: ${{ github.workspace }}/polkadot-launch/9921.log
   docker-image-test:
     timeout-minutes: 120
     if: contains(github.event.pull_request.labels.*.name, 'A-manta' || github.ref == 'refs/heads/manta')

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -22,6 +22,7 @@ const test_config = {
   transfer_size: 1291,
   reclaim_size: 1001,
   expected_tps: 0.5,
+  expected_average_block_time: 13000
 };
 
 describe("Node RPC Test", () => {
@@ -259,6 +260,10 @@ describe("Node RPC Test", () => {
       console.log("\n Transactions sent: ", txsCount);
     }
 
+    const lastHeader = await api.rpc.chain.getHeader();
+    const currentTime = performance.now();
+    const averageBlockTime = lastHeader.number.toNumber() / currentTime;
+
     // wait all txs finalized
     for (let i = 0; i < test_config.max_wait_time_sec; i++) {
       await delay(1000);
@@ -276,6 +281,9 @@ describe("Node RPC Test", () => {
       console.log("allSuccesses Count: ", allSuccesses);
       assert(false);
     }
+
+    console.log("Average block time: ", averageBlockTime);
+    assert(averageBlockTime < test_config.expected_average_block_time);
 
     api.disconnect();
   }).timeout(test_config.timeout);

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -282,6 +282,8 @@ describe("Node RPC Test", () => {
       assert(false);
     }
 
+    console.log("Total time: ", totalTime);
+    console.log("Last header: ", lastHeader);
     console.log("Average block time: ", averageBlockTime);
     assert(averageBlockTime < test_config.expected_average_block_time);
 

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -223,8 +223,6 @@ describe("Node RPC Test", () => {
                   allSuccesses++;
                 }
               });
-              const lastHeader = await api.rpc.chain.getHeader();
-              lastBlock = lastHeader.number.toNumber();
             } else if (status.isFinalized) {
               lastFinalized = true;
               let endTime = performance.now();
@@ -270,6 +268,15 @@ describe("Node RPC Test", () => {
         let tps = (test_config.tests_iterations * 7) / totalTime;
         console.log("Tps is: ", tps);
         assert(tps >= test_config.expected_tps);
+        const lastHeader = await api.rpc.chain.getHeader();
+        
+        lastBlock = lastHeader.number.toNumber();
+        const averageBlockTime = lastBlock / totalTime;
+        console.log("Total time: ", totalTime);
+        console.log("Last block number: ", lastBlock);
+        console.log("Average block time: ", averageBlockTime);
+        assert(averageBlockTime < test_config.expected_average_block_time);
+
         break;
       }
     }
@@ -280,12 +287,6 @@ describe("Node RPC Test", () => {
       console.log("allSuccesses Count: ", allSuccesses);
       assert(false);
     }
-
-    const averageBlockTime = lastBlock / totalTime;
-    console.log("Total time: ", totalTime);
-    console.log("Last block number: ", lastBlock);
-    console.log("Average block time: ", averageBlockTime);
-    assert(averageBlockTime < test_config.expected_average_block_time);
 
     api.disconnect();
   }).timeout(test_config.timeout);

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -68,7 +68,8 @@ describe("Node RPC Test", () => {
     let txsCount = 0;
     let startTime = performance.now();
     let totalTime = 0;
-    
+    let lastBlock = 0;
+
     for (
       let i = test_config.start_iteration;
       i < test_config.start_iteration + test_config.tests_iterations;
@@ -222,6 +223,8 @@ describe("Node RPC Test", () => {
                   allSuccesses++;
                 }
               });
+              const lastHeader = await api.rpc.chain.getHeader();
+              lastBlock = lastHeader.number.toNumber();
             } else if (status.isFinalized) {
               lastFinalized = true;
               let endTime = performance.now();
@@ -260,10 +263,6 @@ describe("Node RPC Test", () => {
       console.log("\n Transactions sent: ", txsCount);
     }
 
-    const lastHeader = await api.rpc.chain.getHeader();
-    const currentTime = performance.now();
-    const averageBlockTime = lastHeader.number.toNumber() / (currentTime - startTime);
-
     // wait all txs finalized
     for (let i = 0; i < test_config.max_wait_time_sec; i++) {
       await delay(1000);
@@ -282,8 +281,9 @@ describe("Node RPC Test", () => {
       assert(false);
     }
 
+    const averageBlockTime = lastBlock / totalTime;
     console.log("Total time: ", totalTime);
-    console.log("Last header: ", lastHeader);
+    console.log("Last block number: ", lastBlock);
     console.log("Average block time: ", averageBlockTime);
     assert(averageBlockTime < test_config.expected_average_block_time);
 

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -262,7 +262,7 @@ describe("Node RPC Test", () => {
 
     const lastHeader = await api.rpc.chain.getHeader();
     const currentTime = performance.now();
-    const averageBlockTime = lastHeader.number.toNumber() / currentTime;
+    const averageBlockTime = lastHeader.number.toNumber() / (currentTime - startTime);
 
     // wait all txs finalized
     for (let i = 0; i < test_config.max_wait_time_sec; i++) {

--- a/tests/stress_benchmark_test.ts
+++ b/tests/stress_benchmark_test.ts
@@ -69,6 +69,9 @@ describe("Node RPC Test", () => {
     let startTime = performance.now();
     let totalTime = 0;
     let lastBlock = 0;
+    
+    const firstHeader = await api.rpc.chain.getHeader();
+    const firstBlock = firstHeader.number.toNumber();
 
     for (
       let i = test_config.start_iteration;
@@ -268,12 +271,12 @@ describe("Node RPC Test", () => {
         let tps = (test_config.tests_iterations * 7) / totalTime;
         console.log("Tps is: ", tps);
         assert(tps >= test_config.expected_tps);
-        const lastHeader = await api.rpc.chain.getHeader();
         
+        const lastHeader = await api.rpc.chain.getHeader();
         lastBlock = lastHeader.number.toNumber();
-        const averageBlockTime = lastBlock / totalTime;
+        const averageBlockTime = totalTime / (lastBlock - firstBlock);
         console.log("Total time: ", totalTime);
-        console.log("Last block number: ", lastBlock);
+        console.log("Number of blocks: ", (lastBlock - firstBlock));
         console.log("Average block time: ", averageBlockTime);
         assert(averageBlockTime < test_config.expected_average_block_time);
 


### PR DESCRIPTION
## Description

* Enable MantaPay rpc tests on manta runtime
* Removed the old parachain block parsing tests (which were disabled anyway)
* added average block time check to our stress tests that it should be less than 13 seconds

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
