### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/benchmark_tests.yaml
+++ b/.github/workflows/benchmark_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/changelog_verification.yml
+++ b/.github/workflows/changelog_verification.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: manta
@@ -23,7 +23,7 @@ jobs:
           cd manta
           sudo cp CHANGELOG.md CHANGELOG_ORIGIN.md
       - name: get Changelog Generator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools

--- a/.github/workflows/check_parachain_lease_expiration.yml
+++ b/.github/workflows/check_parachain_lease_expiration.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: borales/actions-yarn@v3.0.0
       - name: Check manta and calamari lease
         run: |

--- a/.github/workflows/check_tests.yml
+++ b/.github/workflows/check_tests.yml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install sccache
         env:
           SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
@@ -83,7 +83,7 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: init
         shell: bash
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
           echo $image_id
           echo "Adjusting permissions so we can access docker logs..."
           sudo cat /var/lib/docker/containers/${image_id}/${image_id}-json.log
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18.12.x
@@ -168,7 +168,7 @@ jobs:
           echo "::set-output name=short-sha::${GITHUB_SHA:0:7}"
           manta export-state --chain $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json || true
       - uses: borales/actions-yarn@v3.0.0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Manta
           path: Manta
@@ -212,11 +212,11 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           chmod +x zombienet
           ./zombienet version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-rococo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-calamari
@@ -254,7 +254,7 @@ jobs:
             --no-autorestart \
             -- \
             --address=ws://127.0.0.1:9921
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Manta
           path: Manta
@@ -394,7 +394,7 @@ jobs:
         runtime:
           - name: calamari
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: fetch manta
         uses: actions/download-artifact@v4
@@ -423,7 +423,7 @@ jobs:
           echo $image_id
           echo "Adjusting permissions so we can access docker logs..."
           sudo cat /var/lib/docker/containers/${image_id}/${image_id}-json.log
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: install sccache
         env:
@@ -164,7 +164,7 @@ jobs:
           echo "::set-output name=short-sha::${GITHUB_SHA:0:7}"
           manta export-state --chain $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-${GITHUB_SHA:0:7}-spec.json > $HOME/.local/share/calamari-pc/${{ matrix.chain-spec.id }}-state.json || true
       - uses: borales/actions-yarn@v3.0.0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Manta
           path: Manta
@@ -227,11 +227,11 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           chmod +x zombienet
           ./zombienet version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-rococo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-manta
@@ -269,7 +269,7 @@ jobs:
             --no-autorestart \
             -- \
             --address=ws://127.0.0.1:9921
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Manta
           path: Manta
@@ -382,7 +382,7 @@ jobs:
         runtime:
           - name: manta
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: fetch manta
         uses: actions/download-artifact@v4
@@ -411,7 +411,7 @@ jobs:
           echo $image_id
           echo "Adjusting permissions so we can access docker logs..."
           sudo cat /var/lib/docker/containers/${image_id}/${image_id}-json.log
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools

--- a/.github/workflows/metadata_diff.yml
+++ b/.github/workflows/metadata_diff.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: borales/actions-yarn@v3.0.0
       - name: install sccache
         env:
@@ -135,7 +135,7 @@ jobs:
           echo "Target version: $VERSION" >> output.txt
           echo "Chain: $CHAIN" >> output.txt
           echo "----------------------------------------------------------------------" >> output.txt
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: polkadot-js/tools
           path: tools

--- a/.github/workflows/publish_draft_releases.yml
+++ b/.github/workflows/publish_draft_releases.yml
@@ -37,7 +37,7 @@ jobs:
           - name: calamari
           - name: manta
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: cache target dir
         uses: actions/cache@v2
         with:
@@ -80,7 +80,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install sccache
         env:
           SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
@@ -179,7 +179,7 @@ jobs:
           - name: manta
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-runtime

--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 720
     runs-on: runtime-large
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run yamllint
         uses: actionshub/yamllint@v1.5.0
       - name: install sccache

--- a/.github/workflows/runtime_upgrade_test.yml
+++ b/.github/workflows/runtime_upgrade_test.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: cache target dir
         uses: actions/cache@v2
         with:
@@ -145,7 +145,7 @@ jobs:
           cd $GITHUB_WORKSPACE/zombienet-tool
           chmod +x zombienet
           ./zombienet version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools
@@ -162,7 +162,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.RUNTIME }}-runtime
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Manta
           path: Manta

--- a/.github/workflows/try-runtime-mainnet.yml
+++ b/.github/workflows/try-runtime-mainnet.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install sccache
         env:
           SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
@@ -73,7 +73,7 @@ jobs:
           mv target/release/wbuild/${{ env.RUNTIME }}-runtime/${{ env.RUNTIME }}_runtime.compact.compressed.wasm $HOME/.local/bin/runtime.wasm
           chmod +x $HOME/.local/bin/manta
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: Manta-Network/Dev-Tools
           path: dev-tools-calamari

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install sccache
         env:
           SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected