### PR TITLE
Update reference hardware and lower CI machine specs

### DIFF
--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 env:
   AWS_REGION: us-east-1
-  AWS_INSTANCE_TYPE: c5.9xlarge
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 1024
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -13,7 +13,7 @@ env:
   AWS_REGION: us-east-1
   AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
   AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
-  AWS_INSTANCE_TYPE: c5d.metal
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -13,7 +13,7 @@ env:
   AWS_REGION: us-east-1
   AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
   AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
-  AWS_INSTANCE_TYPE: c5d.metal
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/metadata_diff.yml
+++ b/.github/workflows/metadata_diff.yml
@@ -11,7 +11,7 @@ on:
         required: true
 env:
   AWS_REGION: us-east-1
-  AWS_INSTANCE_TYPE: c5.4xlarge
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -12,7 +12,7 @@ env:
   AWS_REGION: us-east-1
   AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
   AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
-  AWS_INSTANCE_TYPE: c5.9xlarge
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -12,7 +12,7 @@ on:
         required: false
 env:
   AWS_REGION: us-east-1
-  AWS_INSTANCE_TYPE: c5d.metal
+  AWS_INSTANCE_TYPE: c6i.4xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 128
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 env:
   AWS_REGION: us-east-1
-  AWS_INSTANCE_TYPE: c5.4xlarge
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 32
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -20,7 +20,7 @@ env:
   AWS_REGION: us-east-1
   AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
   AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
-  AWS_INSTANCE_TYPE: c5.9xlarge
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 128
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'

--- a/.github/workflows/try-runtime-mainnet.yml
+++ b/.github/workflows/try-runtime-mainnet.yml
@@ -17,7 +17,7 @@ env:
   AWS_REGION: us-east-1
   AWS_SUBNET_ID: subnet-08c26caf0a52b7c19
   AWS_SECURITY_GROUP_ID: sg-0315bffea9042ac9b
-  AWS_INSTANCE_TYPE: c5d.metal
+  AWS_INSTANCE_TYPE: c5.2xlarge
   AWS_INSTANCE_ROOT_VOLUME_SIZE: 128
   AWS_IMAGE_SEARCH_PATTERN: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*
   AWS_IMAGE_SEARCH_OWNERS: '["099720109477"]'


### PR DESCRIPTION
## Description

* Update the reference hardware that we use for generating weights to c6i.4xlarge as per https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#standard-hardware
* Reduce all other machine specs to c5.2xlarge to reduce costs (from c5.9xlarge and metal)

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
