### PR TITLE
fix typos in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Manta/Calamari's version number:
 where:
 
 * `<x>` is the major version, i.e. major product release.
-* `<y>` is the middle verison, i.e. adding major features.
+* `<y>` is the middle version, i.e. adding major features.
 * `<z>` is the minor version, i.e. performance improvement and bug fixes.
 
 ## Contributing

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -419,7 +419,7 @@ pub mod pallet {
     #[pallet::getter(fn get_para_id)]
     pub type AllowedDestParaIds<T: Config> = StorageMap<_, Blake2_128Concat, ParaId, AssetCount>;
 
-    /// Multilocation of assets that should not be transfered out of the chain
+    /// Multilocation of assets that should not be transferred out of the chain
     #[pallet::storage]
     #[pallet::getter(fn get_filtered_location)]
     pub type FilteredOutgoingAssetLocations<T: Config> =

--- a/pallets/manta-pay/src/lib.rs
+++ b/pallets/manta-pay/src/lib.rs
@@ -472,7 +472,7 @@ pub mod pallet {
         /// Sender Ledger [`OutgoingNote`] failed to decode
         SenderLedgerOutgoingNodeDecodeFailed,
 
-        /// Reciever Ledger Utxo decode failed
+        /// Receiver Ledger Utxo decode failed
         ReceiverLedgerUtxoDecodeFailed,
 
         /// Receiver Ledger Wrong Checksum Error

--- a/pallets/manta-sbt/src/lib.rs
+++ b/pallets/manta-sbt/src/lib.rs
@@ -800,7 +800,7 @@ pub mod pallet {
         SBTReserved {
             /// Public Account reserving SBT mints
             who: T::AccountId,
-            /// Account which recieves reserved AssetIds, can be the same as the above account
+            /// Account which receives reserved AssetIds, can be the same as the above account
             reserve_account: T::AccountId,
             /// Start of `AssetIds` reserved for use on private ledger
             start_id: StandardAssetId,
@@ -979,7 +979,7 @@ pub mod pallet {
         /// Sender Ledger [`OutgoingNote`] failed to decode
         SenderLedgerOutgoingNodeDecodeFailed,
 
-        /// Reciever Ledger Utxo decode failed
+        /// Receiver Ledger Utxo decode failed
         ReceiverLedgerUtxoDecodeFailed,
 
         /// Receiver Ledger Wrong Checksum Error

--- a/pallets/vesting/src/lib.rs
+++ b/pallets/vesting/src/lib.rs
@@ -180,11 +180,11 @@ pub mod pallet {
 
             let now = T::Timestamp::now().as_secs();
             for (n, o) in new_schedule.iter().zip(old_schedule.iter()) {
-                // n == o means we will partialy update vesting schedule.
+                // n == o means we will partially update vesting schedule.
                 // n > o means new schedule is future schedule.
                 // n < o && n > now, also fine.
                 if o.1 <= now {
-                    // Check partialy updating vesting schedule.
+                    // Check partially updating vesting schedule.
                     // We don't change past schedule, just skip it.
                     ensure!(*n == o.1, Error::<T>::InvalidSchedule);
                 } else {


### PR DESCRIPTION
fix typos in docs and comments