### PR TITLE
Force unstaking

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1374,6 +1374,31 @@ pub mod pallet {
             let delegator = ensure_signed(origin)?;
             Self::delegation_cancel_request(candidate, delegator)
         }
+
+        #[pallet::call_index(27)]
+        #[pallet::weight(<T as Config>::WeightInfo::schedule_revoke_delegation())]
+        /// Root only. Request to revoke an existing delegation. If successful, the delegation is scheduled
+        /// to be allowed to be revoked via the `execute_delegation_request` extrinsic.
+        pub fn force_schedule_revoke_delegation(
+            origin: OriginFor<T>,
+            delegator: T::AccountId,
+            collator: T::AccountId,
+        ) -> DispatchResultWithPostInfo {
+            frame_system::ensure_root(origin)?;
+            Self::delegation_schedule_revoke(collator, delegator)
+        }
+
+        #[pallet::call_index(28)]
+        #[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_less())]
+        /// Root only. Execute pending request to change an existing delegation
+        pub fn force_execute_delegation_request(
+            origin: OriginFor<T>,
+            delegator: T::AccountId,
+            candidate: T::AccountId,
+        ) -> DispatchResultWithPostInfo {
+            frame_system::ensure_root(origin)?;
+            Self::delegation_execute_scheduled_request(candidate, delegator)
+        }
     }
 
     impl<T: Config> Pallet<T> {


### PR DESCRIPTION
## Description

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Add `A-integration-test-checks` to run **start-integration-test-checks** (Required)
- [x] Add `A-benchmark-checks` to run **start-benchmark-check** (Required)
- [x] Add `A-unit-test-checks` to run **start-unit-test-checks** (Required)
- [ ] Add `A-congestion-test-checks` to run **start-integration-test-checks** (Optional)


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
