### PR TITLE
fix: typos in documentation files

### DIFF
--- a/pallets/name-service/src/lib.rs
+++ b/pallets/name-service/src/lib.rs
@@ -173,7 +173,7 @@ pub mod pallet {
             Self::do_register(&username, registrant)
         }
 
-        /// After Pending Register has passed its block wait time, finish regiser
+        /// After Pending Register has passed its block wait time, finish register
         #[pallet::call_index(1)]
         #[pallet::weight(T::WeightInfo::accept_register())]
         #[transactional]
@@ -246,7 +246,7 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_account_truncating()
     }
 
-    /// Queue username for regiser
+    /// Queue username for register
     fn do_register(username: &UserName, registrant: ZkAddressType) -> DispatchResult {
         // Username checks
         username_validation(username).ok_or(Error::<T>::InvalidUsernameFormat)?;

--- a/pallets/pallet-lottery/src/lib.rs
+++ b/pallets/pallet-lottery/src/lib.rs
@@ -162,7 +162,7 @@ pub mod pallet {
         type DrawingInterval: Get<BlockNumberFor<Self>>;
         /// Time in blocks *before* a drawing in
         /// Depending on the randomness source, the winner might be established before the drawing, this prevents modification of the eligible winning set after the winner
-        /// has been established but before it is selected by [`Call::draw_lottery`] which modifications of the win-eligble pool are prevented
+        /// has been established but before it is selected by [`Call::draw_lottery`] which modifications of the win-eligible pool are prevented
         #[pallet::constant]
         type DrawingFreezeout: Get<BlockNumberFor<Self>>;
         /// Time in blocks until a collator is done unstaking

--- a/runtime/manta/src/lib.rs
+++ b/runtime/manta/src/lib.rs
@@ -410,7 +410,7 @@ parameter_types! {
     pub const LotteryPotId: PalletId = LOTTERY_PALLET_ID;
     /// Time in blocks between lottery drawings
     pub DrawingInterval: BlockNumber = prod_or_fast!(7 * DAYS, 3 * MINUTES);
-    /// Time in blocks *before* a drawing in which modifications of the win-eligble pool are prevented
+    /// Time in blocks *before* a drawing in which modifications of the win-eligible pool are prevented
     pub DrawingFreezeout: BlockNumber = prod_or_fast!(1 * DAYS, 1 * MINUTES);
     /// Time in blocks until a collator is done unstaking
     pub UnstakeLockTime: BlockNumber = LeaveDelayRounds::get() * DefaultBlocksPerRound::get();


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `regiser` to `register` x2.
Corrected `eligble` to `eligible` x2.

Please review the changes and let me know if any additional changes are needed.