### PR TITLE
Fix artifact uploading

### DIFF
--- a/.github/workflows/genesis_files_for_relay.yml
+++ b/.github/workflows/genesis_files_for_relay.yml
@@ -32,17 +32,17 @@ jobs:
           sha256sum $CHAIN-genesis.json $CHAIN-genesis.state $CHAIN-genesis.wasm | tee $CHAIN-genesis.sha256
       # upload artifacts
       - name: upload genesis
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.CHAIN}}-genesis.json
           path: ${{env.CHAIN}}-genesis.json
       - name: upload state
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.CHAIN}}-genesis.state
           path: ${{env.CHAIN}}-genesis.state
       - name: upload wasm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.CHAIN}}-genesis.wasm
           path: ${{env.CHAIN}}-genesis.wasm

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -123,7 +123,7 @@ jobs:
           mkdir -p $HOME/.local/bin
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: fetch manta
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: manta
       - name: mv and chmod manta
@@ -397,7 +397,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
       - name: fetch manta
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: manta
       - name: build docker image

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -90,7 +90,7 @@ jobs:
         run: sccache --stop-server || true
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: manta
           path: target/production/manta
@@ -173,17 +173,17 @@ jobs:
           repository: Manta-Network/Manta
           path: Manta
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-state.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-spec.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-spec.json
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-spec.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-spec.json
@@ -199,7 +199,7 @@ jobs:
             '.parachains.[0].collators.[0].command'
           cat $GITHUB_WORKSPACE/Manta/zombienet/tests/0001-block-production.toml
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-launch-config.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-launch-config.json
@@ -280,37 +280,37 @@ jobs:
           pm2 stop measure-block-time-${{ matrix.chain-spec.id }}
           pm2 stop zombienet
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: zombienet-for-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: zombienet-for-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stderr.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stderr.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/measure-block-time-${{ matrix.chain-spec.id }}-stderr.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: block-time-rococo-relay-for-${{ matrix.chain-spec.id }}.json
           path: $GITHUB_WORKSPACE/block-time-rococo.json
@@ -356,7 +356,7 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           pm2 stop zombienet
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-alice-stress.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stdout.log
@@ -380,7 +380,7 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           pm2 stop zombienet
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-alice-stress.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stdout.log

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -119,7 +119,7 @@ jobs:
           mkdir -p $HOME/.local/bin
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: fetch manta
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: manta
       - name: mv and chmod manta
@@ -385,7 +385,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
       - name: fetch manta
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: manta
       - name: build docker image

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -86,7 +86,7 @@ jobs:
         run: sccache --stop-server || true
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: manta
           path: target/production/manta
@@ -169,17 +169,17 @@ jobs:
           repository: Manta-Network/Manta
           path: Manta
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-state.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-spec.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-spec.json
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-spec.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-spec.json
@@ -214,7 +214,7 @@ jobs:
             '.parachains.[0].id'
           cat $GITHUB_WORKSPACE/Manta/zombienet/tests/0001-block-production.toml
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-launch-config.json
           path: /home/runner/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${{ steps.create-chainspec.outputs.short-sha }}-launch-config.json
@@ -312,32 +312,32 @@ jobs:
           cat $GITHUB_WORKSPACE/Manta/zombienet/tests/0001-block-production.zndsl
           ./zombienet -f -p native test $GITHUB_WORKSPACE/Manta/zombienet/tests/0001-block-production.zndsl
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: zombienet-for-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: zombienet-for-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stderr.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/measure-block-time-rococo-relay-for-${{ matrix.chain-spec.id }}-stderr.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-${{ matrix.chain-spec.id }}-stdout.log
           path: $GITHUB_WORKSPACE/measure-block-time-${{ matrix.chain-spec.id }}-stdout.log
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: measure-block-time-${{ matrix.chain-spec.id }}-stderr.log
           path: $GITHUB_WORKSPACE/measure-block-time-${{ matrix.chain-spec.id }}-stderr.log
@@ -361,7 +361,7 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           pm2 stop zombienet
       - if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.chain-spec.id }}-alice-stress.log
           path: $GITHUB_WORKSPACE/zombienet-for-${{ matrix.chain-spec.id }}-stdout.log

--- a/.github/workflows/metadata_diff.yml
+++ b/.github/workflows/metadata_diff.yml
@@ -160,7 +160,7 @@ jobs:
         run: pkill manta
       - if: always()
         name: Save output as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHAIN }}
           path: |

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -180,10 +180,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-runtime
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-srtool-json
       - name: ruby setup
@@ -242,7 +242,7 @@ jobs:
       download_url: ${{ steps.upload-manta.outputs.browser_download_url }}
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: manta
       - id: upload-manta

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -61,13 +61,13 @@ jobs:
           jq > ${{ matrix.runtime.name }}-srtool-output.json
       - if: always()
         name: upload srtool json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-srtool-json
           path: ${{ matrix.runtime.name }}-srtool-output.json
       - if: always()
         name: upload runtime
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-runtime
           path: |
