### PR TITLE
chore(ci): upgrade setup-node to v4

### DIFF
--- a/.github/workflows/benchmark_tests.yaml
+++ b/.github/workflows/benchmark_tests.yaml
@@ -19,7 +19,7 @@ jobs:
       image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: install sccache

--- a/.github/workflows/integration_test_calamari.yml
+++ b/.github/workflows/integration_test_calamari.yml
@@ -38,7 +38,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.12.x
       - name: install sccache
@@ -115,7 +115,7 @@ jobs:
                 para: 4
     steps:
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: |
@@ -395,7 +395,7 @@ jobs:
           - name: calamari
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: fetch manta
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/integration_test_manta.yml
+++ b/.github/workflows/integration_test_manta.yml
@@ -38,7 +38,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: install sccache
         env:
           SCCACHE_RELEASE_URL: https://github.com/mozilla/sccache/releases/download
@@ -111,7 +111,7 @@ jobs:
                 para: 4
     steps:
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.12.x
       - run: |
@@ -383,7 +383,7 @@ jobs:
           - name: manta
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: fetch manta
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/run_all_benchmarks.yml
+++ b/.github/workflows/run_all_benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: runtime-large
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: install sccache


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.