### PR TITLE
Fix wrong reports of congestion test results

### DIFF
--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [manta]
   push:
-    branches: [manta]
+    branches: [ghzlatarev/cong-test]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -423,6 +423,9 @@ jobs:
             }
             // Update comment text with CI status
             const status = '${{ job.steps.congestion_test.outcome }}';
+            echo "---------------------------------------------------------"
+            echo status
+            echo "---------------------------------------------------------"
             const statusIcon = status === 'success' ? ':white_check_mark:' : ':warning:';
             const above = status === 'success' ? 'is above' : 'is NOT above';
             const updatedComment = `${statusIcon} ${comment_text} ${above} target_daily_congestion_cost_kma`;

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -422,9 +422,8 @@ jobs:
               existingComment = newComment;
             }
             // Update comment text with CI status
-            const status = '${{ job.steps.congestion_test.outcome }}';
             echo "---------------------------------------------------------"
-            echo status
+            echo '${{ job.steps.congestion_test.outcome }}'
             echo "---------------------------------------------------------"
             const statusIcon = status === 'success' ? ':white_check_mark:' : ':warning:';
             const above = status === 'success' ? 'is above' : 'is NOT above';

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -407,8 +407,9 @@ jobs:
         id: congestion_test_res
         run: |
           echo "---------------------------------------------------------"
-          echo ${{ job.steps.congestion_test.outcome }}
+          echo ${{ steps.congestion_test.outcome }}
           echo "---------------------------------------------------------"
+        continue-on-error: true
       - name: Comment on PR whether congestion test failed
         uses: actions/github-script@v6
         with:
@@ -428,6 +429,7 @@ jobs:
               existingComment = newComment;
             }
             // Update comment text with CI status
+            const status = `${{ steps.congestion_test.outcome }}`;
             const statusIcon = status === 'success' ? ':white_check_mark:' : ':warning:';
             const above = status === 'success' ? 'is above' : 'is NOT above';
             const updatedComment = `${statusIcon} ${comment_text} ${above} target_daily_congestion_cost_kma`;

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [manta]
   push:
-    branches: [ghzlatarev/cong-test]
+    branches: [manta]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -403,6 +403,12 @@ jobs:
           source ${HOME}/.cargo/env
           RUSTC_BOOTSTRAP=1 cargo test --package ${{ matrix.runtime.name }} --lib -- fee::multiplier_tests::multiplier_growth_simulator_and_congestion_budget_test --exact --nocapture --ignored
         continue-on-error: true
+      - name: Print res
+        id: congestion_test_res
+        run: |
+          echo "---------------------------------------------------------"
+          echo ${{ job.steps.congestion_test.outcome }}
+          echo "---------------------------------------------------------"
       - name: Comment on PR whether congestion test failed
         uses: actions/github-script@v6
         with:
@@ -422,9 +428,6 @@ jobs:
               existingComment = newComment;
             }
             // Update comment text with CI status
-            echo "---------------------------------------------------------"
-            echo '${{ job.steps.congestion_test.outcome }}'
-            echo "---------------------------------------------------------"
             const statusIcon = status === 'success' ? ':white_check_mark:' : ':warning:';
             const above = status === 'success' ? 'is above' : 'is NOT above';
             const updatedComment = `${statusIcon} ${comment_text} ${above} target_daily_congestion_cost_kma`;

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -432,7 +432,7 @@ jobs:
             const status = `${{ steps.congestion_test.outcome }}`;
             const statusIcon = status === 'success' ? ':white_check_mark:' : ':warning:';
             const above = status === 'success' ? 'is above' : 'is NOT above';
-            const updatedComment = `${statusIcon} ${comment_text} ${above} target_daily_congestion_cost_kma`;
+            const updatedComment = `${statusIcon} ${comment_text} ${above} the target daily congestion cost`;
             await octokit.rest.issues.updateComment({ owner, repo, comment_id: existingComment.id, body: updatedComment });
   stop-congestion-test-checks:
     timeout-minutes: 15


### PR DESCRIPTION
## Description

* The congestion test results were always being reported as failures, because we were not reading the outputs of previous steps correctly.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