@@ -135,19 +135,19 @@ jobs:
         run: sccache --stop-server || true
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: manta
           path: target/production/manta
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: config-for-integration-test
           path: .github/resources/config-for-integration-test.json
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: config-for-runtime-upgrade-test
           path: .github/resources/config-for-runtime-upgrade-test.json

--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -110,37 +110,37 @@ jobs:
           ./scripts/benchmarking/run_all_benchmarks.sh -b -c ${{ github.workspace }}/tests/data/fork.json -s ./$FULL_DB_FOLDER
       - if: always()
         name: upload benchmarking binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: manta
           path: ./target/production/manta
       - if: always()
         name: upload frame weights
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: frame-weights-output
           path: ./scripts/benchmarking/frame-weights-output/
       - if: always()
         name: upload xcm weights
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: xcm-weights-output
           path: ./scripts/benchmarking/xcm-weights-output/
       - if: always()
         name: upload benchmarking errors
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks-errors
           path: ./scripts/benchmarking/benchmarking_errors.txt
       - if: always()
         name: upload machine benchmark result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: machine-benchmark
           path: ./scripts/benchmarking/machine_benchmark_result.txt
       - if: always()
         name: upload storage weights
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rocksdb-weights
           path: ./scripts/benchmarking/rocksdb_weights.rs

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -50,13 +50,13 @@ jobs:
           jq > ${{ env.RUNTIME }}-srtool-output.json
       - if: always()
         name: upload srtool json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RUNTIME }}-srtool-json
           path: ${{ env.RUNTIME }}-srtool-output.json
       - if: always()
         name: upload runtime
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RUNTIME }}-runtime
           path: |
@@ -64,7 +64,7 @@ jobs:
             ${{ steps.srtool-build.outputs.wasm_compressed }}
       - if: always()
         name: upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: config-for-runtime-upgrade-test
           path: .github/resources/config-for-runtime-upgrade-test.json
@@ -175,7 +175,7 @@ jobs:
           yarn
           yarn runtime_upgrade_test --address=ws://127.0.0.1:9921 --exit
           if [ $? != 0 ]; then echo "Runtime upgrade failed!"; exit 1; fi
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RUNTIME_SPEC }}-alice.log
           path: ${{ github.workspace }}/zombienet-for-${{ env.RUNTIME_SPEC }}-stdout.log

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -109,7 +109,7 @@ jobs:
           ls -ahl $HOME/.local/share/${{ env.RUNTIME }}-pc/
           manta-base export-state --chain $HOME/.local/share/${{ env.RUNTIME }}-pc/${{ env.RUNTIME_SPEC }}-base-spec.json > $HOME/.local/share/${{ env.RUNTIME }}-pc/${{ env.RUNTIME_SPEC }}-state.json || true
       - name: fetch config-for-runtime-upgrade-test
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: config-for-runtime-upgrade-test
       - name: Install dasel cli
@@ -159,7 +159,7 @@ jobs:
             --error ${{ github.workspace }}/zombienet-for-${{ env.RUNTIME_SPEC }}-stderr.log \
             -- spawn --provider native ${{ github.workspace }}/zombienet/tests/0002-runtime-upgrade.toml
       - name: fetch new ${{ env.RUNTIME }}_runtime.compact.compressed.wasm
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.RUNTIME }}-runtime
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

---

Before we can approve this PR for merge, please make sure that **all** the following items have been checked off:
- [ ] Connected to an issue with discussion and accepted design using zenhub "Connect issue" button below
- [x] Added **one** label out of the `L-` group to this PR
- [x] Added **one or more** labels from the `A-` and `C-` groups to this PR
- [x] Explicitly labelled `A-calamari` and/or `A-manta` if your changes are meant for/impact either of these (CI depends on it)
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [x] Add `A-integration-test-checks` to run **start-integration-test-checks** (Required)
- [x] Add `A-benchmark-checks` to run **start-benchmark-check** (Required)
- [x] Add `A-unit-test-checks` to run **start-unit-test-checks** (Required)
- [ ] Add `A-congestion-test-checks` to run **start-integration-test-checks** (Optional)


Situational Notes:
- If adding functionality, write unit tests!
- If importing a new pallet, choose a proper module index for it, and allow it in `BaseFilter`. Ensure **every** extrinsic works from front-end. If there's corresponding tool, ensure both work for each other.
- If needed, update our Javascript/Typescript APIs. These APIs are officially used by exchanges or community developers.
- If modifying existing runtime storage items, make sure to implement storage migrations for the runtime and test them with `try-runtime`. This includes migrations inherited from upstream changes, and you can search the diffs for modifications of `#[pallet::storage]` items to check for any.
