### PR TITLE
Allow all xtokens extrinsics in calamari

### DIFF
--- a/runtime/calamari/src/lib.rs
+++ b/runtime/calamari/src/lib.rs
@@ -245,10 +245,6 @@ impl Contains<RuntimeCall> for BaseFilter {
                                 | pallet_democracy::Call::cancel_proposal {..}
                                 | pallet_democracy::Call::clear_public_proposals {..})
             | RuntimeCall::Treasury(_) // Treasury calls are filtered while it is accumulating funds.
-            // Everything except transfer() is filtered out until it is practically needed:
-            | RuntimeCall::XTokens(
-                                orml_xtokens::Call::transfer_with_fee {..}
-                                | orml_xtokens::Call::transfer_multiasset {..})
             // Filter callables from XCM pallets, we use XTokens exclusively
             | RuntimeCall::XcmpQueue(_) | RuntimeCall::DmpQueue(_) => false,
 
@@ -306,10 +302,7 @@ impl Contains<RuntimeCall> for BaseFilter {
             | RuntimeCall::MantaPay(_)
             | RuntimeCall::MantaSbt(_)
             | RuntimeCall::NameService(_)
-            | RuntimeCall::XTokens(orml_xtokens::Call::transfer {..}
-                | orml_xtokens::Call::transfer_multicurrencies {..}
-                | orml_xtokens::Call::transfer_multiassets {..}
-                | orml_xtokens::Call::transfer_multiasset_with_fee {..})
+            | RuntimeCall::XTokens(_)
             | RuntimeCall::TransactionPause(_)
             | RuntimeCall::ZenlinkProtocol(_)
             | RuntimeCall::Farming(_)


### PR DESCRIPTION
## Description

* Due to projects requesting all xtokens extrinsics, we're enabling them.

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [x] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Add `A-integration-test-checks` to run **start-integration-test-checks** (Required)
- [x] Add `A-benchmark-checks` to run **start-benchmark-check** (Required)
- [x] Add `A-unit-test-checks` to run **start-unit-test-checks** (Required)
- [x] Add `A-congestion-test-checks` to run **start-integration-test-checks** (Optional)


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
