### PR TITLE
Bump srtool

### DIFF
--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -47,10 +47,10 @@ jobs:
             srtool-target-${{ matrix.runtime.name }}
       - name: build runtime
         id: srtool-build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.9.1
         with:
           image: paritytech/srtool
-          tag: 1.66.1
+          tag: 1.74
           chain: ${{ matrix.runtime.name }}
       - name: persist srtool digest
         run: >

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -38,10 +38,10 @@ jobs:
             srtool-target-${{ env.RUNTIME }}
       - name: build runtime
         id: srtool-build
-        uses: chevdor/srtool-actions@v0.7.0
+        uses: chevdor/srtool-actions@v0.9.1
         with:
           image: paritytech/srtool
-          tag: 1.66.1
+          tag: 1.74
           chain: ${{ env.RUNTIME }}
       - name: persist srtool digest
         run: >


### PR DESCRIPTION
## Description
We have to bump srtool to build our runtime.
```
║ error: package `clap_lex v0.6.0` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.66.1
  ║ Either upgrade to rustc 1.70.0 or newer, or use
  ║ cargo update -p clap_lex@0.6.0 --precise ver
  ║ where `ver` is the latest version of `clap_lex` supporting rustc 1.66.1
```

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [ ] Added **one** label out of the `L-` group to this PR
- [ ] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [ ] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Add `A-integration-test-checks` to run **start-integration-test-checks** (Required)
- [x] Add `A-benchmark-checks` to run **start-benchmark-check** (Required)
- [x] Add `A-unit-test-checks` to run **start-unit-test-checks** (Required)
- [ ] Add `A-congestion-test-checks` to run **start-integration-test-checks** (Optional)


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
