### PR TITLE
:wrench: allow all benchmarks to be triggered on feature branch

### DIFF
--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -20,7 +20,6 @@ jobs:
   run-benchmarks:
     timeout-minutes: 720
     runs-on: runtime-integration-test
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Description

change allows benchmarks pipeline to be triggered on feature branch

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Add `A-integration-test-checks` to run **start-integration-test-checks** (Required)
- [x] Add `A-benchmark-checks` to run **start-benchmark-check** (Required)
- [x] Add `A-unit-test-checks` to run **start-unit-test-checks** (Required)
- [ ] Add `A-congestion-test-checks` to run **start-integration-test-checks** (Optional)


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
