### PR TITLE
Fix release binary building

### DIFF
--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -54,7 +54,7 @@ jobs:
             srtool-target-${{ matrix.runtime.name }}
       - name: build runtime
         id: srtool-build
-        uses: chevdor/srtool-actions@v0.4.0
+        uses: chevdor/srtool-actions@v0.7.0
         with:
           image: paritytech/srtool
           tag: 1.66.1
@@ -128,6 +128,8 @@ jobs:
           rustup default stable
           rustup update
           rustup target add wasm32-unknown-unknown
+          rustup install 1.69.0
+          rustup target add wasm32-unknown-unknown --toolchain 1.69.0
       - name: build
         env:
           RUST_BACKTRACE: full
@@ -136,7 +138,7 @@ jobs:
           SCCACHE_DIR: /home/runner/.cache/sccache
         run: |
           source ${HOME}/.cargo/env
-          RUSTC_BOOTSTRAP=1 cargo build --profile production --verbose
+          RUSTC_BOOTSTRAP=1 cargo +1.69.0 build --profile production --verbose
       - name: stop sccache server
         run: sccache --stop-server || true
       - if: always()

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -57,7 +57,7 @@ jobs:
         uses: chevdor/srtool-actions@v0.7.0
         with:
           image: paritytech/srtool
-          tag: 1.66.1
+          tag: 1.70.0
           chain: ${{ matrix.runtime.name }}
       - name: persist srtool digest
         run: >

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -45,10 +45,10 @@ jobs:
             srtool-target-${{ env.RUNTIME }}
       - name: build runtime
         id: srtool-build
-        uses: chevdor/srtool-actions@v0.4.0
+        uses: chevdor/srtool-actions@v0.7.0
         with:
           image: paritytech/srtool
-          tag: 1.66.1
+          tag: 1.70.0
           chain: ${{ env.RUNTIME }}
       - name: persist srtool digest
         run: >


### PR DESCRIPTION
## Description

1. Bump srtool from 0.4 to 0.7.
2. Rollback stable rust to 1.69. I tried 1.71(just released last week), it has the same problem.

Closes #1098 #1158 

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
